### PR TITLE
fix(solver): callbacks reach NestJS end-to-end

### DIFF
--- a/apps/api/src/modules/timetable/dto/solve-progress.dto.ts
+++ b/apps/api/src/modules/timetable/dto/solve-progress.dto.ts
@@ -1,32 +1,74 @@
+import {
+  IsArray,
+  IsIn,
+  IsInt,
+  IsString,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+
 /**
  * DTOs for solver progress updates.
  * Received from the Timefold sidecar via internal callback (D-08).
+ *
+ * class-validator decorators are required because the global
+ * ValidationPipe runs with `whitelist: true, forbidNonWhitelisted: true`
+ * — without them every property is rejected as "should not exist" and
+ * the sidecar's HTTP/1.1 callback gets a 422. Issue #58.
  */
 
 export class ViolationGroupDto {
   /** Constraint type, e.g. "Teacher conflict", "Room double-booking" */
+  @IsString()
   type!: string;
+
   /** Number of violations of this type */
+  @IsInt()
   count!: number;
+
   /** Human-readable examples: "Mueller: Mon P3", "Room 101: Fri P5-P6" */
+  @IsArray()
+  @IsString({ each: true })
   examples!: string[];
 }
 
 export class ScoreHistoryEntryDto {
   /** Milliseconds since solve start */
+  @IsInt()
   timestamp!: number;
+
   /** Hard score (0 = no hard violations) */
+  @IsInt()
   hard!: number;
+
   /** Soft score (higher is better, always <= 0) */
+  @IsInt()
   soft!: number;
 }
 
 export class SolveProgressDto {
+  @IsString()
   runId!: string;
+
+  @IsInt()
   hardScore!: number;
+
+  @IsInt()
   softScore!: number;
+
+  @IsInt()
   elapsedSeconds!: number;
+
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => ViolationGroupDto)
   remainingViolations!: ViolationGroupDto[];
+
+  @IsIn(['improving', 'plateauing', 'stagnant'])
   improvementRate!: 'improving' | 'plateauing' | 'stagnant';
+
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => ScoreHistoryEntryDto)
   scoreHistory!: ScoreHistoryEntryDto[];
 }

--- a/apps/api/src/modules/timetable/dto/solve-result.dto.ts
+++ b/apps/api/src/modules/timetable/dto/solve-result.dto.ts
@@ -1,31 +1,72 @@
+import {
+  IsArray,
+  IsIn,
+  IsInt,
+  IsString,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+
 /**
  * DTOs for solver completion result.
  * Received from the Timefold sidecar via internal callback on solve completion.
+ *
+ * Decorators required because the global ValidationPipe runs with
+ * `whitelist: true, forbidNonWhitelisted: true`. Without them every
+ * property gets rejected as "should not exist" — see issue #58.
  */
 
 import { ViolationGroupDto } from './solve-progress.dto';
 
 export class SolvedLessonDto {
   /** Lesson ID in format classSubjectId-index */
+  @IsString()
   lessonId!: string;
+
   /** Assigned timeslot ID (Period.id or Period.id-A/B for A/B weeks) */
+  @IsString()
   timeslotId!: string;
+
   /** Assigned room ID */
+  @IsString()
   roomId!: string;
+
   /** Day of week extracted from the assigned timeslot */
+  @IsString()
   dayOfWeek!: string;
+
   /** Period number extracted from the assigned timeslot */
+  @IsInt()
   periodNumber!: number;
+
   /** Week type: "BOTH", "A", or "B" */
+  @IsString()
   weekType!: string;
 }
 
 export class SolveResultDto {
+  @IsString()
   runId!: string;
+
+  @IsIn(['COMPLETED', 'STOPPED', 'FAILED'])
   status!: 'COMPLETED' | 'STOPPED' | 'FAILED';
+
+  @IsInt()
   hardScore!: number;
+
+  @IsInt()
   softScore!: number;
+
+  @IsInt()
   elapsedSeconds!: number;
+
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => SolvedLessonDto)
   lessons!: SolvedLessonDto[];
+
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => ViolationGroupDto)
   violations!: ViolationGroupDto[];
 }

--- a/apps/api/src/modules/timetable/solve-watchdog.service.spec.ts
+++ b/apps/api/src/modules/timetable/solve-watchdog.service.spec.ts
@@ -78,6 +78,10 @@ describe('SolveWatchdogService', () => {
       expect.objectContaining({
         runId: 'run-stuck',
         status: 'FAILED',
+        // #58 — synthetic complete event must carry the same German
+        // reason that was just written to the DB so the FE red card
+        // renders the real message instead of "Unbekannter Fehler".
+        errorReason: expect.stringMatching(/Watchdog-Timeout/),
       }),
     );
   });

--- a/apps/api/src/modules/timetable/solve-watchdog.service.ts
+++ b/apps/api/src/modules/timetable/solve-watchdog.service.ts
@@ -70,6 +70,9 @@ export class SolveWatchdogService {
         hardScore: 0,
         softScore: 0,
         elapsedSeconds: run.maxSolveSeconds,
+        // Issue #58: hand the reason we just persisted to the open
+        // /admin/solver page so the red FAILED card shows it directly.
+        errorReason: reason,
       });
     }
   }

--- a/apps/api/src/modules/timetable/timetable.gateway.ts
+++ b/apps/api/src/modules/timetable/timetable.gateway.ts
@@ -71,6 +71,11 @@ export class TimetableGateway implements OnGatewayConnection, OnGatewayDisconnec
       hardScore: number;
       softScore: number;
       elapsedSeconds: number;
+      // Issue #58: watchdog-driven FAILED events carry the German timeout
+      // message; normal completions pass null. Frontend mirrors this into
+      // activeRun so the red FAILED card shows the real reason instead of
+      // "Unbekannter Fehler".
+      errorReason?: string | null;
     },
   ): void {
     this.server.to(`school:${schoolId}`).emit('solve:complete', result);

--- a/apps/solver/src/main/java/at/schoolflow/solver/dto/SolveResult.java
+++ b/apps/solver/src/main/java/at/schoolflow/solver/dto/SolveResult.java
@@ -96,7 +96,13 @@ public class SolveResult {
 
     /**
      * A lesson with its solved timeslot and room assignments.
-     * Only the IDs are sent back -- NestJS maps them to full entities.
+     * NestJS maps the IDs to full entities and persists TimetableLesson rows.
+     *
+     * Issue #58: dayOfWeek + periodNumber + weekType are denormalized
+     * out of the Timeslot so NestJS can persist TimetableLesson rows
+     * without an extra DB lookup. SolveResultDto on the NestJS side
+     * declares them required; without these fields validation rejected
+     * the callback with 422.
      */
     public static class SolvedLesson {
 
@@ -109,13 +115,26 @@ public class SolveResult {
         @JsonProperty("roomId")
         private String roomId;
 
+        @JsonProperty("dayOfWeek")
+        private String dayOfWeek;
+
+        @JsonProperty("periodNumber")
+        private int periodNumber;
+
+        @JsonProperty("weekType")
+        private String weekType;
+
         public SolvedLesson() {
         }
 
-        public SolvedLesson(String lessonId, String timeslotId, String roomId) {
+        public SolvedLesson(String lessonId, String timeslotId, String roomId,
+                            String dayOfWeek, int periodNumber, String weekType) {
             this.lessonId = lessonId;
             this.timeslotId = timeslotId;
             this.roomId = roomId;
+            this.dayOfWeek = dayOfWeek;
+            this.periodNumber = periodNumber;
+            this.weekType = weekType;
         }
 
         public String getLessonId() {
@@ -140,6 +159,30 @@ public class SolveResult {
 
         public void setRoomId(String roomId) {
             this.roomId = roomId;
+        }
+
+        public String getDayOfWeek() {
+            return dayOfWeek;
+        }
+
+        public void setDayOfWeek(String dayOfWeek) {
+            this.dayOfWeek = dayOfWeek;
+        }
+
+        public int getPeriodNumber() {
+            return periodNumber;
+        }
+
+        public void setPeriodNumber(int periodNumber) {
+            this.periodNumber = periodNumber;
+        }
+
+        public String getWeekType() {
+            return weekType;
+        }
+
+        public void setWeekType(String weekType) {
+            this.weekType = weekType;
         }
     }
 }

--- a/apps/solver/src/main/java/at/schoolflow/solver/rest/SolverResource.java
+++ b/apps/solver/src/main/java/at/schoolflow/solver/rest/SolverResource.java
@@ -27,6 +27,7 @@ import ai.timefold.solver.core.api.solver.SolutionManager;
 import ai.timefold.solver.core.api.solver.SolverManager;
 import at.schoolflow.solver.domain.Lesson;
 import at.schoolflow.solver.domain.SchoolTimetable;
+import at.schoolflow.solver.domain.SolverTimeslot;
 import at.schoolflow.solver.dto.SolveProgress;
 import at.schoolflow.solver.dto.SolveRequest;
 import at.schoolflow.solver.dto.SolveResult;
@@ -205,14 +206,22 @@ public class SolverResource {
             result.setSoftScore(score.softScore());
             result.setElapsedSeconds(elapsed);
 
-            // Map solved lessons to SolvedLesson DTOs
+            // Map solved lessons to SolvedLesson DTOs.
+            // Denormalize dayOfWeek/periodNumber/weekType out of the
+            // assigned Timeslot so NestJS can persist TimetableLesson rows
+            // directly. SolveResultDto on the NestJS side declares these
+            // required (issue #58).
             List<SolveResult.SolvedLesson> solvedLessons = new ArrayList<>();
             for (Lesson lesson : solution.getLessons()) {
                 if (lesson.getTimeslot() != null && lesson.getRoom() != null) {
+                    SolverTimeslot ts = lesson.getTimeslot();
                     solvedLessons.add(new SolveResult.SolvedLesson(
                             lesson.getId(),
-                            lesson.getTimeslot().getId(),
-                            lesson.getRoom().getId()
+                            ts.getId(),
+                            lesson.getRoom().getId(),
+                            ts.getDayOfWeek(),
+                            ts.getPeriodNumber(),
+                            ts.getWeekType()
                     ));
                 }
             }
@@ -348,7 +357,12 @@ public class SolverResource {
             String json = objectMapper.writeValueAsString(payload);
             String url = callbackUrl + path;
 
+            // Pin HTTP/1.1 — Java's default is HTTP/2 with cleartext upgrade,
+            // which Fastify (NestJS) does not handle cleanly: the connection
+            // is accepted but the response is closed before headers, surfacing
+            // as "header parser received no bytes". Issue #58.
             HttpRequest request = HttpRequest.newBuilder()
+                    .version(HttpClient.Version.HTTP_1_1)
                     .uri(URI.create(url))
                     .header("Content-Type", "application/json")
                     .header("X-Solver-Secret", SOLVER_SHARED_SECRET)

--- a/apps/web/src/hooks/__tests__/useSolverSocket.spec.ts
+++ b/apps/web/src/hooks/__tests__/useSolverSocket.spec.ts
@@ -112,6 +112,34 @@ describe('useSolverSocket — #53 Schicht 1', () => {
     expect(result.current.activeRun?.errorReason).toMatch(/Watchdog-Timeout/);
   });
 
+  it('mirrors errorReason from solve:complete event into activeRun (#58)', () => {
+    const { result } = renderHook(() => useSolverSocket('s1'), { wrapper });
+    act(() => {
+      result.current.trackRun('run-failed');
+    });
+
+    // Watchdog-style FAILED completion event with the real reason.
+    act(() => {
+      const onComplete = handlers.get('solve:complete');
+      onComplete?.({
+        runId: 'run-failed',
+        status: 'FAILED',
+        hardScore: 0,
+        softScore: 0,
+        elapsedSeconds: 300,
+        errorReason: 'Watchdog-Timeout: Solver-Sidecar hat keine Antwort gesendet.',
+      });
+    });
+
+    // Without the #58 fix, errorReason stays null (last polled value)
+    // and the FE red card falls back to "Unbekannter Fehler".
+    expect(result.current.activeRun).toEqual({
+      runId: 'run-failed',
+      status: 'FAILED',
+      errorReason: expect.stringMatching(/Watchdog-Timeout/),
+    });
+  });
+
   it('cancels polling fallback when a WS progress event arrives within the grace window', async () => {
     apiFetchMock.mockResolvedValue({
       ok: true,

--- a/apps/web/src/hooks/useSolverSocket.ts
+++ b/apps/web/src/hooks/useSolverSocket.ts
@@ -49,6 +49,11 @@ export interface SolveProgressEvent {
  * Lightweight completion summary emitted by `/solver` when the run finishes.
  * Matches the payload constructed in SolverCallbackController.handleCompletion
  * (full lesson list is fetched via REST afterwards, not broadcast here).
+ *
+ * Issue #58: errorReason is set when status === 'FAILED' (watchdog timeout,
+ * sidecar 5xx, validator failure). Normal completions pass null. Mirrored
+ * into activeRun so the red FAILED card has the real message at hand
+ * without an extra REST round-trip.
  */
 export interface SolveCompleteEvent {
   runId: string;
@@ -56,6 +61,7 @@ export interface SolveCompleteEvent {
   hardScore: number;
   softScore: number;
   elapsedSeconds: number;
+  errorReason?: string | null;
 }
 
 /**
@@ -238,12 +244,16 @@ export function useSolverSocket(schoolId: string | null | undefined) {
       setLastResult(event);
       setProgress(null);
       // Mirror terminal status into activeRun so the page can render the
-      // FAILED-card from a single source of truth.
+      // FAILED-card from a single source of truth. #58: also mirror
+      // errorReason from the event so the red card shows the real message
+      // (was falling back to "Unbekannter Fehler" because the last poll
+      // had errorReason=null while the run was still SOLVING).
       setActiveRun((prev) =>
         prev && prev.runId === event.runId
           ? {
               ...prev,
               status: event.status as ActiveRunState['status'],
+              errorReason: event.errorReason ?? prev.errorReason,
             }
           : prev,
       );


### PR DESCRIPTION
## Summary
The solver was completing successfully but NestJS never saw the callbacks. Three layered bugs each hid the next:

| # | Bug | Fix |
|---|---|---|
| **B** (root) | Java HttpClient default HTTP/2 cleartext → Fastify closes stream during h2c → \"header parser received no bytes\" | \`HttpRequest.newBuilder().version(Version.HTTP_1_1)\` |
| **C** | \`SolveProgressDto\` + \`SolveResultDto\` had no class-validator decorators → global pipe rejects everything as \"property should not exist\" → 422 | Add \`@IsString\` / \`@IsInt\` / \`@IsArray\` / \`@ValidateNested\` everywhere |
| **C2** | Java \`SolvedLesson\` sent 3 fields, \`SolveResultDto\` + \`handleCompletion\` need 6 (\`dayOfWeek\`, \`periodNumber\`, \`weekType\`) | Extend Java DTO + denormalize from \`Timeslot\` in \`onFinalSolution\` |
| **A** (UX) | Watchdog \`solve:complete\` lost \`errorReason\`; FE \`activeRun.errorReason\` stayed null → red card showed \"Unbekannter Fehler\" | Carry \`errorReason\` through gateway + WS event + FE state |

Closes #58.

## Live verification on seed school
\`\`\`text
POST /timetable/solve              -> 202 QUEUED
Sidecar Local Search 5min          -> Solve completed: 0hard/-7soft
POST /api/.../solver/complete/...  -> 200 (was 422 / "no bytes")
TimetableService.handleCompletion  -> Stored 32 lesson assignments

DB:
  status        = COMPLETED
  hard_score    = 0
  soft_score    = -7
  elapsed_secs  = 300
  error_reason  = NULL
\`\`\`

## Test plan
- [x] \`solve-watchdog.spec\` extended — \`emitComplete\` carries \`errorReason\`
- [x] \`useSolverSocket.spec\` extended — FAILED \`solve:complete\` mirrors \`errorReason\` into \`activeRun\`
- [x] Full API suite: 759 passed, 0 failed
- [x] API + Web typecheck clean
- [x] Live solve reaches DB \`status=COMPLETED\` with 32 lesson rows

## Out of scope
Per-request \`maxSolveSeconds\` still ignored by sidecar — separate ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)