### PR TITLE
docs(e2e): ADMIN-03 honest naming — "navigation-triggered refetch" + known-limitation note (#41)

### DIFF
--- a/apps/web/e2e/admin-dashboard.spec.ts
+++ b/apps/web/e2e/admin-dashboard.spec.ts
@@ -17,27 +17,38 @@
  *   4. ADMIN-02 (deep-link)     — clicking the timegrid row navigates with
  *      `?tab=timegrid` search param (Plan 03 DashboardChecklist.tsx:62-64
  *      route-validator alignment)
- *   5. ADMIN-03 (live invalidation) — after API-creating a teacher, the
- *      dashboard's teachers row re-renders within 5s (no manual reload).
+ *   5. ADMIN-03 (navigation-triggered refetch) — after API-creating a
+ *      teacher, navigating back to /admin within 5s shows the new count.
  *      Validates Plan 16-06 cross-mutation fan-out wiring + the dashboard
- *      query refetch.
+ *      query refetch on route mount.
+ *
+ *      KNOWN LIMITATION — cross-tab live-flip is NOT covered. Permission /
+ *      role-change events from Tab A do not propagate to Tab B without a
+ *      page navigation. Closing this gap would require backend SSE/WebSocket
+ *      push for permission-changes (issue #41, punted as known limitation
+ *      2026-05-11 — extreme edge case for the school admin workflow, and
+ *      the real auth-revocation risk vector is Keycloak token-refresh,
+ *      not the TanStack-Query cache). The test below documents this
+ *      assumption by exercising the navigation-triggered refresh path
+ *      explicitly rather than relying on a passive push.
  *   6. RBAC sidebar             — non-admin (lehrer) has no Dashboard
  *      sidebar entry on any admin route load
  *   7. RBAC direct URL          — non-admin direct-URL hit on /admin sees
  *      the "Aktion nicht erlaubt" admin-gate fallback (Plan 03 Task 2,
  *      T-16-10 mitigation in admin/index.tsx:32-40)
  *
- * NOTE on the live-invalidation test (Test 5):
+ * NOTE on the navigation-triggered refetch test (Test 5):
  *   - Uses the API-level `createTeacherViaAPI` helper to avoid coupling this
  *     spec to teacher-CRUD UI affordances. The dashboard onSuccess wiring
- *     (Plan 16-06 Task 1a `useTeachers.ts`) invalidates `['dashboard-status']`,
- *     so the on-screen `/admin` page should refetch via the standard
- *     TanStack-Query refetch-on-invalidate flow.
+ *     (Plan 16-06 Task 1a `useTeachers.ts`) invalidates `['dashboard-status']`
+ *     on UI-driven mutations only — a pure API mutation does NOT push to
+ *     the active tab. The test bridges this by re-navigating to /admin,
+ *     which remounts the route and re-runs the dashboard query.
  *   - The seed school already has teachers, so the teachers row is `done`
  *     before this test runs. We assert the SECONDARY copy text changes
  *     (e.g. "{n} Lehrpersonen angelegt" → "{n+1} Lehrpersonen angelegt")
- *     within 5s. This is the same `expect(...).toPass({ timeout: 5_000 })`
- *     retry pattern used elsewhere in the suite for live-update assertions.
+ *     within 5s after the re-navigation. This is the same
+ *     `expect(...).toPass({ timeout: 5_000 })` retry pattern used elsewhere.
  *   - The afterEach cleanup deletes any E2E-DASH-LIVE- prefixed teachers via
  *     the standard `cleanupE2ETeachers` helper.
  *
@@ -61,7 +72,7 @@ import { cleanupE2ETeachers, createTeacherViaAPI } from './helpers/teachers';
 const LIVE_PREFIX = 'E2E-DASH-LIVE-';
 
 test.describe('Phase 16 — Admin Dashboard (desktop)', () => {
-  test.describe('admin happy-path + deep-link + live invalidation', () => {
+  test.describe('admin happy-path + deep-link + navigation-triggered refetch', () => {
     test.beforeEach(async ({ page }) => {
       await loginAsAdmin(page);
     });
@@ -158,8 +169,10 @@ test.describe('Phase 16 — Admin Dashboard (desktop)', () => {
       await expect(page).toHaveURL(/tab=timegrid/);
     });
 
-    // ADMIN-03 — live invalidation: API-create teacher → dashboard re-renders
-    test('creating a teacher updates the dashboard within 5s (no manual reload)', async ({
+    // ADMIN-03 — navigation-triggered refetch: API-create teacher, navigate
+    // back to /admin, dashboard reflects new count within 5s.
+    // Cross-tab live-flip without navigation is a known limitation (#41).
+    test('creating a teacher updates the dashboard within 5s after navigating back to /admin', async ({
       page,
       request,
     }) => {


### PR DESCRIPTION
Closes #41 with **Option C + light B** (per discussion 2026-05-11) — punt the cross-tab live-flip as a known limitation, but tighten the spec naming/docs so future readers understand the actual coverage.

## Summary

- Renames Test 5 from `creating a teacher updates the dashboard within 5s (no manual reload)` to `... within 5s after navigating back to /admin`
- Renames the describe block from `admin happy-path + deep-link + live invalidation` to `... + navigation-triggered refetch`
- Header doc explicitly documents the known-limitation (cross-tab live-flip) with rationale and references #41
- No behavioural change — the spec already exercised the navigation-triggered refetch path, the rename just stops promising what isn't covered

## Why not Option A (build SSE/WebSocket push)?

- Admin role-revocation in the school context is a rare operation
- Real auth-revocation risk vector is Keycloak token-refresh, not the TanStack-Query cache
- Large architectural change for an extreme edge case

If cross-tab live-flip becomes business-critical, that's a fresh issue with concrete user-impact data, not a backlog cleanup item.

## Test plan

- [x] `pnpm --filter web exec playwright test admin-dashboard --project=desktop` — 8 passed (15.1s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)