### PR TITLE
fix(solver): unblock solve pipeline (4 bugs)

### DIFF
--- a/apps/api/src/modules/timetable/processors/solve.processor.ts
+++ b/apps/api/src/modules/timetable/processors/solve.processor.ts
@@ -41,7 +41,11 @@ export class SolveProcessor extends WorkerHost {
       );
 
       // 3. Determine callback URL (from env or config)
-      const callbackBaseUrl = process.env.API_INTERNAL_URL || 'http://localhost:3000';
+      // The sidecar appends `/progress/<runId>` and `/complete/<runId>` to this
+      // base, so it must already include the SolverCallbackController prefix
+      // (`api/v1/api/internal/solver`). See issue #50 Bug 4.
+      const apiBase = process.env.API_INTERNAL_URL || 'http://localhost:3000';
+      const callbackBaseUrl = `${apiBase}/api/v1/api/internal/solver`;
 
       // 4. Submit to sidecar (non-blocking, sidecar calls back)
       await this.solverClient.submitSolve(runId, solverPayload, callbackBaseUrl, maxSolveSeconds);

--- a/apps/api/src/modules/timetable/solver-input.service.ts
+++ b/apps/api/src/modules/timetable/solver-input.service.ts
@@ -230,31 +230,34 @@ export class SolverInputService {
         const period = periods[i];
         const nextPeriod = i + 1 < periods.length ? periods[i + 1] : null;
 
+        // Period.id is shared across weekdays in the schema, so timeslot ids
+        // must be composite (day + period) to satisfy Timefold's planningId
+        // uniqueness invariant. See issue #50 Bug 2.
         if (abWeekEnabled) {
           // Duplicate for A and B weeks
           for (const weekType of ['A', 'B'] as const) {
             const suffix = `-${weekType}`;
             timeslots.push({
-              id: `${period.id}${suffix}`,
+              id: `${day}-${period.id}${suffix}`,
               dayOfWeek: day,
               periodNumber: period.periodNumber,
               startTime: period.startTime,
               endTime: period.endTime,
               weekType,
               isBreak: period.isBreak,
-              nextTimeslotId: nextPeriod ? `${nextPeriod.id}${suffix}` : null,
+              nextTimeslotId: nextPeriod ? `${day}-${nextPeriod.id}${suffix}` : null,
             });
           }
         } else {
           timeslots.push({
-            id: period.id,
+            id: `${day}-${period.id}`,
             dayOfWeek: day,
             periodNumber: period.periodNumber,
             startTime: period.startTime,
             endTime: period.endTime,
             weekType: 'BOTH',
             isBreak: period.isBreak,
-            nextTimeslotId: nextPeriod ? nextPeriod.id : null,
+            nextTimeslotId: nextPeriod ? `${day}-${nextPeriod.id}` : null,
           });
         }
       }

--- a/apps/solver/src/main/resources/application.properties
+++ b/apps/solver/src/main/resources/application.properties
@@ -1,6 +1,8 @@
 # Timefold Solver configuration
 quarkus.timefold.solver.termination.spent-limit=5m
-quarkus.timefold.solver.move-thread-count=AUTO
+# Multi-threaded solving (AUTO / 2+) requires Timefold Enterprise Edition (commercial).
+# Community Edition supports only NONE (single-threaded). See issue #50.
+quarkus.timefold.solver.move-thread-count=NONE
 
 # REST
 quarkus.http.port=8081

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -86,6 +86,10 @@ services:
       - "8081:8081"
     environment:
       QUARKUS_HTTP_PORT: 8081
+    # Solver runs in container, API runs on host (dev setup) — sidecar's
+    # callback to host:3000 must resolve to the Mac/Linux host. See #50.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8081/health"]
       interval: 10s

--- a/scripts/dev-up.sh
+++ b/scripts/dev-up.sh
@@ -69,6 +69,10 @@ if lsof -ti:3000 >/dev/null 2>&1; then
 fi
 
 step "Start API (background)"
+# API_INTERNAL_URL is the address the Solver container uses to call back into
+# the API. The solver runs in docker, the API runs on the host — host.docker.internal
+# resolves to the host gateway via the extra_hosts entry in docker-compose.yml.
+export API_INTERNAL_URL="${API_INTERNAL_URL:-http://host.docker.internal:3000}"
 (cd apps/api && nohup node dist/main.js > "$API_LOG" 2>&1 < /dev/null &) >/dev/null 2>&1
 for i in {1..20}; do
   if curl -sf http://localhost:3000/api/v1/health >/dev/null 2>&1; then


### PR DESCRIPTION
Closes #50. Issue #51 separat (Construction Heuristic, Java-Engineering).

## TL;DR

Live-Run gegen Seed-Schule hat ergeben: Solver wurde nie end-to-end getestet. Vier übereinanderliegende Bugs, jeder maskierte den nächsten. Dieser PR fixt alle vier — Pipeline ist damit durchgängig bis zum Java-Engine, der finale Engine-Bug ist als #51 getrennt tracked.

## Fixes

| # | File | Change |
|---|---|---|
| 1 | `apps/solver/src/main/resources/application.properties` | `move-thread-count=AUTO` → `NONE` (Multi-Threading ist Timefold Enterprise Edition only) |
| 2 | `apps/api/src/modules/timetable/solver-input.service.ts` | Timeslot-ID composite aus `day + period.id` (vorher: shared Period-UUID kollidiert über Wochentage) |
| 4 | `apps/api/src/modules/timetable/processors/solve.processor.ts` | `callbackBaseUrl` bekommt `/api/v1/api/internal/solver` Prefix |
| 5 | `docker/docker-compose.yml` + `scripts/dev-up.sh` | Solver-Container bekommt `host.docker.internal:host-gateway` extra_hosts; dev-up exportiert `API_INTERNAL_URL=http://host.docker.internal:3000` als Default |

## Live-Test

**Vorher:** `POST /solve` → API queued → Sidecar antwortet 500, Run failed sofort.

**Nachher:** `POST /solve` → API queued → Sidecar akzeptiert → Engine startet → crasht auf Construction-Heuristic-missing (#51).

Pipeline ist damit durchgängig. Der finale Engine-Bug ist Java-Solver-Engineering und gehört nicht mehr in dieses Issue.

## Test plan

- [x] `pnpm --filter api test` — 754 passed | 65 todo, keine Regression
- [x] Manueller Live-Run: 5 Iterationen mit zunehmend tiefem Stack-Eintrag, alle 4 Bugs reproduziert + verifiziert
- [ ] CI Playwright E2E

🤖 Generated with [Claude Code](https://claude.com/claude-code)