### PR TITLE
fix(solver): three-layer UX/watchdog/auth fix for hung SOLVING runs

### DIFF
--- a/apps/api/prisma/migrations/20260507194927_add_timetable_run_error_reason/migration.sql
+++ b/apps/api/prisma/migrations/20260507194927_add_timetable_run_error_reason/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "timetable_runs" ADD COLUMN     "error_reason" TEXT;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -730,6 +730,9 @@ model TimetableRun {
   isActive         Boolean     @default(false) @map("is_active")
   maxSolveSeconds  Int         @default(300) @map("max_solve_seconds")
   abWeekEnabled    Boolean     @default(false) @map("ab_week_enabled")
+  // Set when status becomes FAILED (watchdog timeout, sidecar 5xx, validator
+  // failure, etc.). Surfaced as red error card on /admin/solver. Issue #53.
+  errorReason      String?     @map("error_reason")
   createdAt        DateTime    @default(now()) @map("created_at")
   updatedAt        DateTime    @updatedAt @map("updated_at")
 

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
+import { ScheduleModule } from '@nestjs/schedule';
 import { PrismaModule } from './config/database/prisma.module';
 import { QueueModule } from './config/queue/queue.module';
 import { AuthModule } from './modules/auth/auth.module';
@@ -40,6 +41,7 @@ import { DashboardModule } from './modules/dashboard/dashboard.module';
       isGlobal: true,
       envFilePath: '../../.env',
     }),
+    ScheduleModule.forRoot(),
     QueueModule,
     PrismaModule,
     AuthModule,

--- a/apps/api/src/modules/timetable/dto/timetable-run-response.dto.ts
+++ b/apps/api/src/modules/timetable/dto/timetable-run-response.dto.ts
@@ -34,6 +34,13 @@ export class TimetableRunResponseDto {
   @ApiProperty({ description: 'Whether A/B week mode was enabled for this run' })
   abWeekEnabled!: boolean;
 
+  @ApiPropertyOptional({
+    description:
+      'Human-readable error message — set when status=FAILED (watchdog timeout, sidecar 5xx). Issue #53.',
+    nullable: true,
+  })
+  errorReason!: string | null;
+
   @ApiProperty({ description: 'Run creation timestamp' })
   createdAt!: Date;
 

--- a/apps/api/src/modules/timetable/solve-watchdog.service.spec.ts
+++ b/apps/api/src/modules/timetable/solve-watchdog.service.spec.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { Test, TestingModule } from '@nestjs/testing';
+import { SolveWatchdogService } from './solve-watchdog.service';
+import { PrismaService } from '../../config/database/prisma.service';
+import { TimetableGateway } from './timetable.gateway';
+
+describe('SolveWatchdogService', () => {
+  let service: SolveWatchdogService;
+  let prisma: any;
+  let gateway: any;
+
+  beforeEach(async () => {
+    prisma = {
+      timetableRun: {
+        findMany: vi.fn(),
+        update: vi.fn(),
+      },
+    };
+    gateway = {
+      emitComplete: vi.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SolveWatchdogService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: TimetableGateway, useValue: gateway },
+      ],
+    }).compile();
+
+    service = module.get<SolveWatchdogService>(SolveWatchdogService);
+  });
+
+  it('does nothing when no runs are SOLVING', async () => {
+    prisma.timetableRun.findMany.mockResolvedValue([]);
+    await service.sweep();
+    expect(prisma.timetableRun.update).not.toHaveBeenCalled();
+    expect(gateway.emitComplete).not.toHaveBeenCalled();
+  });
+
+  it('leaves runs alone when still within budget + grace', async () => {
+    // Run started 100s ago with 300s budget — well within budget.
+    prisma.timetableRun.findMany.mockResolvedValue([
+      {
+        id: 'run-1',
+        schoolId: 'school-1',
+        maxSolveSeconds: 300,
+        updatedAt: new Date(Date.now() - 100_000),
+      },
+    ]);
+    await service.sweep();
+    expect(prisma.timetableRun.update).not.toHaveBeenCalled();
+    expect(gateway.emitComplete).not.toHaveBeenCalled();
+  });
+
+  it('marks run FAILED once budget + 30s grace expires', async () => {
+    // Run last touched 400s ago, budget=300s -> 400 > 300+30 -> expired.
+    prisma.timetableRun.findMany.mockResolvedValue([
+      {
+        id: 'run-stuck',
+        schoolId: 'school-7',
+        maxSolveSeconds: 300,
+        updatedAt: new Date(Date.now() - 400_000),
+      },
+    ]);
+    prisma.timetableRun.update.mockResolvedValue({});
+    await service.sweep();
+
+    expect(prisma.timetableRun.update).toHaveBeenCalledWith({
+      where: { id: 'run-stuck' },
+      data: {
+        status: 'FAILED',
+        errorReason: expect.stringMatching(/Watchdog-Timeout/),
+      },
+    });
+    expect(gateway.emitComplete).toHaveBeenCalledWith(
+      'school-7',
+      expect.objectContaining({
+        runId: 'run-stuck',
+        status: 'FAILED',
+      }),
+    );
+  });
+
+  it('only flips expired runs when several SOLVING entries exist', async () => {
+    prisma.timetableRun.findMany.mockResolvedValue([
+      {
+        id: 'fresh',
+        schoolId: 's',
+        maxSolveSeconds: 300,
+        updatedAt: new Date(Date.now() - 60_000),
+      },
+      {
+        id: 'expired',
+        schoolId: 's',
+        maxSolveSeconds: 60,
+        updatedAt: new Date(Date.now() - 200_000),
+      },
+    ]);
+    prisma.timetableRun.update.mockResolvedValue({});
+    await service.sweep();
+
+    expect(prisma.timetableRun.update).toHaveBeenCalledTimes(1);
+    expect(prisma.timetableRun.update).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 'expired' } }),
+    );
+  });
+});

--- a/apps/api/src/modules/timetable/solve-watchdog.service.ts
+++ b/apps/api/src/modules/timetable/solve-watchdog.service.ts
@@ -1,0 +1,76 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { PrismaService } from '../../config/database/prisma.service';
+import { TimetableGateway } from './timetable.gateway';
+
+/**
+ * Watchdog for hung TimetableRuns (issue #53, Schicht 2).
+ *
+ * If the sidecar's final callback never arrives (Crash, Network-Fail,
+ * 403 from auth-header bug), a run sits in SOLVING forever — BullMQ job
+ * already done, DB record stuck. This cron flips any SOLVING run that
+ * exceeded its budget by more than 30s into FAILED with a recorded reason
+ * so the UI can render a red error card and the user can retry.
+ *
+ * Runs every 60s. Cheap query — `status='SOLVING'` index hits the
+ * @@index([schoolId, createdAt]) covering filter-then-sort path.
+ */
+@Injectable()
+export class SolveWatchdogService {
+  private readonly logger = new Logger(SolveWatchdogService.name);
+
+  /** Grace period beyond maxSolveSeconds before declaring a run dead. */
+  private static readonly GRACE_SECONDS = 30;
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly gateway: TimetableGateway,
+  ) {}
+
+  @Cron(CronExpression.EVERY_MINUTE, { name: 'solve-watchdog' })
+  async sweep(): Promise<void> {
+    const stuck = await this.prisma.timetableRun.findMany({
+      where: { status: 'SOLVING' },
+      select: {
+        id: true,
+        schoolId: true,
+        maxSolveSeconds: true,
+        updatedAt: true,
+      },
+    });
+
+    if (stuck.length === 0) return;
+
+    const now = Date.now();
+    const expired = stuck.filter((run) => {
+      const ageSeconds = (now - run.updatedAt.getTime()) / 1000;
+      return ageSeconds > run.maxSolveSeconds + SolveWatchdogService.GRACE_SECONDS;
+    });
+
+    if (expired.length === 0) return;
+
+    for (const run of expired) {
+      const reason =
+        'Watchdog-Timeout: Solver-Sidecar hat keine Antwort innerhalb des Zeitbudgets gesendet. ' +
+        'Möglicher Solver-Crash oder unterbrochene Verbindung — Lauf erneut starten.';
+      await this.prisma.timetableRun.update({
+        where: { id: run.id },
+        data: { status: 'FAILED', errorReason: reason },
+      });
+      this.logger.warn(
+        `Watchdog: marked run ${run.id} (school ${run.schoolId}) FAILED — ` +
+          `last update ${Math.round((now - run.updatedAt.getTime()) / 1000)}s ago, ` +
+          `budget ${run.maxSolveSeconds}s + grace ${SolveWatchdogService.GRACE_SECONDS}s`,
+      );
+      // Push a synthetic completion event so any open /admin/solver page
+      // unblocks immediately instead of waiting for the next polling tick.
+      this.gateway.emitComplete(run.schoolId, {
+        runId: run.id,
+        status: 'FAILED',
+        hardScore: 0,
+        softScore: 0,
+        elapsedSeconds: run.maxSolveSeconds,
+      });
+    }
+  }
+}

--- a/apps/api/src/modules/timetable/timetable.module.ts
+++ b/apps/api/src/modules/timetable/timetable.module.ts
@@ -12,6 +12,7 @@ import { ConstraintTemplateController } from './constraint-template.controller';
 import { ConstraintTemplateService } from './constraint-template.service';
 import { ConstraintWeightOverrideController } from './constraint-weight-override.controller';
 import { ConstraintWeightOverrideService } from './constraint-weight-override.service';
+import { SolveWatchdogService } from './solve-watchdog.service';
 
 @Module({
   controllers: [
@@ -31,6 +32,7 @@ import { ConstraintWeightOverrideService } from './constraint-weight-override.se
     SolveProcessor,
     ConstraintTemplateService,
     ConstraintWeightOverrideService,
+    SolveWatchdogService,
   ],
   exports: [
     TimetableService,

--- a/apps/solver/src/main/java/at/schoolflow/solver/rest/SolverResource.java
+++ b/apps/solver/src/main/java/at/schoolflow/solver/rest/SolverResource.java
@@ -62,6 +62,15 @@ public class SolverResource {
             .connectTimeout(Duration.ofSeconds(10))
             .build();
 
+    /**
+     * Shared secret used to authenticate sidecar -> NestJS callbacks.
+     * NestJS SolverCallbackController.validateSolverSecret rejects requests
+     * without a matching X-Solver-Secret header; we read it from env at
+     * request time so docker-compose env propagation works without rebuild.
+     */
+    private static final String SOLVER_SHARED_SECRET =
+            System.getenv().getOrDefault("SOLVER_SHARED_SECRET", "dev-secret");
+
     /** Tracks solve start times for elapsed seconds calculation */
     private final Map<String, Instant> startTimes = new ConcurrentHashMap<>();
 
@@ -342,6 +351,7 @@ public class SolverResource {
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(url))
                     .header("Content-Type", "application/json")
+                    .header("X-Solver-Secret", SOLVER_SHARED_SECRET)
                     .POST(HttpRequest.BodyPublishers.ofString(json))
                     .timeout(Duration.ofSeconds(5))
                     .build();

--- a/apps/web/src/hooks/__tests__/useSolverSocket.spec.ts
+++ b/apps/web/src/hooks/__tests__/useSolverSocket.spec.ts
@@ -1,0 +1,149 @@
+/* @vitest-environment jsdom */
+/**
+ * Regression guard for #53 Schicht 1 — useSolverSocket polling fallback +
+ * activeRun state machine.
+ *
+ * Specs cover three things the websocket-only version silently dropped:
+ *   1. trackRun() flips activeRun -> { status: 'QUEUED', runId } *immediately*
+ *      so the page can show "Wird in Warteschlange aufgenommen…" before
+ *      the first solver tick.
+ *   2. After the 10s grace window, REST polling on /runs/:runId kicks in
+ *      and surfaces FAILED + errorReason — even when no WS event arrives
+ *      (the watchdog-flips-a-hung-run scenario).
+ *   3. A WS solve:progress event before the grace expires cancels polling
+ *      so the two paths don't both fire.
+ */
+import React, { type ReactNode } from 'react';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock socket.io-client lib so we capture handlers without a real connection.
+const handlers = new Map<string, (...args: unknown[]) => void>();
+const fakeSocket = {
+  on: (event: string, handler: (...args: unknown[]) => void) => {
+    handlers.set(event, handler);
+  },
+  disconnect: vi.fn(),
+};
+
+vi.mock('@/lib/socket', () => ({
+  createSolverSocket: () => fakeSocket,
+  disconnectSolverSocket: vi.fn(),
+}));
+
+const { apiFetchMock } = vi.hoisted(() => ({ apiFetchMock: vi.fn() }));
+vi.mock('@/lib/api', () => ({
+  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+import { useSolverSocket } from '../useSolverSocket';
+
+function wrapper({ children }: { children: ReactNode }) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return React.createElement(QueryClientProvider, { client: qc }, children);
+}
+
+describe('useSolverSocket — #53 Schicht 1', () => {
+  beforeEach(() => {
+    handlers.clear();
+    apiFetchMock.mockReset();
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('trackRun() sets activeRun to QUEUED + runId immediately', () => {
+    const { result } = renderHook(() => useSolverSocket('s1'), { wrapper });
+    act(() => {
+      result.current.trackRun('run-abc');
+    });
+    expect(result.current.activeRun).toEqual({
+      runId: 'run-abc',
+      status: 'QUEUED',
+      errorReason: null,
+    });
+  });
+
+  it('falls back to REST polling after 10s grace, surfaces FAILED + errorReason', async () => {
+    apiFetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        id: 'run-abc',
+        status: 'FAILED',
+        errorReason: 'Watchdog-Timeout: Solver-Sidecar hat keine Antwort gesendet.',
+      }),
+    });
+
+    const { result } = renderHook(() => useSolverSocket('s1'), { wrapper });
+    act(() => {
+      result.current.trackRun('run-abc');
+    });
+
+    // Advance past the grace window — kicks off pollOnce(). We then
+    // await the in-flight fetch + state setters synchronously by
+    // draining microtasks (waitFor doesn't play with fake timers).
+    await act(async () => {
+      vi.advanceTimersByTime(10_001);
+    });
+    // Drain microtasks so apiFetch().then(...).then(...) settles and
+    // setActiveRun runs.
+    await act(async () => {
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+    });
+
+    expect(apiFetchMock).toHaveBeenCalled();
+    const url = apiFetchMock.mock.calls[0][0] as string;
+    expect(url).toBe('/api/v1/schools/s1/timetable/runs/run-abc');
+
+    expect(result.current.activeRun?.status).toBe('FAILED');
+    expect(result.current.activeRun?.errorReason).toMatch(/Watchdog-Timeout/);
+  });
+
+  it('cancels polling fallback when a WS progress event arrives within the grace window', async () => {
+    apiFetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: 'run-abc', status: 'SOLVING', errorReason: null }),
+    });
+
+    const { result } = renderHook(() => useSolverSocket('s1'), { wrapper });
+    act(() => {
+      result.current.trackRun('run-abc');
+    });
+
+    // Simulate WS progress event arriving immediately.
+    act(() => {
+      const onProgress = handlers.get('solve:progress');
+      onProgress?.({
+        runId: 'run-abc',
+        hardScore: -2,
+        softScore: -10,
+        elapsedSeconds: 1,
+        remainingViolations: [],
+        improvementRate: 'improving',
+        scoreHistory: [],
+      });
+    });
+
+    expect(result.current.activeRun?.status).toBe('SOLVING');
+
+    // Advance past grace — pollOnce() must NOT fire because progressSeenRef
+    // was set true.
+    await act(async () => {
+      vi.advanceTimersByTime(15_000);
+    });
+    expect(apiFetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/hooks/useSolverSocket.ts
+++ b/apps/web/src/hooks/useSolverSocket.ts
@@ -1,8 +1,9 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import type { Socket } from 'socket.io-client';
 import { createSolverSocket, disconnectSolverSocket } from '@/lib/socket';
+import { apiFetch } from '@/lib/api';
 
 /**
  * One entry in the solver's remaining-violation grouping.
@@ -58,6 +59,32 @@ export interface SolveCompleteEvent {
 }
 
 /**
+ * Active-run snapshot exposed to /admin/solver while a solve is in flight.
+ * Issue #53 Schicht 1: surfaces QUEUED + SOLVING-without-progress states
+ * (which the websocket-only path silently dropped) and FAILED + errorReason
+ * (so the user sees a real reason instead of a stuck spinner).
+ *
+ * Built from two sources, in this priority order:
+ *   1. The POST /solve response  -> QUEUED + runId, instantly.
+ *   2. The REST polling fallback -> latest server-side status + errorReason.
+ *   3. The 'solve:complete' WS event  -> mirrored into here so a single
+ *      consumer (the page) can drive its state machine off `activeRun`.
+ */
+export interface ActiveRunState {
+  runId: string;
+  status: 'QUEUED' | 'SOLVING' | 'COMPLETED' | 'FAILED' | 'STOPPED';
+  errorReason: string | null;
+}
+
+/** Terminal statuses — polling stops once a run reaches one of these. */
+const TERMINAL_STATUSES = new Set(['COMPLETED', 'FAILED', 'STOPPED']);
+
+/** Wait this long after starting a run before assuming WS is silent. */
+const POLL_GRACE_MS = 10_000;
+/** Polling cadence after the grace period. */
+const POLL_INTERVAL_MS = 5_000;
+
+/**
  * TIME-06 -- Real-time solver progress Socket.IO hook.
  *
  * Closes v1.0 audit Finding 3: the `/solver` Socket.IO namespace existed on
@@ -90,6 +117,84 @@ export function useSolverSocket(schoolId: string | null | undefined) {
   const [isConnected, setIsConnected] = useState(false);
   const [progress, setProgress] = useState<SolveProgressEvent | null>(null);
   const [lastResult, setLastResult] = useState<SolveCompleteEvent | null>(null);
+  const [activeRun, setActiveRun] = useState<ActiveRunState | null>(null);
+
+  // Polling-fallback bookkeeping (#53 Schicht 1). Refs, not state, so polling
+  // restarts don't cause renders.
+  const pollingRunIdRef = useRef<string | null>(null);
+  const pollingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const progressSeenRef = useRef(false);
+
+  const stopPolling = useCallback(() => {
+    if (pollingTimerRef.current) {
+      clearTimeout(pollingTimerRef.current);
+      pollingTimerRef.current = null;
+    }
+    pollingRunIdRef.current = null;
+  }, []);
+
+  /** Background fetch of the run's authoritative state, then re-arm or stop. */
+  const pollOnce = useCallback(async () => {
+    const runId = pollingRunIdRef.current;
+    if (!runId || !schoolId) return;
+    try {
+      const res = await apiFetch(
+        `/api/v1/schools/${schoolId}/timetable/runs/${runId}`,
+      );
+      if (res.ok) {
+        const run = (await res.json()) as {
+          id: string;
+          status: ActiveRunState['status'];
+          errorReason: string | null;
+        };
+        setActiveRun({
+          runId: run.id,
+          status: run.status,
+          errorReason: run.errorReason,
+        });
+        if (TERMINAL_STATUSES.has(run.status)) {
+          stopPolling();
+          // FAILED / STOPPED never produce a 'solve:complete' WS event when
+          // the watchdog flips a hung run, so make sure the UI surfaces it.
+          if (run.status === 'FAILED' && !lastResult) {
+            toast.error('Stundenplan-Generierung fehlgeschlagen', {
+              description: run.errorReason ?? 'Unbekannter Fehler',
+            });
+          }
+          return;
+        }
+      }
+    } catch {
+      // Swallow — next poll re-tries; the watchdog will eventually flip the
+      // run to FAILED on the server side anyway.
+    }
+    // Re-arm.
+    pollingTimerRef.current = setTimeout(pollOnce, POLL_INTERVAL_MS);
+  }, [schoolId, stopPolling, lastResult]);
+
+  /**
+   * Mark a freshly POSTed run as active and arm the polling fallback.
+   * The page calls this right after `POST /solve` returns 202 so the UI
+   * shows "QUEUED + Run-ID" *immediately*, then arms a 10s grace timer
+   * that flips into REST-polling mode if no `solve:progress` event arrives.
+   */
+  const trackRun = useCallback(
+    (runId: string) => {
+      // Reset any prior tracking — start fresh.
+      stopPolling();
+      progressSeenRef.current = false;
+      setActiveRun({ runId, status: 'QUEUED', errorReason: null });
+      pollingRunIdRef.current = runId;
+      pollingTimerRef.current = setTimeout(() => {
+        // If a websocket progress event already arrived, skip polling — the
+        // socket path is richer (scoreHistory, violations) and authoritative
+        // while the run is live. Otherwise start the REST poll loop.
+        if (progressSeenRef.current) return;
+        pollOnce();
+      }, POLL_GRACE_MS);
+    },
+    [stopPolling, pollOnce],
+  );
 
   useEffect(() => {
     if (!schoolId) return;
@@ -115,25 +220,55 @@ export function useSolverSocket(schoolId: string | null | undefined) {
 
     socket.on('solve:progress', (event: SolveProgressEvent) => {
       setProgress(event);
+      progressSeenRef.current = true;
+      // WS is alive — kill the REST polling fallback to save round-trips.
+      if (pollingRunIdRef.current === event.runId) {
+        stopPolling();
+      }
+      // Reflect the SOLVING transition in activeRun so the page can drop
+      // the "wird in Warteschlange aufgenommen" copy.
+      setActiveRun((prev) =>
+        prev && prev.runId === event.runId
+          ? { ...prev, status: 'SOLVING' }
+          : prev,
+      );
     });
 
     socket.on('solve:complete', (event: SolveCompleteEvent) => {
       setLastResult(event);
       setProgress(null);
+      // Mirror terminal status into activeRun so the page can render the
+      // FAILED-card from a single source of truth.
+      setActiveRun((prev) =>
+        prev && prev.runId === event.runId
+          ? {
+              ...prev,
+              status: event.status as ActiveRunState['status'],
+            }
+          : prev,
+      );
+      stopPolling();
       // Invalidate timetable + runs caches so the admin page reflects the
       // freshly generated plan without a manual refresh.
       queryClient.invalidateQueries({ queryKey: ['timetable'] });
       queryClient.invalidateQueries({ queryKey: ['timetable-runs'] });
-      toast.success('Stundenplan-Generierung abgeschlossen', {
-        description: `Status: ${event.status} | Hard: ${event.hardScore} | Soft: ${event.softScore}`,
-      });
+      if (event.status === 'FAILED') {
+        toast.error('Stundenplan-Generierung fehlgeschlagen', {
+          description: 'Details siehe rote Fehler-Karte.',
+        });
+      } else {
+        toast.success('Stundenplan-Generierung abgeschlossen', {
+          description: `Status: ${event.status} | Hard: ${event.hardScore} | Soft: ${event.softScore}`,
+        });
+      }
     });
 
     return () => {
       disconnectSolverSocket(socketRef.current);
       socketRef.current = null;
+      stopPolling();
     };
-  }, [schoolId, queryClient]);
+  }, [schoolId, queryClient, stopPolling]);
 
-  return { isConnected, progress, lastResult };
+  return { isConnected, progress, lastResult, activeRun, trackRun };
 }

--- a/apps/web/src/routes/_authenticated/admin/solver.tsx
+++ b/apps/web/src/routes/_authenticated/admin/solver.tsx
@@ -34,7 +34,8 @@ export const Route = createFileRoute('/_authenticated/admin/solver')({
 function AdminSolverPage() {
   const schoolId = useSchoolContext((s) => s.schoolId);
   const navigate = useNavigate();
-  const { isConnected, progress, lastResult } = useSolverSocket(schoolId);
+  const { isConnected, progress, lastResult, activeRun, trackRun } =
+    useSolverSocket(schoolId);
   const [isStarting, setIsStarting] = useState(false);
   const [isActivating, setIsActivating] = useState(false);
 
@@ -52,8 +53,13 @@ function AdminSolverPage() {
       if (!res.ok) {
         throw new Error(`Failed to start solve (HTTP ${res.status})`);
       }
+      // #53 Schicht 1: capture runId from the 202 response so the UI can
+      // show "Wird in Warteschlange aufgenommen…" immediately, and arm
+      // the REST polling fallback for cases where the WS goes silent.
+      const data = (await res.json()) as { runId: string; status: string };
+      trackRun(data.runId);
       toast.info('Stundenplan-Generierung gestartet', {
-        description: 'Der Solver laeuft. Fortschritt erscheint hier.',
+        description: `Run ${data.runId.slice(0, 8)}… eingereiht.`,
       });
     } catch (error) {
       toast.error('Fehler beim Starten der Generierung', {
@@ -88,7 +94,20 @@ function AdminSolverPage() {
     }
   };
 
-  const isRunning = progress !== null;
+  // #53 Schicht 1: explicit run-state machine that drives the UI cards.
+  //   - "running"  = QUEUED or SOLVING (button disabled, queued/progress card)
+  //   - "failed"   = FAILED (red error card with errorReason)
+  //   - "complete" = COMPLETED (green result card via `lastResult`)
+  // Falls back to the legacy `progress !== null` flag so this still works
+  // if the socket fires before activeRun gets the QUEUED snapshot.
+  const isQueued =
+    activeRun?.status === 'QUEUED' && progress === null;
+  const isRunning =
+    progress !== null ||
+    activeRun?.status === 'SOLVING' ||
+    activeRun?.status === 'QUEUED';
+  const failedRun =
+    activeRun?.status === 'FAILED' ? activeRun : null;
 
   return (
     <div className="max-w-[800px] mx-auto space-y-6">
@@ -140,6 +159,31 @@ function AdminSolverPage() {
                 : 'Nicht verbunden (Updates folgen beim Verbinden)'}
             </span>
           </div>
+
+          {/* #53 Schicht 1: queued-state card. Shown while the run is
+              QUEUED and no progress event has arrived yet — closes the
+              "silent void" gap between POST and first solver tick. */}
+          {isQueued && activeRun && (
+            <div
+              className="space-y-2 rounded-md border border-border bg-muted/30 p-4"
+              role="status"
+              aria-live="polite"
+              data-testid="solver-queued-card"
+            >
+              <div className="flex items-center gap-2 text-sm font-semibold">
+                <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-blue-500" />
+                Wird in Warteschlange aufgenommen…
+              </div>
+              <div className="text-xs text-muted-foreground">
+                Run:{' '}
+                <span className="font-mono">{activeRun.runId}</span>
+              </div>
+              <div className="text-xs text-muted-foreground">
+                Engine startet gleich. Fortschritt erscheint hier sobald die
+                ersten Lösungen gefunden wurden.
+              </div>
+            </div>
+          )}
 
           {/* Live progress block -- only while solver is running */}
           {progress && (
@@ -194,8 +238,39 @@ function AdminSolverPage() {
         </CardContent>
       </Card>
 
+      {/* #53 Schicht 1: failure card — surfaces the watchdog-detected
+          timeout (or any other FAILED reason) instead of leaving the user
+          staring at a silent spinner. Backed by activeRun.errorReason. */}
+      {failedRun && (
+        <Card
+          className="border-destructive/60 bg-destructive/5"
+          data-testid="solver-failed-card"
+        >
+          <CardHeader>
+            <CardTitle className="text-[20px] text-destructive">
+              Generierung fehlgeschlagen
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm">
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Run ID</span>
+              <span className="font-mono text-xs">{failedRun.runId}</span>
+            </div>
+            <div className="rounded-md bg-background/40 p-3 text-sm">
+              {failedRun.errorReason ??
+                'Unbekannter Fehler — siehe API-Logs für Details.'}
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Bitte Generierung erneut starten. Wiederholen sich Fehler,
+              prüfen Sie unter „Stundenplan-Tuning“ die Constraints und
+              kontaktieren Sie den Support.
+            </p>
+          </CardContent>
+        </Card>
+      )}
+
       {/* Last result card -- only after a solve:complete event */}
-      {lastResult && (
+      {lastResult && lastResult.status !== 'FAILED' && (
         <Card>
           <CardHeader>
             <CardTitle className="text-[20px]">Letztes Ergebnis</CardTitle>

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -55,6 +55,15 @@ VAPID_SUBJECT=mailto:admin@schoolflow.example
 # API_INTERNAL_URL=http://api:3000/api/v1/api/internal/solver
 
 # ==============================================================================
+# Solver shared secret (X-Solver-Secret header on every sidecar -> NestJS callback)
+# ==============================================================================
+# Both NestJS (SolverCallbackController.validateSolverSecret) and the Java
+# Quarkus sidecar (SolverResource.sendCallback) read this from env. The
+# default "dev-secret" is fine for local dev; pick a long random string for
+# prod. Mismatch causes 403 from NestJS and runs hang in SOLVING (#53).
+SOLVER_SHARED_SECRET=dev-secret
+
+# ==============================================================================
 # Backup / restore scripts (docker/scripts/backup.sh, restore.sh)
 # ==============================================================================
 # BACKUP_DIR is where backup.sh writes timestamped dumps + manifest.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -86,6 +86,10 @@ services:
       - "8081:8081"
     environment:
       QUARKUS_HTTP_PORT: 8081
+      # Sidecar -> NestJS callbacks must include X-Solver-Secret. Both sides
+      # default to "dev-secret"; override via shell env or docker/.env when
+      # running prod. See #53 (Bug 6 in the original audit).
+      SOLVER_SHARED_SECRET: ${SOLVER_SHARED_SECRET:-dev-secret}
     # Solver runs in container, API runs on host (dev setup) — sidecar's
     # callback to host:3000 must resolve to the Mac/Linux host. See #50.
     extra_hosts:


### PR DESCRIPTION
## Summary
- **Layer 3 — Sidecar X-Solver-Secret header** (root cause): Java `sendCallback()` now sends `X-Solver-Secret` from `SOLVER_SHARED_SECRET` env. Was silently failing 403 on every callback, leaving runs stuck in SOLVING forever.
- **Layer 2 — API watchdog cron**: `ScheduleModule` + new `SolveWatchdogService` sweeps every 60s. SOLVING runs older than `maxSolveSeconds + 30s` flip to FAILED with a recorded `errorReason`, plus synthetic `solve:complete` event so open pages unblock immediately. New `error_reason` column on `timetable_runs` (additive migration `20260507194927_add_timetable_run_error_reason`).
- **Layer 1 — Frontend feedback + polling fallback**: `useSolverSocket` gets `activeRun` state machine + `trackRun()` helper. `/admin/solver` shows "Wird in Warteschlange aufgenommen…" immediately on POST, polls REST after 10s grace if WS is silent, surfaces FAILED + errorReason in a red card.

Closes #53.

## Live verification (manual smoke against dev stack)

```text
[NestJS]  ScheduleModule dependencies initialized
[NestJS]  SolveWatchdogService — Watchdog: marked run f9ec68e5… (school a000…) FAILED — last update 64s ago, budget 30s + grace 30s
GET  /timetable/runs/f9ec68e5-…  ->  status=FAILED, errorReason="Watchdog-Timeout: Solver-Sidecar hat keine Antwort innerhalb des Zeitbudgets gesendet…"
```

Watchdog also self-healed three pre-existing hung SOLVING runs from the
DB on first sweep — exactly the scenario described in the issue.

## Test plan
- [x] Unit: `solve-watchdog.service.spec.ts` (4 cases — empty list, fresh run untouched, expired run flipped, mixed batch)
- [x] Unit: `useSolverSocket.spec.ts` (3 cases — trackRun sets QUEUED instantly, REST polling kicks in after 10s grace and surfaces FAILED, WS progress cancels polling)
- [x] API typecheck (`pnpm --filter api build`) — clean, 449 files compiled
- [x] Web typecheck (`tsc -b`) — clean
- [x] Live smoke against dev stack: POST /solve → QUEUED, sidecar callbacks now arrive (manual `curl` from container hits `/api/v1/api/internal/solver/progress/...` → 422 instead of 403, proving the auth header path works), watchdog flips hung run to FAILED + errorReason after grace
- [ ] Browser smoke (next): /admin/solver shows the new queued/failed cards end-to-end

## Out of scope
- #51 — Construction Heuristic still missing in Java solver config; engine crashes mid-solve. This PR makes that crash *visible* (red FAILED card with reason) instead of *silent* (stuck spinner).
- #54 — ZEIT-01 throwaway-school refactor unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)