### PR TITLE
fix: unblock CI build (12 TS errors + 2 bundler errors)

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -87,8 +87,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -101,14 +101,31 @@ jobs:
       # reuse the dev compose file. The `keycloak-db` service is its own
       # Postgres container (separate from the GitHub-service Postgres which
       # is the application DB).
-      - name: Start Keycloak (Docker Compose)
-        run: docker compose -f docker/docker-compose.yml up -d keycloak keycloak-db
+      #
+      # The `solver` service is the Timefold sidecar (Quarkus/Java 21).
+      # `apps/web/e2e/helpers/global-setup.ts:41` precheck-pings
+      # http://localhost:8081/health — without this the entire Playwright
+      # run aborts in globalSetup. Maven build is slow on first cache miss
+      # (~3-5 min); subsequent runs hit Docker layer cache for the
+      # dependency-resolution layer (mvnw dependency:go-offline copies
+      # pom.xml first per Dockerfile) and rebuild only the source layer.
+      - name: Start Keycloak + Solver (Docker Compose)
+        run: docker compose -f docker/docker-compose.yml up -d --build keycloak keycloak-db solver
 
       - name: Wait for Keycloak realm discovery
         run: |
           timeout 180 bash -c '
             until curl -sf http://localhost:8080/realms/schoolflow/.well-known/openid-configuration > /dev/null; do
               echo "waiting for Keycloak..."
+              sleep 3
+            done
+          '
+
+      - name: Wait for Solver healthcheck
+        run: |
+          timeout 180 bash -c '
+            until curl -sf http://localhost:8081/health > /dev/null; do
+              echo "waiting for Timefold solver..."
               sleep 3
             done
           '

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -53,6 +53,7 @@
     "sonner": "^2.0.0",
     "tailwind-merge": "^3.0.0",
     "vite-plugin-pwa": "^1.2.0",
+    "workbox-window": "^7.4.0",
     "zod": "^4.3.6",
     "zustand": "^5.0.0"
   },

--- a/apps/web/src/components/admin/school-settings/CreateSchoolYearDialog.tsx
+++ b/apps/web/src/components/admin/school-settings/CreateSchoolYearDialog.tsx
@@ -1,7 +1,13 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
+import type { z } from 'zod';
 import { SchoolYearSchema, type SchoolYearInput } from '@schoolflow/shared';
+
+// SchoolYearSchema uses z.coerce.date() — input fields hold unknown (raw form value
+// before coercion), output is Date (after Zod parse). RHF needs both generics
+// explicit; otherwise Resolver<input, ctx, output> doesn't unify with useForm<output>.
+type SchoolYearFormInput = z.input<typeof SchoolYearSchema>;
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -29,9 +35,9 @@ export function CreateSchoolYearDialog({ open, isSubmitting, onClose, onSubmit }
     watch,
     setValue,
     reset,
-  } = useForm<SchoolYearInput>({
+  } = useForm<SchoolYearFormInput, unknown, SchoolYearInput>({
     resolver: zodResolver(SchoolYearSchema),
-    defaultValues: { name: '', isActive: false } as Partial<SchoolYearInput>,
+    defaultValues: { name: '', isActive: false } as Partial<SchoolYearFormInput>,
   });
 
   // Reset on close so the next open starts clean.

--- a/apps/web/src/components/admin/student/StudentDetailTabs.tsx
+++ b/apps/web/src/components/admin/student/StudentDetailTabs.tsx
@@ -68,7 +68,7 @@ export function StudentDetailTabs({
   };
 
   const handleStammdatenSave = async (values: StudentStammdatenFormValues) => {
-    await updateMutation.mutateAsync(values);
+    await updateMutation.mutateAsync(values as unknown as Parameters<typeof updateMutation.mutateAsync>[0]);
     setStammdatenDirty(false);
   };
 

--- a/apps/web/src/hooks/useMyAbsenceSubstitutions.ts
+++ b/apps/web/src/hooks/useMyAbsenceSubstitutions.ts
@@ -6,7 +6,7 @@ export type MyAbsenceSubstitution = SubstitutionDto & {
   hasHandoverNote?: boolean;
 };
 
-export function useMyAbsenceSubstitutions(schoolId: string | undefined) {
+export function useMyAbsenceSubstitutions(schoolId: string | null | undefined) {
   return useQuery({
     queryKey: ['substitutions', schoolId, 'my-absences'],
     queryFn: async (): Promise<MyAbsenceSubstitution[]> => {

--- a/apps/web/src/hooks/usePushSubscription.ts
+++ b/apps/web/src/hooks/usePushSubscription.ts
@@ -59,11 +59,11 @@ export interface UsePushSubscriptionResult {
  * `PushManager.subscribe({ applicationServerKey })` expects. Standard helper
  * documented in the MDN Push API docs.
  */
-function urlBase64ToUint8Array(base64String: string): Uint8Array {
+function urlBase64ToUint8Array(base64String: string): Uint8Array<ArrayBuffer> {
   const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
   const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
   const rawData = window.atob(base64);
-  const outputArray = new Uint8Array(rawData.length);
+  const outputArray = new Uint8Array(new ArrayBuffer(rawData.length));
   for (let i = 0; i < rawData.length; ++i) {
     outputArray[i] = rawData.charCodeAt(i);
   }

--- a/apps/web/src/hooks/useStudents.ts
+++ b/apps/web/src/hooks/useStudents.ts
@@ -349,10 +349,7 @@ export function useBulkMoveStudents(schoolId: string) {
     }) => {
       const total = studentIds.length;
       let done = 0;
-      const failed: { studentId: string; error: StudentApiError | Error } = null as unknown as {
-        studentId: string;
-        error: StudentApiError | Error;
-      };
+      let failed: { studentId: string; error: StudentApiError | Error } | null = null;
       for (const studentId of studentIds) {
         onProgress?.(done, total, studentId);
         const res = await apiFetch(`/api/v1/students/${studentId}`, {
@@ -361,7 +358,7 @@ export function useBulkMoveStudents(schoolId: string) {
         });
         if (!res.ok) {
           const err = new StudentApiError(res.status, await readProblemDetail(res));
-          (failed as any) = { studentId, error: err };
+          failed = { studentId, error: err };
           throw err;
         }
         done += 1;

--- a/apps/web/src/routes/_authenticated/classbook/$lessonId.tsx
+++ b/apps/web/src/routes/_authenticated/classbook/$lessonId.tsx
@@ -92,6 +92,8 @@ function ClassBookLessonPage() {
 
   const handleTabChange = (value: string) => {
     navigate({
+      to: Route.fullPath,
+      params: { lessonId },
       search: { tab: value },
       replace: true,
     });

--- a/apps/web/src/routes/_authenticated/messages/$conversationId.tsx
+++ b/apps/web/src/routes/_authenticated/messages/$conversationId.tsx
@@ -31,7 +31,7 @@ function ConversationDetailPage() {
         <Button
           variant="ghost"
           size="sm"
-          onClick={() => navigate({ to: '/messages' })}
+          onClick={() => navigate({ to: '/messages', search: { id: undefined } })}
           className="h-10 w-10 p-0"
         >
           <ArrowLeft className="h-5 w-5" />

--- a/apps/web/src/routes/_authenticated/messages/index.tsx
+++ b/apps/web/src/routes/_authenticated/messages/index.tsx
@@ -7,8 +7,8 @@ import { ConversationView } from '@/components/messaging/ConversationView';
 
 export const Route = createFileRoute('/_authenticated/messages/')({
   component: MessagesPage,
-  validateSearch: (search: Record<string, unknown>) => ({
-    id: (search.id as string) ?? undefined,
+  validateSearch: (search: Record<string, unknown>): { id: string | undefined } => ({
+    id: typeof search.id === 'string' && search.id.length > 0 ? search.id : undefined,
   }),
 });
 

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -291,6 +291,9 @@ importers:
       vite-plugin-pwa:
         specifier: ^1.2.0
         version: 1.2.0(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(workbox-build@7.4.0)(workbox-window@7.4.0)
+      workbox-window:
+        specifier: ^7.4.0
+        version: 7.4.0
       zod:
         specifier: ^4.3.6
         version: 4.3.6


### PR DESCRIPTION
## Summary

Lokaler `pnpm build` und damit CI Playwright-Workflow waren auf main rot — 12 TypeScript-Fehler + 2 rolldown-Bundler-Fehler. Niemand hat's gemerkt, weil:
- `vite dev` macht keinen Typecheck
- CI war seit Wochen durch eine pnpm/action-setup-Regression komplett blockiert (siehe Commit `1eed1ed`)
- → Tech-Debt akkumuliert in Phasen 10–15 ohne dass Build-Gate je grün lief

Diese PR sollte vor Phase 15 + chore PRs gemerged werden — dann werden die anderen beiden PRs nach rebase grün.

## Atomic commits (10)

| # | Commit | Was |
|---|---|---|
| 1 | `3bc93a3` | Missing `apps/web/src/vite-env.d.ts` angelegt — fixt 6 von 12 TS-Errors (`import.meta.env` x4, `./app.css` import) |
| 2 | `3088fa2` | `useMyAbsenceSubstitutions` schoolId-Param auf `string \| null \| undefined` aligned (matched sibling hook) |
| 3 | `3539c09` | `usePushSubscription` Uint8Array<ArrayBuffer>-Pin gegen TS 5.7+ DOM-lib-Drift |
| 4 | `5ac3365` | `StudentDetailTabs` mutation call-site cast (containing structural mismatch) |
| 5 | `46aa6aa` | `CreateSchoolYearDialog` z.input + z.output Split für coerce.date()-Schema |
| 6 | `0bffa92` | Messages route `validateSearch` proper string \| undefined typing |
| 7 | `d1647b4` | Classbook tab navigation an `Route.fullPath` + `params` gepinnt |
| 8 | `277d070` | `useStudents.ts` const-with-any-cast Hack ersetzt — rolldown ILLEGAL_REASSIGNMENT-Bug |
| 9 | `0304fa6` | Missing `workbox-window` peer dep für `vite-plugin-pwa` |
| 10 | `1eed1ed` | `ci: drop pnpm version pin` — pnpm/action-setup@v4 lehnt Doppel-Pin (Action + packageManager) ab |

## Test plan

- [x] `pnpm --filter @schoolflow/web exec tsc -b` → 0 errors
- [x] `pnpm --filter @schoolflow/web build` → exit 0, `dist/` generated
- [ ] CI green (auto-runs on this PR)
- [ ] After merge: rebase phase-15 + chore PRs on new main → CI grün dort

## Aftermath

Nach Merge: rebase
- PR #1 (gsd/phase-15-...) → CI sollte grün
- PR #2 (chore/gsd-1.38.5-update) → CI sollte grün

Beide haben den `1eed1ed` als duplizierten Commit drauf; nach rebase verschwindet er.

🤖 Generated with [Claude Code](https://claude.com/claude-code)