### PR TITLE
fix(e2e): scope solver-tuning cleanup to OWNED types — unblock main CI

### DIFF
--- a/apps/web/e2e/admin-solver-tuning-audit.spec.ts
+++ b/apps/web/e2e/admin-solver-tuning-audit.spec.ts
@@ -38,12 +38,32 @@ import {
   CONSTRAINT_API,
   CONSTRAINT_SCHOOL_ID,
   cleanupConstraintTemplatesViaAPI,
-  cleanupConstraintWeightOverridesViaAPI,
   createConstraintTemplateViaAPI,
 } from './helpers/constraints';
 
 const CONSTRAINT_NAME = 'No same subject doubling';
 const SEED_CLASS_1A = 'seed-class-1a';
+
+/**
+ * Targeted reset for the ONE weight name this spec mutates (#24 follow-up).
+ * Replaces the unscoped bulk-PUT-empty-map cleanup that wiped every
+ * override and raced against admin-solver-tuning-weights.spec.ts on a
+ * parallel browser project. The DELETE endpoint resets a single name to
+ * default without touching siblings.
+ */
+async function resetOwnedWeight(
+  request: import('@playwright/test').APIRequestContext,
+): Promise<void> {
+  const token = await getAdminToken(request);
+  await request
+    .delete(
+      `${CONSTRAINT_API}/schools/${CONSTRAINT_SCHOOL_ID}/constraint-weights/${encodeURIComponent(
+        CONSTRAINT_NAME,
+      )}`,
+      { headers: { Authorization: `Bearer ${token}` } },
+    )
+    .catch(() => undefined);
+}
 
 interface AuditEntry {
   id: string;
@@ -57,16 +77,20 @@ interface AuditEntry {
 }
 
 test.describe('Phase 14 — Solver-Tuning Audit Trail', () => {
+  // #24 follow-up: scope template + weight cleanup to what this spec owns
+  // to avoid wiping in-flight rows of admin-solver-tuning-preferences /
+  // admin-solver-tuning-weights on parallel browser projects.
+  const OWNED_TEMPLATE_TYPES = ['NO_LESSONS_AFTER'] as const;
 
   test.beforeEach(async ({ page, request }) => {
-    await cleanupConstraintTemplatesViaAPI(request);
-    await cleanupConstraintWeightOverridesViaAPI(request);
+    await cleanupConstraintTemplatesViaAPI(request, [...OWNED_TEMPLATE_TYPES]);
+    await resetOwnedWeight(request);
     await loginAsAdmin(page);
   });
 
   test.afterEach(async ({ request }) => {
-    await cleanupConstraintTemplatesViaAPI(request);
-    await cleanupConstraintWeightOverridesViaAPI(request);
+    await cleanupConstraintTemplatesViaAPI(request, [...OWNED_TEMPLATE_TYPES]);
+    await resetOwnedWeight(request);
   });
 
   test('E2E-SOLVER-11: audit-log entries emitted for weight + template mutations', async ({

--- a/apps/web/e2e/admin-solver-tuning-restrictions.spec.ts
+++ b/apps/web/e2e/admin-solver-tuning-restrictions.spec.ts
@@ -20,7 +20,6 @@ import {
   CONSTRAINT_API,
   CONSTRAINT_SCHOOL_ID,
   cleanupConstraintTemplatesViaAPI,
-  cleanupConstraintWeightOverridesViaAPI,
   createConstraintTemplateViaAPI,
 } from './helpers/constraints';
 
@@ -28,16 +27,22 @@ import {
 const SEED_CLASS_1A = 'seed-class-1a';
 
 test.describe('Phase 14 — Solver-Tuning Class Restrictions (Tab 3)', () => {
+  // #24 follow-up: scope cleanup to the template types this spec actually
+  // creates. An unscoped wipe races against admin-solver-tuning-preferences
+  // running on a parallel browser project: it deletes the in-flight
+  // SUBJECT_MORNING row mid-test, surfacing as `toHaveCount(1) → 0` on the
+  // other spec. The helper documents exactly this hazard. Also drop the
+  // weight cleanup entirely — this spec never touches weights, the bulk
+  // PUT-empty-map cleanup races against admin-solver-tuning-weights.spec.ts.
+  const OWNED_TEMPLATE_TYPES = ['NO_LESSONS_AFTER'] as const;
 
   test.beforeEach(async ({ page, request }) => {
-    await cleanupConstraintTemplatesViaAPI(request);
-    await cleanupConstraintWeightOverridesViaAPI(request);
+    await cleanupConstraintTemplatesViaAPI(request, [...OWNED_TEMPLATE_TYPES]);
     await loginAsAdmin(page);
   });
 
   test.afterEach(async ({ request }) => {
-    await cleanupConstraintTemplatesViaAPI(request);
-    await cleanupConstraintWeightOverridesViaAPI(request);
+    await cleanupConstraintTemplatesViaAPI(request, [...OWNED_TEMPLATE_TYPES]);
   });
 
   test('E2E-SOLVER-04: class restriction CRUD happy path', async ({ page }) => {


### PR DESCRIPTION
## Summary
Main has been red since #24 merge — run 25564742559 surfaced **E2E-SOLVER-07 + -08** failures (\`toHaveCount(1) → received 0\`). Local repro on \`--project=desktop --project=desktop-firefox\` confirmed: unscoped cleanup in restrictions + audit wipes in-flight rows from the preferences spec running on a parallel browser project.

The hazard was already documented in \`helpers/constraints.ts\` (\"races against parallel specs on the second worker\"); the preferences spec already scoped to \`OWNED_TEMPLATE_TYPES\`. This applies the same pattern to restrictions + audit.

## What changed
- \`admin-solver-tuning-restrictions.spec.ts\`:
  - \`OWNED_TEMPLATE_TYPES = ['NO_LESSONS_AFTER']\` + scoped cleanup
  - Dropped \`cleanupConstraintWeightOverridesViaAPI\` entirely (this spec never touches weights; bulk PUT-empty-map races against the weights spec)
- \`admin-solver-tuning-audit.spec.ts\`:
  - Same \`OWNED_TEMPLATE_TYPES\` scoping
  - Bulk weight cleanup replaced with targeted \`DELETE /constraint-weights/:name\` for the single constraint name the spec mutates (\`'No same subject doubling'\`)

## Live verification
\`\`\`text
$ npx playwright test admin-solver-tuning --project=desktop --project=desktop-firefox
22 passed, 2 skipped, 0 failed (44.3s)
\`\`\`

## Test plan
- [x] Web typecheck clean
- [x] All solver-tuning specs pass on 2 parallel browser projects
- [x] No new helpers — uses existing scoped cleanup API

🤖 Generated with [Claude Code](https://claude.com/claude-code)