### PR TITLE
test(e2e): un-skip Phase-14 solver-tuning specs — 422 regression resolved

### DIFF
--- a/apps/web/e2e/admin-solver-tuning-audit.spec.ts
+++ b/apps/web/e2e/admin-solver-tuning-audit.spec.ts
@@ -57,13 +57,6 @@ interface AuditEntry {
 }
 
 test.describe('Phase 14 — Solver-Tuning Audit Trail', () => {
-  // Phase 17 deferred: POST /constraint-templates 422 regression — same
-  // root-cause cluster as admin-solver-tuning-restrictions (E2E-SOLVER-04).
-  // See 17-TRIAGE.md row #cluster-14-422-audit-11. Owner: Phase 17.1.
-  test.skip(
-    true,
-    'Phase 17 deferred: POST /constraint-templates 422 regression — see 17-TRIAGE.md row #cluster-14-422-audit-11.',
-  );
 
   test.beforeEach(async ({ page, request }) => {
     await cleanupConstraintTemplatesViaAPI(request);

--- a/apps/web/e2e/admin-solver-tuning-preferences.spec.ts
+++ b/apps/web/e2e/admin-solver-tuning-preferences.spec.ts
@@ -49,13 +49,6 @@ test.describe('Phase 14 — Solver-Tuning Subject Preferences (Tab 4)', () => {
   });
 
   test('E2E-SOLVER-07: SUBJECT_MORNING preference CRUD', async ({ page }) => {
-    // Phase 17 deferred: POST /constraint-templates 422 regression — same
-    // root-cause cluster as admin-solver-tuning-restrictions (E2E-SOLVER-04).
-    // See 17-TRIAGE.md row #cluster-14-422-preferences-07. Owner: Phase 17.1.
-    test.skip(
-      true,
-      'Phase 17 deferred: POST /constraint-templates 422 regression — see 17-TRIAGE.md row #cluster-14-422-preferences-07.',
-    );
     await page.goto('/admin/solver-tuning?tab=preferences');
 
     // Default sub-tab is "Vormittags-Präferenzen". Click the Add CTA — both
@@ -203,13 +196,6 @@ test.describe('Phase 14 — Solver-Tuning Subject Preferences (Tab 4)', () => {
     page,
     request,
   }) => {
-    // Phase 17 deferred: POST /constraint-templates 422 regression — same
-    // root-cause cluster as admin-solver-tuning-restrictions (E2E-SOLVER-04).
-    // See 17-TRIAGE.md row #cluster-14-422-preferences-09. Owner: Phase 17.1.
-    test.skip(
-      true,
-      'Phase 17 deferred: POST /constraint-templates 422 regression — see 17-TRIAGE.md row #cluster-14-422-preferences-09.',
-    );
     // Seed one of each via API.
     await createConstraintTemplateViaAPI(request, 'SUBJECT_MORNING', {
       subjectId: SEED_SUBJECT_M,

--- a/apps/web/e2e/admin-solver-tuning-restrictions.spec.ts
+++ b/apps/web/e2e/admin-solver-tuning-restrictions.spec.ts
@@ -28,22 +28,6 @@ import {
 const SEED_CLASS_1A = 'seed-class-1a';
 
 test.describe('Phase 14 — Solver-Tuning Class Restrictions (Tab 3)', () => {
-  // Phase 17 deferred: POST /constraint-templates 422 — regression suspected
-  // between Phase 14 final (E2E-SOLVER-04 passing — see 14-03-SUMMARY.md) and
-  // PR #1 baseline run 25065085891 (failing). Shared root cause with
-  // admin-solver-tuning-preferences (E2E-SOLVER-07/-09) and
-  // admin-solver-tuning-audit (E2E-SOLVER-11), all of which fail on the same
-  // POST /constraint-templates seed call. Local repro is blocked
-  // (parallel-worktree environment — API on :3000 not running, identical
-  // constraint to Plans F/D wave-merge verification rows in 17-TRIAGE.md).
-  // Backend-fix path requires live stack to inspect 422 problem+json `type`
-  // (cross-reference-missing vs period-out-of-range vs other) — exceeded the
-  // 30-minute D-12 budget. See 17-TRIAGE.md row #cluster-14-422 and
-  // .planning/phases/17-ci-stabilization/deferred-items.md (Phase 17 deferred).
-  test.skip(
-    true,
-    'Phase 17 deferred: POST /constraint-templates 422 regression — shared root cause with admin-solver-tuning-preferences/audit; live-stack repro required (Phase 17.1 owner). See 17-TRIAGE.md row #cluster-14-422.',
-  );
 
   test.beforeEach(async ({ page, request }) => {
     await cleanupConstraintTemplatesViaAPI(request);


### PR DESCRIPTION
## Summary
The 6 admin-solver-tuning specs (E2E-SOLVER-04 through -11) were skip-with-reason'd in Phase 17 because \`POST /constraint-templates\` allegedly returned 422 with no time to root-cause. Live repro on the stabilized seed shows **all 7 tests pass green in 13s** — the original issue is gone, the skips are dead weight.

Closes #24.

## What changed
- 1 describe-level \`test.skip\` removed from \`admin-solver-tuning-restrictions.spec.ts\`
- 2 in-test \`test.skip\` removed from \`admin-solver-tuning-preferences.spec.ts\` (E2E-SOLVER-07 + -09)
- 1 describe-level \`test.skip\` removed from \`admin-solver-tuning-audit.spec.ts\`
- All \`17-TRIAGE.md\` / \"Phase 17 deferred\" comments stripped (GSD-era references; D1 directive disables that workflow)

No code fix needed. The original 422 most likely stemmed from the seed's missing rooms (#51), or solver-pipeline errors (#50/#53/#58) — all closed by recent PRs. The test suite now **trusts the running tests** rather than carrying stale defer-comments.

## Live verification
\`\`\`text
$ npx playwright test admin-solver-tuning-* --project=desktop
✓ E2E-SOLVER-04 (6.1s)  class restriction CRUD happy path
✓ E2E-SOLVER-05 (1.8s)  cross-reference 422 surfaces correct problem+json
✓ E2E-SOLVER-06 (2.4s)  duplicate restrictions show strictest-wins banner
✓ E2E-SOLVER-07 (5.9s)  SUBJECT_MORNING preference CRUD
✓ E2E-SOLVER-08 (3.7s)  SUBJECT_PREFERRED_SLOT CRUD
✓ E2E-SOLVER-09 (2.4s)  sub-tab isolated
✓ E2E-SOLVER-11 (4.7s)  audit-log entries emitted
7 passed (13.0s)
\`\`\`

## Test plan
- [x] Web typecheck clean
- [x] All 7 tests pass on live stack
- [x] No new code or DTOs touched — diff is 100% test-comment cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)