### PR TITLE
test+ux(solver): E2E coverage for solver -> /timetable + recovery card

### DIFF
--- a/apps/web/e2e/fixtures/timetable-run.ts
+++ b/apps/web/e2e/fixtures/timetable-run.ts
@@ -177,13 +177,30 @@ export interface TimetableRunFixture {
 }
 
 /**
- * Seed exactly one TimetableRun (status COMPLETED, isActive true) and exactly
- * one TimetableLesson at (MONDAY, period 1) for class 1A in the seed school.
+ * Options for `seedTimetableRun`.
+ *
+ * Issue #60: when `active: false`, the run is created with isActive=false
+ * so a spec can drive the Aktivieren-button flow on /admin/solver. The
+ * default stays true to preserve the contract every existing spec relies
+ * on.
+ */
+export interface SeedTimetableRunOptions {
+  /** Default true — passes the run straight into "active" state. */
+  active?: boolean;
+}
+
+/**
+ * Seed exactly one TimetableRun (status COMPLETED) and exactly one
+ * TimetableLesson at (MONDAY, period 1) for class 1A in the seed school.
  *
  * Picks the FIRST classSubject for class 1A and the FIRST Teacher + FIRST
  * Room of the school. All lookups are deterministic via createdAt asc.
  */
-export async function seedTimetableRun(schoolId: string): Promise<TimetableRunFixture> {
+export async function seedTimetableRun(
+  schoolId: string,
+  options: SeedTimetableRunOptions = {},
+): Promise<TimetableRunFixture> {
+  const { active = true } = options;
   const prisma = new PrismaClient({
     adapter: new PrismaPg({ connectionString: process.env.DATABASE_URL ?? '' }),
   });
@@ -297,7 +314,7 @@ export async function seedTimetableRun(schoolId: string): Promise<TimetableRunFi
       data: {
         schoolId,
         status: 'COMPLETED',
-        isActive: true,
+        isActive: active,
         maxSolveSeconds: 300,
         abWeekEnabled: false,
         hardScore: 0,

--- a/apps/web/e2e/timetable-generation-flow.spec.ts
+++ b/apps/web/e2e/timetable-generation-flow.spec.ts
@@ -1,0 +1,147 @@
+/**
+ * Issue #60 — End-to-end regression guard for the solver's user-visible output.
+ *
+ * The user reported that the solver said "Generierung abgeschlossen" but the
+ * timetable was nowhere to be found. Diagnosis (live DB inspection):
+ *   - 2 runs in status COMPLETED with 64 persisted timetable_lessons rows
+ *   - All 3 runs had isActive=false → /timetable was empty
+ *
+ * Root cause is twofold:
+ *   1. The /admin/solver page only renders an Aktivieren button via the
+ *      WS-driven `lastResult` state. If the solve:complete event was lost
+ *      (watchdog flipped first, page was mid-reconnect, browser tab not
+ *      focused while the run completed), the button never appears and the
+ *      COMPLETED run is invisible to the user.
+ *   2. There was no automated test covering "solver run produces
+ *      user-visible timetable" — only constraint correctness + DB
+ *      persistence were tested. The activation step fell off the contract.
+ *
+ * Two specs:
+ *   GEN-01 — fast-path:
+ *     Active run with lessons already in DB → /timetable renders cells.
+ *     Catches /timetable rendering regressions independent of activation.
+ *
+ *   GEN-02 — activation-recovery:
+ *     COMPLETED but inactive run in DB → /admin/solver shows the new
+ *     "Letzte Runs" card with Aktivieren button → click it → /timetable
+ *     now renders the lesson. Catches the exact #60 user bug — without
+ *     this, removing the run-history card would silently break recovery.
+ *
+ * Why fixture-based, not real solver: a real solve takes ~5 minutes and is
+ * non-deterministic on lesson placement. The fixture inserts a
+ * deterministic single-lesson COMPLETED run via Prisma (mirrors what
+ * TimetableService.handleCompletion would write). Same shape, no wait,
+ * stable assertions.
+ */
+import { expect, test } from '@playwright/test';
+import { SEED_SCHOOL_UUID } from './fixtures/seed-uuids';
+import { loginAsAdmin } from './helpers/login';
+import {
+  cleanupTimetableRun,
+  seedTimetableRun,
+  type TimetableRunFixture,
+} from './fixtures/timetable-run';
+
+const SCHOOL_ID = process.env.E2E_SCHOOL_ID ?? SEED_SCHOOL_UUID;
+
+test.describe('Issue #60 — solver output reaches /timetable end-to-end', () => {
+  // Mobile projects render the same data; this guard is desktop-only to
+  // avoid mobile-specific selector divergence (DayWeekToggle vs day list,
+  // bottom-sheet selectors). The wire-up under test is identical across
+  // viewports.
+  test.skip(
+    ({ isMobile }) => isMobile,
+    'Solver output rendering is identical across viewports — desktop only.',
+  );
+  // Mutating the seed school's timetable runs from parallel browser
+  // projects races on the same school resources (see #54). Limit to
+  // chromium until the throwaway-school refactor lands.
+  test.skip(
+    ({ browserName }) => browserName !== 'chromium',
+    'flaky on parallel browser projects — see #54 (shared seed-school race).',
+  );
+
+  let fixture: TimetableRunFixture;
+
+  test.afterEach(async () => {
+    if (fixture) {
+      await cleanupTimetableRun(fixture);
+    }
+  });
+
+  test('GEN-01: active completed run renders at least one lesson cell on /timetable', async ({
+    page,
+  }) => {
+    fixture = await seedTimetableRun(SCHOOL_ID);
+    await loginAsAdmin(page);
+    await page.goto('/timetable');
+
+    // Pick the seeded teacher in the perspective selector so the grid
+    // filters down to our seeded lesson. The seed teacher is Maria Mueller
+    // (kc-lehrer), pinned by SEED_TEACHER_KC_LEHRER_UUID — the fixture
+    // exposes the display string as `teacherDisplayName` ("Mueller Maria").
+    const trigger = page.getByRole('combobox').first();
+    await expect(trigger).toBeVisible();
+    await trigger.click();
+    const dropdown = page.getByRole('listbox');
+    await expect(dropdown).toBeVisible();
+    await dropdown
+      .getByRole('option', { name: fixture.teacherDisplayName, exact: true })
+      .click();
+
+    // The cell shows `subjectAbbreviation` as line 1 (TimetableCell.tsx:74).
+    // The fixture seeds exactly one lesson, so this label appears exactly
+    // once. Assertion fails loudly if the active-run query / lesson join /
+    // perspective filter chain breaks anywhere.
+    await expect(
+      page.getByText(fixture.subjectAbbreviation, { exact: true }).first(),
+      'lesson cell must render the seeded subject abbreviation',
+    ).toBeVisible();
+  });
+
+  test('GEN-02: completed-but-inactive run is recoverable from /admin/solver -> Letzte Runs -> Aktivieren -> /timetable shows the lesson', async ({
+    page,
+  }) => {
+    // The fixture's `active: false` mode is the exact shape of the user's
+    // 2026-05-08 incident: handleCompletion wrote 32 rows, status went to
+    // COMPLETED, but the WS event was lost so the user never got to click
+    // Aktivieren. The "Letzte Runs" card on /admin/solver is the recovery
+    // path this test guards.
+    fixture = await seedTimetableRun(SCHOOL_ID, { active: false });
+    await loginAsAdmin(page);
+
+    // Step 1 — /admin/solver shows the inactive run with an Aktivieren button.
+    await page.goto('/admin/solver');
+    const recentRuns = page.getByTestId('recent-runs-card');
+    await expect(
+      recentRuns,
+      'Letzte Runs card must render when at least one run exists in DB',
+    ).toBeVisible();
+    const activateBtn = page.getByTestId(`activate-run-${fixture.runId}`);
+    await expect(
+      activateBtn,
+      'Aktivieren button must be available for COMPLETED+!isActive runs',
+    ).toBeVisible();
+
+    // Step 2 — click Aktivieren. The page navigates to /timetable on success.
+    await activateBtn.click();
+    await page.waitForURL('**/timetable', { timeout: 10_000 });
+
+    // Step 3 — same lesson assertion as GEN-01. If activation didn't flip
+    // isActive=true on the run, the timetable view's `findFirst({ isActive
+    // })` returns null and the grid renders empty.
+    const trigger = page.getByRole('combobox').first();
+    await expect(trigger).toBeVisible();
+    await trigger.click();
+    const dropdown = page.getByRole('listbox');
+    await expect(dropdown).toBeVisible();
+    await dropdown
+      .getByRole('option', { name: fixture.teacherDisplayName, exact: true })
+      .click();
+
+    await expect(
+      page.getByText(fixture.subjectAbbreviation, { exact: true }).first(),
+      'lesson cell must render after Aktivieren-click flipped isActive=true',
+    ).toBeVisible();
+  });
+});

--- a/apps/web/src/hooks/useRecentTimetableRuns.ts
+++ b/apps/web/src/hooks/useRecentTimetableRuns.ts
@@ -1,0 +1,62 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiFetch } from '@/lib/api';
+
+/**
+ * One row from `GET /api/v1/schools/:schoolId/timetable/runs`.
+ * Mirrors `TimetableRunResponseDto` on the API side, only with the
+ * fields /admin/solver renders.
+ */
+export interface RecentRunDto {
+  id: string;
+  status: 'QUEUED' | 'SOLVING' | 'COMPLETED' | 'FAILED' | 'STOPPED';
+  hardScore: number | null;
+  softScore: number | null;
+  elapsedSeconds: number | null;
+  isActive: boolean;
+  errorReason: string | null;
+  createdAt: string;
+}
+
+/**
+ * Issue #60 — REST-driven listing of the last 3 runs per school.
+ *
+ * Sibling to `useActiveTimetableRun` (which returns the single active
+ * run for /timetable). This one returns the whole short list so
+ * /admin/solver can show a "Letzte Runs" card with an Aktivieren button
+ * per row, even when the WebSocket `solve:complete` event was lost
+ * (watchdog flipped first, page mid-reconnect, etc.) and the WS-driven
+ * `lastResult` state never populated.
+ *
+ * Backend caps the list at 3 (D-11), so this is cheap to refetch.
+ */
+export function useRecentTimetableRuns(schoolId: string | null | undefined) {
+  return useQuery({
+    queryKey: ['timetable-runs:recent', schoolId ?? ''],
+    queryFn: async (): Promise<RecentRunDto[]> => {
+      if (!schoolId) return [];
+      const res = await apiFetch(`/api/v1/schools/${schoolId}/timetable/runs`);
+      if (!res.ok) return [];
+      const body: unknown = await res.json();
+      // The API returns an array directly (TimetableController.findRuns).
+      const arr = Array.isArray(body)
+        ? (body as Array<Partial<RecentRunDto>>)
+        : Array.isArray((body as { runs?: unknown[] })?.runs)
+          ? ((body as { runs: Array<Partial<RecentRunDto>> }).runs)
+          : [];
+      return arr.map((r) => ({
+        id: String(r.id),
+        status: (r.status ?? 'QUEUED') as RecentRunDto['status'],
+        hardScore: r.hardScore ?? null,
+        softScore: r.softScore ?? null,
+        elapsedSeconds: r.elapsedSeconds ?? null,
+        isActive: !!r.isActive,
+        errorReason: r.errorReason ?? null,
+        createdAt: String(r.createdAt ?? ''),
+      }));
+    },
+    enabled: !!schoolId,
+    // Refetch when the page regains focus so a run that just completed in
+    // a different tab / device shows up without a manual reload.
+    refetchOnWindowFocus: true,
+  });
+}

--- a/apps/web/src/routes/_authenticated/admin/solver.tsx
+++ b/apps/web/src/routes/_authenticated/admin/solver.tsx
@@ -1,10 +1,12 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { useState } from 'react';
 import { toast } from 'sonner';
+import { useQueryClient } from '@tanstack/react-query';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { useSchoolContext } from '@/stores/school-context-store';
 import { useSolverSocket } from '@/hooks/useSolverSocket';
+import { useRecentTimetableRuns } from '@/hooks/useRecentTimetableRuns';
 import { apiFetch } from '@/lib/api';
 import { GeneratorPageWeightsCard } from '@/components/admin/solver/GeneratorPageWeightsCard';
 
@@ -34,10 +36,16 @@ export const Route = createFileRoute('/_authenticated/admin/solver')({
 function AdminSolverPage() {
   const schoolId = useSchoolContext((s) => s.schoolId);
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const { isConnected, progress, lastResult, activeRun, trackRun } =
     useSolverSocket(schoolId);
+  // #60: REST-driven listing of recent runs. Independent of WS state so the
+  // user can always recover and activate a COMPLETED run, even when the
+  // solve:complete event was lost.
+  const { data: recentRuns = [] } = useRecentTimetableRuns(schoolId);
   const [isStarting, setIsStarting] = useState(false);
   const [isActivating, setIsActivating] = useState(false);
+  const [activatingRunId, setActivatingRunId] = useState<string | null>(null);
 
   const handleGenerate = async () => {
     if (!schoolId) return;
@@ -91,6 +99,32 @@ function AdminSolverPage() {
       });
     } finally {
       setIsActivating(false);
+    }
+  };
+
+  // #60: activate any run from the REST-driven "Letzte Runs" list. The
+  // existing handleActivate is keyed off `lastResult` (WS state) and is
+  // kept for the live happy-path; this one is the resilient fallback.
+  const handleActivateRun = async (runId: string) => {
+    if (!schoolId) return;
+    setActivatingRunId(runId);
+    try {
+      const res = await apiFetch(
+        `/api/v1/schools/${schoolId}/timetable/runs/${runId}/activate`,
+        { method: 'POST' },
+      );
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      toast.success('Stundenplan aktiviert');
+      // Refresh recent-runs so the new isActive=true row is reflected
+      // before navigation.
+      await queryClient.invalidateQueries({ queryKey: ['timetable-runs:recent'] });
+      navigate({ to: '/timetable' });
+    } catch (error) {
+      toast.error('Aktivierung fehlgeschlagen', {
+        description: error instanceof Error ? error.message : 'Unbekannter Fehler',
+      });
+    } finally {
+      setActivatingRunId(null);
     }
   };
 
@@ -237,6 +271,80 @@ function AdminSolverPage() {
           )}
         </CardContent>
       </Card>
+
+      {/* #60: REST-driven "Letzte Runs" card. Resilient to WS event loss —
+          the user can always see and activate any COMPLETED run from the
+          server's actual state, not just the one whose solve:complete
+          event made it through. Hidden when the list is empty (no runs
+          ever started) so the page stays uncluttered for first use. */}
+      {recentRuns.length > 0 && (
+        <Card data-testid="recent-runs-card">
+          <CardHeader>
+            <CardTitle className="text-[20px]">Letzte Runs</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ul className="divide-y divide-border text-sm">
+              {recentRuns.map((run) => {
+                const dt = new Date(run.createdAt);
+                const created = isNaN(dt.getTime())
+                  ? run.createdAt
+                  : dt.toLocaleString('de-AT', {
+                      dateStyle: 'short',
+                      timeStyle: 'short',
+                    });
+                const canActivate =
+                  run.status === 'COMPLETED' && !run.isActive;
+                return (
+                  <li
+                    key={run.id}
+                    className="flex flex-wrap items-center justify-between gap-3 py-3"
+                    data-testid={`recent-run-row-${run.id}`}
+                  >
+                    <div className="flex flex-col gap-1">
+                      <div className="flex items-center gap-2">
+                        <span className="font-mono text-xs">{run.id}</span>
+                        <span
+                          className={
+                            run.isActive
+                              ? 'rounded bg-emerald-100 px-2 py-0.5 text-xs font-semibold text-emerald-800'
+                              : run.status === 'COMPLETED'
+                                ? 'rounded bg-blue-100 px-2 py-0.5 text-xs font-semibold text-blue-800'
+                                : run.status === 'FAILED'
+                                  ? 'rounded bg-red-100 px-2 py-0.5 text-xs font-semibold text-red-800'
+                                  : 'rounded bg-muted px-2 py-0.5 text-xs font-semibold text-muted-foreground'
+                          }
+                        >
+                          {run.isActive ? 'Aktiv' : run.status}
+                        </span>
+                      </div>
+                      <div className="text-xs text-muted-foreground">
+                        {created}
+                        {run.hardScore !== null && run.softScore !== null && (
+                          <>
+                            {' · '}Hard {run.hardScore} / Soft {run.softScore}
+                          </>
+                        )}
+                      </div>
+                    </div>
+                    {canActivate && (
+                      <Button
+                        size="sm"
+                        onClick={() => handleActivateRun(run.id)}
+                        disabled={activatingRunId !== null}
+                        data-testid={`activate-run-${run.id}`}
+                      >
+                        {activatingRunId === run.id
+                          ? 'Wird aktiviert…'
+                          : 'Aktivieren'}
+                      </Button>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          </CardContent>
+        </Card>
+      )}
 
       {/* #53 Schicht 1: failure card — surfaces the watchdog-detected
           timeout (or any other FAILED reason) instead of leaving the user


### PR DESCRIPTION
## Summary
The user reported that the solver said \"Generierung abgeschlossen\" but the timetable was nowhere visible. DB inspection confirmed 2× COMPLETED runs + 64 persisted lessons — all with \`isActive=false\`. Two layered gaps closed:

| Layer | Fix |
|---|---|
| **UX** | New \"Letzte Runs\" card on /admin/solver fed by REST \`GET /timetable/runs\` with Aktivieren button per COMPLETED+!isActive row. Resilient when the WS \`solve:complete\` event is lost (watchdog flipped first, page mid-reconnect, etc.). The existing WS-driven \`lastResult\` path is untouched. |
| **Tests** | Two new Playwright specs in \`timetable-generation-flow.spec.ts\` that reproduce the user incident as a regression guard. |

Closes #60.

## Specs

- **GEN-01 (fast-path)** — seed active COMPLETED run via fixture → navigate to \`/timetable\` → assert lesson cell renders. Catches /timetable rendering regressions independent of activation.
- **GEN-02 (recovery)** — seed COMPLETED+!isActive run → navigate to \`/admin/solver\` → assert new \"Letzte Runs\" card + Aktivieren button → click → \`/timetable\` now renders the lesson. **Reproduces the exact user incident.**

Fixture extension: \`seedTimetableRun(schoolId, { active })\` — defaults to true so all 5 existing call sites keep their contract; pass false to drive the recovery flow.

## Live verification
\`\`\`text
$ npx playwright test e2e/timetable-generation-flow.spec.ts --project=desktop
✓  GEN-01 (2.1s)
✓  GEN-02 (2.3s)
2 passed (6.6s)
\`\`\`

## Test plan
- [x] Web typecheck clean
- [x] Both new specs pass against live stack
- [x] Existing useSolverSocket spec still passes (only pre-existing PeriodsEditor flake on main remains)
- [x] Restricted to chromium + desktop — same race-isolation as #54

## Out of scope
- Throwaway-school refactor for proper E2E parallelism (#54)
- Sidecar ignoring per-request \`maxSolveSeconds\` — separate ticket

🤖 Generated with [Claude Code](https://claude.com/claude-code)