### PR TITLE
fix(solver): respect per-request maxSolveSeconds (#62)

### DIFF
--- a/apps/solver/src/main/java/at/schoolflow/solver/rest/SolverResource.java
+++ b/apps/solver/src/main/java/at/schoolflow/solver/rest/SolverResource.java
@@ -24,6 +24,7 @@ import jakarta.ws.rs.core.Response;
 import ai.timefold.solver.core.api.score.analysis.ScoreAnalysis;
 import ai.timefold.solver.core.api.score.buildin.hardsoft.HardSoftScore;
 import ai.timefold.solver.core.api.solver.SolutionManager;
+import ai.timefold.solver.core.api.solver.SolverConfigOverride;
 import ai.timefold.solver.core.api.solver.SolverManager;
 import at.schoolflow.solver.domain.Lesson;
 import at.schoolflow.solver.domain.SchoolTimetable;
@@ -90,20 +91,32 @@ public class SolverResource {
         String runId = request.getRunId();
         String callbackUrl = request.getCallbackUrl();
         SchoolTimetable problem = request.getProblem();
+        int maxSolveSeconds = request.getMaxSolveSeconds();
 
-        LOG.infof("Starting solve for runId=%s, lessons=%d, timeslots=%d, rooms=%d",
+        LOG.infof("Starting solve for runId=%s, lessons=%d, timeslots=%d, rooms=%d, maxSolveSeconds=%d",
                 runId,
                 problem.getLessons().size(),
                 problem.getTimeslots().size(),
-                problem.getRooms().size());
+                problem.getRooms().size(),
+                maxSolveSeconds);
 
         startTimes.put(runId, Instant.now());
         callbackUrls.put(runId, callbackUrl);
         scoreHistories.put(runId, Collections.synchronizedList(new ArrayList<>()));
 
+        // Issue #62: per-request termination override. Without this, the
+        // SolverManager falls back to quarkus.timefold.solver.termination
+        // .spent-limit (5m) and ignores whatever the caller asked for. We
+        // override ONLY this run's termination so future callers that omit
+        // the field still get the global default.
+        SolverConfigOverride<SchoolTimetable> configOverride =
+                new SolverConfigOverride<SchoolTimetable>()
+                        .withTerminationSpentLimit(Duration.ofSeconds(maxSolveSeconds));
+
         solverManager.solveBuilder()
                 .withProblemId(runId)
                 .withProblem(problem)
+                .withConfigOverride(configOverride)
                 .withBestSolutionConsumer(solution -> onBestSolution(runId, solution))
                 .withFinalBestSolutionConsumer(solution -> onFinalSolution(runId, solution))
                 .run();


### PR DESCRIPTION
Closes #62.

## Summary

- `SolverResource.startSolve` now reads `request.getMaxSolveSeconds()` and passes it to `SolverManager.solveBuilder()` via `SolverConfigOverride.withTerminationSpentLimit(Duration.ofSeconds(...))`. Before this PR the sidecar accepted the field on the DTO but discarded it, leaving every solve at the global `quarkus.timefold.solver.termination.spent-limit=5m`.
- `LOG.infof` for "Starting solve …" now includes `maxSolveSeconds` so the override is visible in container logs.
- No NestJS / DTO changes: the field was already plumbed end-to-end (controller → service → BullMQ → `SolverClientService.submitSolve` → sidecar). The bug was strictly in how the sidecar built the solver job.

## Live-stack validation

Seed-school problem (32 lessons, 35 timeslots, 6 rooms). Posted three `POST /api/v1/schools/:id/timetable/solve` requests after rebuilding the solver image and watched `GET /timetable/runs`:

| budget | elapsed | score |
|--------|---------|-------|
| 300s   | 300s    | 0hard/-7soft (pre-fix baseline) |
| 30s    | 30s     | 0hard/-7soft |
| 60s    | 60s     | 0hard/-7soft |

Identical score reached in 30s as in 5m on this instance, so no quality regression here. The 300s row is from a run started before the fix to anchor the comparison.

## Test plan

- [x] `pnpm --filter @schoolflow/api test --run` — 759 passed / 65 todo / 0 failed
- [x] `docker compose -f docker/docker-compose.yml build solver` — Java 21 compile against Timefold 1.32 clean (verifies `SolverConfigOverride` / `withTerminationSpentLimit` import paths)
- [x] Live-stack smoke: budgets of 30s and 60s both produce `elapsedSeconds` equal to the requested budget
- [x] Default-without-field still works: `SolveRequest.maxSolveSeconds` default is 300 in the Jackson DTO, the NestJS side falls back to 300 in `TimetableService.startSolve`, so a caller that omits the field gets the historical 5m budget unchanged

## Acceptance criteria from #62

- [x] `{ "maxSolveSeconds": 30 }` → `elapsedSeconds ≈ 30`
- [x] Default (no field) still 300s
- [x] All 759 API specs still pass
- [ ] New (or extended) E2E asserting `run.elapsedSeconds <= maxSolveSeconds + 5` — **deferred.** The existing `timetable-generation-flow.spec.ts` is deliberately fixture-based (real solves take 30s+ and are non-deterministic, see header comment) and our CI has no Java/solver pipeline. Live-stack curl evidence above proves the override at runtime; a real-solver E2E would need its own runtime budget design and is worth its own ticket.

## Out of scope

Per the issue: `unimprovedSpentLimit`, UI surfacing of elapsed-vs-budget, and any solver-quality tuning. This PR is the minimal wire-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)