### PR TITLE
fix(solver): construction heuristic + zero-rooms guard

### DIFF
--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -145,6 +145,16 @@ const SEED_PARENTSTUDENT_KC_ELTERN_UUID = '10000000-0000-4000-8000-000000000005'
 const SEED_REDUCTION_T2_KV_UUID         = '20000000-0000-4000-8000-000000000001';
 const SEED_RULE_RELIGION_1A_UUID        = '20000000-0000-4000-8000-000000000002';
 
+// Solver-input fixed UUIDs (issue #51): the seed school MUST have rooms or
+// the Construction Heuristic cannot initialize Lesson.room (one of two
+// @PlanningVariables) and Local Search crashes with "uninitialized entities".
+const SEED_ROOM_K_1A_UUID               = '30000000-0000-4000-8000-000000000001';
+const SEED_ROOM_K_2A_UUID               = '30000000-0000-4000-8000-000000000002';
+const SEED_ROOM_K_RESERVE_UUID          = '30000000-0000-4000-8000-000000000003';
+const SEED_ROOM_TURNSAAL_UUID           = '30000000-0000-4000-8000-000000000004';
+const SEED_ROOM_EDV_UUID                = '30000000-0000-4000-8000-000000000005';
+const SEED_ROOM_MUSIK_UUID              = '30000000-0000-4000-8000-000000000006';
+
 // Lookup arrays (1-indexed via [n - 1]) for the studentNames loop:
 const SEED_PERSON_STUDENT_UUIDS = [
   SEED_PERSON_STUDENT_1_UUID,
@@ -1045,9 +1055,42 @@ async function main() {
     data: { klassenvorstandId: lehrerTeacher.id },
   });
 
+  // --- Rooms (issue #51) ---
+  // Six rooms covering the four most common Austrian school room types so
+  // the Timefold solver Construction Heuristic always has a value range
+  // for Lesson.room. Capacities match a typical 25–30-student class.
+  const seedRooms: Array<{
+    id: string;
+    name: string;
+    roomType: 'KLASSENZIMMER' | 'TURNSAAL' | 'EDV_RAUM' | 'MUSIKRAUM';
+    capacity: number;
+    equipment: string[];
+  }> = [
+    { id: SEED_ROOM_K_1A_UUID, name: 'Raum 1A', roomType: 'KLASSENZIMMER', capacity: 30, equipment: ['Beamer'] },
+    { id: SEED_ROOM_K_2A_UUID, name: 'Raum 2A', roomType: 'KLASSENZIMMER', capacity: 30, equipment: ['Smartboard'] },
+    { id: SEED_ROOM_K_RESERVE_UUID, name: 'Raum 3 (Reserve)', roomType: 'KLASSENZIMMER', capacity: 28, equipment: [] },
+    { id: SEED_ROOM_TURNSAAL_UUID, name: 'Turnsaal', roomType: 'TURNSAAL', capacity: 60, equipment: [] },
+    { id: SEED_ROOM_EDV_UUID, name: 'EDV-Raum', roomType: 'EDV_RAUM', capacity: 24, equipment: ['PCs', 'Beamer'] },
+    { id: SEED_ROOM_MUSIK_UUID, name: 'Musikraum', roomType: 'MUSIKRAUM', capacity: 28, equipment: ['Klavier'] },
+  ];
+  for (const r of seedRooms) {
+    await prisma.room.upsert({
+      where: { id: r.id },
+      update: {},
+      create: {
+        id: r.id,
+        schoolId: school.id,
+        name: r.name,
+        roomType: r.roomType,
+        capacity: r.capacity,
+        equipment: r.equipment,
+      },
+    });
+  }
+
   console.log(`Seeded ${roles.length} roles and ${allPermissions.length} default permissions`);
   console.log(`Seeded sample school: ${school.name} (${school.schoolType})`);
-  console.log('Seeded 3 teachers, 6 students, 4 subjects, 2 classes, 7 retention policies');
+  console.log(`Seeded 3 teachers, 6 students, 4 subjects, 2 classes, ${seedRooms.length} rooms, 7 retention policies`);
   console.log('Linked 5 Keycloak test users to Person records with Klassenvorstand assignment');
 }
 

--- a/apps/api/src/modules/timetable/timetable.service.spec.ts
+++ b/apps/api/src/modules/timetable/timetable.service.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getQueueToken } from '@nestjs/bullmq';
-import { NotFoundException } from '@nestjs/common';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { TimetableService } from './timetable.service';
 import { PrismaService } from '../../config/database/prisma.service';
 import { SolverClientService } from './solver-client.service';
@@ -54,6 +54,12 @@ describe('TimetableService', () => {
   const mockPrismaService = {
     school: {
       findUniqueOrThrow: vi.fn().mockResolvedValue(mockSchool),
+    },
+    room: {
+      // #51 defensive pre-check needs at least one room. Default mock
+      // returns 6 (matches the seed-school count); the no-rooms spec
+      // overrides to 0.
+      count: vi.fn().mockResolvedValue(6),
     },
     timetableRun: {
       create: vi.fn().mockResolvedValue(mockRun),
@@ -139,6 +145,18 @@ describe('TimetableService', () => {
           maxSolveSeconds: 300,
         }),
       });
+    });
+
+    it('refuses startSolve with BadRequest when school has zero rooms (#51)', async () => {
+      prismaService.room.count.mockResolvedValueOnce(0);
+
+      await expect(service.startSolve('school-1')).rejects.toThrow(
+        BadRequestException,
+      );
+      // Crucial: do NOT enqueue a job that would crash inside the
+      // sidecar's CH with "uninitialized entities".
+      expect(prismaService.timetableRun.create).not.toHaveBeenCalled();
+      expect(solverQueue.add).not.toHaveBeenCalled();
     });
 
     it('should snapshot the RESOLVED weight map into constraintConfig (D-06)', async () => {

--- a/apps/api/src/modules/timetable/timetable.service.ts
+++ b/apps/api/src/modules/timetable/timetable.service.ts
@@ -1,4 +1,9 @@
-import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
 import { InjectQueue } from '@nestjs/bullmq';
 import { Queue } from 'bullmq';
 import { endOfWeek, startOfWeek } from 'date-fns';
@@ -54,6 +59,20 @@ export class TimetableService {
     const school = await this.prisma.school.findUniqueOrThrow({
       where: { id: schoolId },
     });
+
+    // #51 defensive pre-check: Lesson has TWO @PlanningVariables in the
+    // sidecar (timeslot + room). With zero rooms the Construction
+    // Heuristic cannot initialize the room field and Local Search crashes
+    // with "uninitialized entities". Refuse the run upfront with a clear
+    // error so the UI can render a helpful FAILED card instead of a
+    // generic "watchdog timeout" 60+ seconds later.
+    const roomCount = await this.prisma.room.count({ where: { schoolId } });
+    if (roomCount === 0) {
+      throw new BadRequestException(
+        'Stundenplan-Generierung nicht möglich: Diese Schule hat noch keine Räume. ' +
+          'Bitte mindestens einen Raum unter „Räume“ anlegen, dann erneut versuchen.',
+      );
+    }
 
     // D-06 Step 0: load school-scoped DB overrides BEFORE building the payload
     const dbWeights = await this.constraintWeightOverrideService.findOverridesOnly(schoolId);

--- a/apps/solver/src/main/resources/application.properties
+++ b/apps/solver/src/main/resources/application.properties
@@ -1,4 +1,11 @@
 # Timefold Solver configuration
+#
+# Phase config lives in solverConfig.xml (resources root). Quarkus auto-
+# discovers it; we set this property explicitly so a future move of the
+# file fails loudly. Issue #51 — without explicit phases, the implicit
+# Quarkus default did not insert a Construction Heuristic before the
+# Local Search phase, crashing the run with "32 uninitialized entities".
+quarkus.timefold.solver-config-xml=solverConfig.xml
 quarkus.timefold.solver.termination.spent-limit=5m
 # Multi-threaded solving (AUTO / 2+) requires Timefold Enterprise Edition (commercial).
 # Community Edition supports only NONE (single-threaded). See issue #50.

--- a/apps/solver/src/main/resources/solverConfig.xml
+++ b/apps/solver/src/main/resources/solverConfig.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Explicit solver configuration for the SchoolFlow timetabling problem.
+
+  Why this file exists (issue #51):
+    Without an explicit solverConfig.xml, the Quarkus Timefold extension
+    builds an implicit config that under our domain (32 lessons, dual
+    @PlanningVariable, ConstraintConfiguration) failed to insert a
+    Construction Heuristic before Local Search. The result was an
+    instant crash:
+      "Local Search phase (1) needs to start from an initialized
+       solution, but there are (32) uninitialized entities."
+
+  Defaults applied here:
+    - constructionHeuristic with no body  -> Timefold picks
+      FIRST_FIT_DECREASING automatically.
+    - localSearch with no body            -> Timefold picks
+      LATE_ACCEPTANCE automatically.
+
+  Property overrides still win:
+    quarkus.timefold.solver.termination.spent-limit (in
+    application.properties) overrides the XML <termination> below.
+    move-thread-count is also property-driven (Community Edition needs
+    NONE, see #50).
+
+  Domain class lookup:
+    - solutionClass + entityClass are listed explicitly so the Quarkus
+      extension does not need to scan the whole jar — the same
+      annotated classes are still auto-detected by Timefold for the
+      ConstraintConfiguration / @ValueRangeProvider wiring.
+-->
+<solver xmlns="https://timefold.ai/xsd/solver"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://timefold.ai/xsd/solver https://timefold.ai/xsd/solver/solver.xsd">
+
+    <solutionClass>at.schoolflow.solver.domain.SchoolTimetable</solutionClass>
+    <entityClass>at.schoolflow.solver.domain.Lesson</entityClass>
+
+    <scoreDirectorFactory>
+        <constraintProviderClass>at.schoolflow.solver.constraints.TimetableConstraintProvider</constraintProviderClass>
+    </scoreDirectorFactory>
+
+    <termination>
+        <!-- Overridden at runtime by quarkus.timefold.solver.termination.spent-limit -->
+        <spentLimit>5m</spentLimit>
+    </termination>
+
+    <constructionHeuristic/>
+    <localSearch/>
+</solver>

--- a/apps/web/e2e/rooms-filter.spec.ts
+++ b/apps/web/e2e/rooms-filter.spec.ts
@@ -13,12 +13,13 @@
  *     appears anywhere in the request URL.
  *
  *   Test 2 — UI-level guard for hasActiveFilters branching:
- *     Selecting Raumtyp=EDV-Raum yields zero matches (the seedTimetableRun
- *     fixture only ever provisions a KLASSENZIMMER room, and prisma:seed
- *     creates ZERO rooms). The empty-state Card must show the filter-aware
- *     copy ("Keine passenden Raeume") and NOT the legacy un-branched copy
- *     ("Keine Raeume angelegt"). Reverting the hasActiveFilters branch in
- *     rooms/index.tsx fails this assertion.
+ *     Selecting Raumtyp=Werkraum yields zero matches. After #51 the
+ *     prisma:seed creates 3 KLASSENZIMMER + Turnsaal + EDV-Raum +
+ *     Musikraum, but neither Werkraum nor Labor — Werkraum is the
+ *     stable empty-filter target. The empty-state Card must show the
+ *     filter-aware copy ("Keine passenden Raeume") and NOT the legacy
+ *     un-branched copy ("Keine Raeume angelegt"). Reverting the
+ *     hasActiveFilters branch in rooms/index.tsx fails this assertion.
  *
  * Closes deferred items 2 + 3 from
  *   .planning/debug/resolved/room-filter-not-working.md
@@ -27,16 +28,15 @@
  *
  * Fixture choice — REUSE seedTimetableRun:
  *   - Self-provisions a Room with roomType KLASSENZIMMER (timetable-run.ts:240-249)
- *     when the seed school has none — guarantees the precondition for
- *     Test 1 (a Klassenzimmer match exists, so the request still fires)
- *     and the precondition for Test 2 (only a Klassenzimmer exists, so
- *     EDV-Raum yields zero matches).
+ *     when the seed school has none — kept for back-compat even though
+ *     prisma:seed now creates rooms (since #51). Test 1 still finds a
+ *     Klassenzimmer match. Test 2 deliberately picks Werkraum (which
+ *     neither seed nor fixture provisions) for guaranteed zero matches.
  *   - Activates MON–FRI school days so the availability grid renders.
  *   - Same fixture used by admin-timetable-edit-perspective.spec.ts —
  *     keeping the contract in one place reduces fixture drift.
- *   If a future seed adds an EDV_RAUM room, Test 2 will start failing —
- *   that's the correct signal. Flip the assertion to a different empty
- *   type (MUSIKRAUM, WERKRAUM) at that point.
+ *   If a future seed adds a WERKRAUM room, Test 2 will start failing —
+ *   that's the correct signal. Flip the assertion to LABOR at that point.
  *
  * Desktop-only via file naming (no `mobile` infix) — playwright.config.ts:42
  * routes `*.spec.ts` files to the desktop project automatically.
@@ -128,12 +128,14 @@ test.describe('Rooms-filter regression — German enum + filter-aware empty stat
   }) => {
     await page.waitForLoadState('networkidle');
 
-    // Pick EDV-Raum — guaranteed zero matches because seedTimetableRun's
-    // self-provisioned room is KLASSENZIMMER and prisma:seed creates zero
-    // rooms. Day filter stays at the default (today's weekday or MONDAY).
+    // Pick Werkraum — guaranteed zero matches. The seed school has 3
+    // KLASSENZIMMER + Turnsaal + EDV-Raum + Musikraum, but neither
+    // Werkraum nor Labor (#51 added rooms; the doc-comment of this file
+    // foresaw exactly this drift and prescribed flipping the filter to
+    // an empty type when it happens). Day filter stays at the default.
     await page.getByRole('combobox').nth(1).click();
     await page
-      .getByRole('option', { name: 'EDV-Raum', exact: true })
+      .getByRole('option', { name: 'Werkraum', exact: true })
       .click();
 
     // Filter-aware copy (the regression target):


### PR DESCRIPTION
## Summary
Three changes that together let a solve reach **COMPLETED with hardScore=0** on the seed school for the first time.

1. **Explicit Timefold phase config** — `apps/solver/src/main/resources/solverConfig.xml` with `<constructionHeuristic/>` + `<localSearch/>`. Quarkus' implicit default did not insert CH for our domain.
2. **Seed-school rooms** — six fixed-UUID rooms (3 Klassenzimmer + Turnsaal + EDV-Raum + Musikraum). Lesson has TWO `@PlanningVariable`s (timeslot + room); with zero rooms CH cannot initialize, regardless of phase config.
3. **Defensive pre-check** — `TimetableService.startSolve` now throws 400 BadRequest with a German error before queueing the BullMQ job if the school has zero rooms. Surfaces as the #53 red FAILED card immediately, no 60s watchdog wait.

Closes #51.

## Live verification on seed school
\`\`\`
Construction Heuristic phase (0) ended: best score (0hard/-7soft), step total (32)
Local Search phase (1) ended: best score (0hard/-7soft), step total (9990736)
Solve completed for runId=f1485193-…: score=0hard/-7soft, elapsed=300s
\`\`\`

\`hardScore=0\` = the acceptance criterion of the issue is met. The 7 soft-violations are normal for a 32-lesson schedule on 6 rooms; tunable via constraint weights in /admin/solver-tuning.

## Test plan
- [x] Unit: extended \`timetable.service.spec.ts\` with zero-rooms BadRequest case
- [x] All API specs: 759 passed / 65 todo
- [x] API typecheck: clean
- [x] Live solve on seed school: COMPLETED with hardScore=0, 9.9M LS steps in 5min
- [x] Solver logs show CH phase 0 + LS phase 1 + Solve completed

## Out of scope (future tickets)
- Sidecar ignores per-request \`maxSolveSeconds\` and always uses the globally configured 5m
- \"header parser received no bytes\" on long-running callbacks (Docker Desktop / macOS TCP idle quirk) — already handled UX-side by #53 watchdog

🤖 Generated with [Claude Code](https://claude.com/claude-code)