### PR TITLE
feat(subject): add required room type — BSP now goes to Turnsaal (#69)

### DIFF
--- a/apps/api/prisma/migrations/20260511211704_add_subject_required_room_type/migration.sql
+++ b/apps/api/prisma/migrations/20260511211704_add_subject_required_room_type/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "subjects" ADD COLUMN     "required_room_type" "RoomType";

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -541,6 +541,9 @@ model Subject {
   subjectType              SubjectType @map("subject_type")
   lehrverpflichtungsgruppe String?     @map("lehrverpflichtungsgruppe")
   werteinheitenFactor      Float?      @map("werteinheiten_factor")
+  // Issue #69: drives the solver roomTypeRequirement constraint.
+  // Null = no requirement, solver picks freely.
+  requiredRoomType         RoomType?   @map("required_room_type")
   createdAt                DateTime    @default(now()) @map("created_at")
   updatedAt                DateTime    @updatedAt @map("updated_at")
 

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -704,7 +704,11 @@ async function main() {
 
   const subjectBSP = await prisma.subject.upsert({
     where: { schoolId_shortName: { schoolId: school.id, shortName: 'BSP' } },
-    update: {},
+    // Issue #69: backfill requiredRoomType on existing seed installs. The
+    // `update: {}` no-op meant pre-existing seed schools never picked up
+    // the Turnsaal requirement after the schema landed; setting it in the
+    // update branch makes `pnpm dev:up` re-seed self-healing.
+    update: { requiredRoomType: 'TURNSAAL' },
     create: {
       id: 'seed-subject-bsp',
       schoolId: school.id,
@@ -713,6 +717,7 @@ async function main() {
       subjectType: 'PFLICHT',
       lehrverpflichtungsgruppe: 'IVa',
       werteinheitenFactor: 0.857,
+      requiredRoomType: 'TURNSAAL',
     },
   });
 

--- a/apps/api/src/modules/subject/dto/create-subject.dto.ts
+++ b/apps/api/src/modules/subject/dto/create-subject.dto.ts
@@ -8,6 +8,18 @@ enum SubjectTypeDto {
   UNVERBINDLICH = 'UNVERBINDLICH',
 }
 
+// Issue #69: kept in sync with the Prisma `RoomType` enum
+// (apps/api/prisma/schema.prisma). The DTO must list every value the DB
+// enum supports so class-validator accepts admin-form input.
+enum RoomTypeDto {
+  KLASSENZIMMER = 'KLASSENZIMMER',
+  TURNSAAL = 'TURNSAAL',
+  EDV_RAUM = 'EDV_RAUM',
+  WERKRAUM = 'WERKRAUM',
+  LABOR = 'LABOR',
+  MUSIKRAUM = 'MUSIKRAUM',
+}
+
 export class CreateSubjectDto {
   @ApiProperty({ description: 'School ID', example: 'uuid-or-seed-id' })
   // Rule-1 fix (Phase 11 Plan 11-03): accept non-UUID seed IDs (e.g.
@@ -43,4 +55,14 @@ export class CreateSubjectDto {
   @IsOptional()
   @IsNumber()
   werteinheitenFactor?: number;
+
+  @ApiPropertyOptional({
+    enum: RoomTypeDto,
+    description:
+      'Required room type for lessons of this subject. Drives the solver roomTypeRequirement constraint — see issue #69. Null/omitted = no requirement.',
+    example: 'TURNSAAL',
+  })
+  @IsOptional()
+  @IsEnum(RoomTypeDto)
+  requiredRoomType?: RoomTypeDto;
 }

--- a/apps/api/src/modules/subject/dto/subject-response.dto.ts
+++ b/apps/api/src/modules/subject/dto/subject-response.dto.ts
@@ -22,6 +22,12 @@ export class SubjectResponseDto {
   @ApiPropertyOptional({ description: 'Werteinheiten factor', example: 1.0 })
   werteinheitenFactor?: number | null;
 
+  @ApiPropertyOptional({
+    description: 'Required room type — drives the solver (#69)',
+    example: 'TURNSAAL',
+  })
+  requiredRoomType?: string | null;
+
   @ApiProperty({ description: 'Number of classes this subject is assigned to' })
   classSubjectsCount!: number;
 

--- a/apps/api/src/modules/subject/dto/update-subject.dto.ts
+++ b/apps/api/src/modules/subject/dto/update-subject.dto.ts
@@ -1,6 +1,30 @@
-import { OmitType, PartialType } from '@nestjs/swagger';
+import { ApiPropertyOptional, OmitType, PartialType } from '@nestjs/swagger';
+import { IsEnum, IsOptional, ValidateIf } from 'class-validator';
 import { CreateSubjectDto } from './create-subject.dto';
 
+// Issue #69: kept in sync with the Prisma `RoomType` enum.
+enum RoomTypeDto {
+  KLASSENZIMMER = 'KLASSENZIMMER',
+  TURNSAAL = 'TURNSAAL',
+  EDV_RAUM = 'EDV_RAUM',
+  WERKRAUM = 'WERKRAUM',
+  LABOR = 'LABOR',
+  MUSIKRAUM = 'MUSIKRAUM',
+}
+
 export class UpdateSubjectDto extends PartialType(
-  OmitType(CreateSubjectDto, ['schoolId'] as const),
-) {}
+  OmitType(CreateSubjectDto, ['schoolId', 'requiredRoomType'] as const),
+) {
+  // Re-declare requiredRoomType so clients can pass explicit null to clear
+  // the assignment. PartialType alone makes the field optional but
+  // class-validator @IsEnum rejects null without ValidateIf.
+  @ApiPropertyOptional({
+    enum: RoomTypeDto,
+    nullable: true,
+    description: 'Required room type. Pass null to clear. Issue #69.',
+  })
+  @IsOptional()
+  @ValidateIf((_, v) => v !== null)
+  @IsEnum(RoomTypeDto)
+  requiredRoomType?: RoomTypeDto | null;
+}

--- a/apps/api/src/modules/subject/subject.service.ts
+++ b/apps/api/src/modules/subject/subject.service.ts
@@ -32,6 +32,9 @@ export class SubjectService {
         subjectType: dto.subjectType as any,
         lehrverpflichtungsgruppe: dto.lehrverpflichtungsgruppe,
         werteinheitenFactor: dto.werteinheitenFactor,
+        // Issue #69: optional. null/undefined → no requirement; the solver
+        // roomTypeRequirement constraint only fires when this is non-null.
+        requiredRoomType: dto.requiredRoomType as any,
       },
       include: {
         _count: { select: { classSubjects: true } },
@@ -107,6 +110,10 @@ export class SubjectService {
         subjectType: dto.subjectType as any,
         lehrverpflichtungsgruppe: dto.lehrverpflichtungsgruppe,
         werteinheitenFactor: dto.werteinheitenFactor,
+        // Issue #69: clients send null to clear the requirement, omit to
+        // leave it unchanged. Prisma treats undefined as "don't touch",
+        // null as "SET NULL".
+        requiredRoomType: dto.requiredRoomType as any,
       },
       include: {
         _count: { select: { classSubjects: true } },

--- a/apps/api/src/modules/timetable/solver-input.service.ts
+++ b/apps/api/src/modules/timetable/solver-input.service.ts
@@ -276,7 +276,7 @@ export class SolverInputService {
       weeklyHours: number;
       preferDoublePeriod: boolean;
       groupId: string | null;
-      subject: { id: string; name: string; subjectType: string; lehrverpflichtungsgruppe: string | null; werteinheitenFactor: number | null };
+      subject: { id: string; name: string; subjectType: string; lehrverpflichtungsgruppe: string | null; werteinheitenFactor: number | null; requiredRoomType: string | null };
       schoolClass: { id: string; name: string; homeRoomId: string | null };
     }>,
     teacherMap: Map<string, { id: string; person: { firstName: string; lastName: string } }>,
@@ -286,9 +286,10 @@ export class SolverInputService {
     for (const cs of classSubjects) {
       if (cs.weeklyHours <= 0) continue;
 
-      // Look up subject's requiredRoomType from subject model
-      // Note: Subject doesn't have requiredRoomType in schema yet -- use null for now
-      const requiredRoomType: string | null = null;
+      // Issue #69: pass the subject's requiredRoomType through to the Java
+      // roomTypeRequirement constraint. null = no requirement, solver
+      // picks freely (the pre-#69 default for every lesson).
+      const requiredRoomType: string | null = cs.subject.requiredRoomType;
 
       // Resolve teacher name
       // Note: ClassSubject doesn't have a direct teacherId in the schema

--- a/apps/web/e2e/admin-subjects-required-room-type.spec.ts
+++ b/apps/web/e2e/admin-subjects-required-room-type.spec.ts
@@ -1,0 +1,222 @@
+/**
+ * Issue #69 — Subject Pflicht-Raumtyp assignment.
+ *
+ * Covers the UI affordance shipped in the requiredRoomType PR:
+ *   - E2E-SUB-RRT-CREATE: SubjectFormDialog create-mode with
+ *                          Pflicht-Raumtyp = Turnsaal → POST /subjects
+ *                          carries requiredRoomType=TURNSAAL.
+ *   - E2E-SUB-RRT-EDIT-ASSIGN: open edit dialog on a subject without
+ *                              requiredRoomType, pick Turnsaal, save →
+ *                              PUT body carries TURNSAAL, value persists.
+ *   - E2E-SUB-RRT-EDIT-CLEAR:  open edit dialog on a subject WITH
+ *                              requiredRoomType=TURNSAAL, switch to
+ *                              "Kein Pflichtraum", save → PUT body
+ *                              requiredRoomType=null.
+ *
+ * DOM contract:
+ *   - SubjectFormDialog.tsx — `<SelectTrigger id="subject-required-room-type"
+ *     aria-label="Pflicht-Raumtyp">` (data-testid same).
+ *   - Sentinel `__no_required_room__` clears the assignment (Radix Select
+ *     does not accept empty string as a value).
+ *
+ * Scoped to desktop + chromium-only per the parallel-cleanup race family
+ * — same pattern as admin-classes-home-room.spec.ts (#67) and
+ * project_e2e_parallel_cleanup_race_family.md.
+ */
+import { expect, test } from '@playwright/test';
+import { getAdminToken, loginAsAdmin } from './helpers/login';
+import { cleanupE2ESubjects, createSubjectViaAPI } from './helpers/subjects';
+import { SEED_SCHOOL_UUID } from './fixtures/seed-uuids';
+
+const PREFIX = 'E2E-RRT-';
+const API = 'http://localhost:3000/api/v1';
+
+async function fetchSubject(
+  request: import('@playwright/test').APIRequestContext,
+  id: string,
+): Promise<{ id: string; requiredRoomType: string | null }> {
+  const token = await getAdminToken(request);
+  const res = await request.get(`${API}/subjects/${id}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  expect(res.ok(), `GET /subjects/${id}`).toBeTruthy();
+  return (await res.json()) as { id: string; requiredRoomType: string | null };
+}
+
+async function setSubjectRequiredRoomType(
+  request: import('@playwright/test').APIRequestContext,
+  id: string,
+  value: string | null,
+): Promise<void> {
+  const token = await getAdminToken(request);
+  const res = await request.put(`${API}/subjects/${id}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    data: { requiredRoomType: value },
+  });
+  expect(res.ok(), `PUT /subjects/${id} requiredRoomType=${value}`).toBeTruthy();
+}
+
+test.describe('Issue #69 — Subject Pflicht-Raumtyp (desktop)', () => {
+  // Mobile renders the same SubjectFormDialog with the same Select;
+  // the contract is identical, no viewport-specific affordance to test.
+  test.skip(
+    ({ isMobile }) => isMobile,
+    'Pflicht-Raumtyp form contract is identical across viewports — desktop only.',
+  );
+  // Mutating subjects on the seed school from parallel browser projects
+  // shares school resources; the chromium-only pattern is the established
+  // mitigation for this surface (same as admin-classes-home-room.spec.ts).
+  test.skip(
+    ({ browserName }) => browserName !== 'chromium',
+    'flaky on parallel browser projects — shared seed-school race.',
+  );
+
+  test.beforeEach(async ({ page }) => {
+    await loginAsAdmin(page);
+  });
+
+  test.afterEach(async ({ request }) => {
+    await cleanupE2ESubjects(request, PREFIX);
+  });
+
+  test('E2E-SUB-RRT-CREATE: dialog with Pflicht-Raumtyp=Turnsaal → POST carries TURNSAAL', async ({
+    page,
+    request,
+  }) => {
+    const ts = Date.now().toString().slice(-6);
+    const subjectName = `${PREFIX}Sport-${ts}`;
+    // Keep Kürzel short (max 8). Combine a stable prefix with the last
+    // 4 timestamp digits — well under the limit.
+    const shortName = `T${ts.slice(-4)}`;
+
+    await page.goto('/admin/subjects');
+
+    // Open create dialog — empty-state and populated-state both expose
+    // a "Fach anlegen" CTA.
+    await page.getByRole('button', { name: 'Fach anlegen' }).first().click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(
+      dialog.getByRole('heading', { name: 'Fach anlegen' }),
+    ).toBeVisible();
+
+    await dialog.getByTestId('subject-name-input').fill(subjectName);
+    await dialog.getByTestId('subject-shortname-input').fill(shortName);
+
+    // Pflicht-Raumtyp = Turnsaal.
+    await dialog.getByRole('combobox', { name: 'Pflicht-Raumtyp' }).click();
+    await page.getByRole('option', { name: 'Turnsaal' }).click();
+
+    // Submit.
+    const postPromise = page.waitForResponse(
+      (res) => res.url().endsWith('/subjects') && res.request().method() === 'POST',
+      { timeout: 15_000 },
+    );
+    await dialog.getByTestId('subject-submit').click();
+    const postRes = await postPromise;
+    expect(postRes.ok(), 'POST must succeed').toBeTruthy();
+    const reqBody = JSON.parse(postRes.request().postData() ?? '{}');
+    expect(
+      reqBody.requiredRoomType,
+      'POST body carries requiredRoomType=TURNSAAL',
+    ).toBe('TURNSAAL');
+
+    // DB persistence verification.
+    const body = (await postRes.json()) as { id: string };
+    const persisted = await fetchSubject(request, body.id);
+    expect(persisted.requiredRoomType).toBe('TURNSAAL');
+  });
+
+  test('E2E-SUB-RRT-EDIT-ASSIGN: pick Turnsaal → save → PUT body + DB persist', async ({
+    page,
+    request,
+  }) => {
+    const ts = Date.now().toString().slice(-6);
+    const subject = await createSubjectViaAPI(request, {
+      name: `${PREFIX}A-${ts}`,
+      shortName: `A${ts.slice(-4)}`,
+    });
+
+    // Start state — no requiredRoomType.
+    const before = await fetchSubject(request, subject.id);
+    expect(before.requiredRoomType).toBeNull();
+
+    await page.goto('/admin/subjects');
+
+    // SubjectList rows carry data-testid="subject-row-${shortName}"
+    // (SubjectList.tsx Pattern S4) on both desktop <tr> and mobile card;
+    // clicking the row opens the edit dialog (onRowClick=onEdit).
+    await page.getByTestId(`subject-row-${subject.shortName}`).first().click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(
+      dialog.getByRole('heading', { name: 'Fach bearbeiten' }),
+    ).toBeVisible();
+
+    await dialog.getByRole('combobox', { name: 'Pflicht-Raumtyp' }).click();
+    await page.getByRole('option', { name: 'Turnsaal' }).click();
+
+    const putPromise = page.waitForResponse(
+      (res) =>
+        res.url().endsWith(`/subjects/${subject.id}`) &&
+        res.request().method() === 'PUT',
+      { timeout: 15_000 },
+    );
+    await dialog.getByTestId('subject-submit').click();
+    const putRes = await putPromise;
+    expect(putRes.ok(), 'PUT must succeed').toBeTruthy();
+    const reqBody = JSON.parse(putRes.request().postData() ?? '{}');
+    expect(reqBody.requiredRoomType, 'PUT body sets TURNSAAL').toBe('TURNSAAL');
+
+    const after = await fetchSubject(request, subject.id);
+    expect(after.requiredRoomType).toBe('TURNSAAL');
+  });
+
+  test('E2E-SUB-RRT-EDIT-CLEAR: switch from Turnsaal → Kein Pflichtraum → PUT body null', async ({
+    page,
+    request,
+  }) => {
+    const ts = Date.now().toString().slice(-6);
+    const subject = await createSubjectViaAPI(request, {
+      name: `${PREFIX}C-${ts}`,
+      shortName: `C${ts.slice(-4)}`,
+    });
+
+    // Seed-state: pre-set requiredRoomType so the clear flow has something
+    // to remove. The createSubjectViaAPI helper doesn't accept the field
+    // today; PATCH afterwards rather than expanding the helper signature.
+    await setSubjectRequiredRoomType(request, subject.id, 'TURNSAAL');
+    const before = await fetchSubject(request, subject.id);
+    expect(before.requiredRoomType).toBe('TURNSAAL');
+
+    await page.goto('/admin/subjects');
+
+    await page.getByTestId(`subject-row-${subject.shortName}`).first().click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(
+      dialog.getByRole('heading', { name: 'Fach bearbeiten' }),
+    ).toBeVisible();
+
+    await dialog.getByRole('combobox', { name: 'Pflicht-Raumtyp' }).click();
+    await page.getByRole('option', { name: 'Kein Pflichtraum' }).click();
+
+    const putPromise = page.waitForResponse(
+      (res) =>
+        res.url().endsWith(`/subjects/${subject.id}`) &&
+        res.request().method() === 'PUT',
+      { timeout: 15_000 },
+    );
+    await dialog.getByTestId('subject-submit').click();
+    const putRes = await putPromise;
+    expect(putRes.ok(), 'PUT must succeed').toBeTruthy();
+    const reqBody = JSON.parse(putRes.request().postData() ?? '{}');
+    expect(reqBody.requiredRoomType, 'PUT body sets null').toBeNull();
+
+    const after = await fetchSubject(request, subject.id);
+    expect(after.requiredRoomType).toBeNull();
+  });
+});

--- a/apps/web/src/components/admin/subject/SubjectFormDialog.tsx
+++ b/apps/web/src/components/admin/subject/SubjectFormDialog.tsx
@@ -11,11 +11,30 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
   useCreateSubject,
   useUpdateSubject,
   SubjectApiError,
   type SubjectDto,
 } from '@/hooks/useSubjects';
+
+// Issue #69: kept in sync with the Prisma RoomType enum
+// (apps/api/prisma/schema.prisma). German labels per UI-SPEC.
+const ROOM_TYPE_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: 'KLASSENZIMMER', label: 'Klassenzimmer' },
+  { value: 'TURNSAAL', label: 'Turnsaal' },
+  { value: 'EDV_RAUM', label: 'EDV-Raum' },
+  { value: 'WERKRAUM', label: 'Werkraum' },
+  { value: 'LABOR', label: 'Labor' },
+  { value: 'MUSIKRAUM', label: 'Musikraum' },
+];
+const NO_REQUIRED_ROOM = '__no_required_room__';
 
 /**
  * SubjectFormDialog (Phase 11 Plan 11-02 SUBJECT-02).
@@ -48,6 +67,7 @@ export function SubjectFormDialog({ open, onOpenChange, schoolId, subject }: Pro
 
   const [name, setName] = useState('');
   const [shortName, setShortName] = useState('');
+  const [requiredRoomType, setRequiredRoomType] = useState<string | null>(null);
   const [touched, setTouched] = useState(false);
   const [shortNameServerError, setShortNameServerError] = useState<string | null>(
     null,
@@ -58,9 +78,16 @@ export function SubjectFormDialog({ open, onOpenChange, schoolId, subject }: Pro
     if (!open) return;
     setName(subject?.name ?? '');
     setShortName(subject?.shortName ?? '');
+    setRequiredRoomType(subject?.requiredRoomType ?? null);
     setTouched(false);
     setShortNameServerError(null);
-  }, [open, subject?.id, subject?.name, subject?.shortName]);
+  }, [
+    open,
+    subject?.id,
+    subject?.name,
+    subject?.shortName,
+    subject?.requiredRoomType,
+  ]);
 
   const errors = {
     name:
@@ -106,9 +133,19 @@ export function SubjectFormDialog({ open, onOpenChange, schoolId, subject }: Pro
 
     try {
       if (isEdit) {
-        await updateMutation.mutateAsync(basePayload);
+        // Update accepts explicit null to clear the requirement.
+        await updateMutation.mutateAsync({
+          ...basePayload,
+          requiredRoomType: requiredRoomType,
+        });
       } else {
-        await createMutation.mutateAsync({ ...basePayload, schoolId });
+        // Create omits the field when "Kein Pflichtraum" is selected;
+        // the API DTO is @IsOptional() so undefined is fine.
+        await createMutation.mutateAsync({
+          ...basePayload,
+          schoolId,
+          ...(requiredRoomType ? { requiredRoomType } : {}),
+        });
       }
       onOpenChange(false);
     } catch (err) {
@@ -187,6 +224,39 @@ export function SubjectFormDialog({ open, onOpenChange, schoolId, subject }: Pro
                 {errors.shortName}
               </p>
             )}
+          </div>
+
+          <div>
+            <Label htmlFor="subject-required-room-type">
+              Pflicht-Raumtyp (optional)
+            </Label>
+            <Select
+              value={requiredRoomType ?? NO_REQUIRED_ROOM}
+              onValueChange={(v) =>
+                setRequiredRoomType(v === NO_REQUIRED_ROOM ? null : v)
+              }
+            >
+              <SelectTrigger
+                id="subject-required-room-type"
+                aria-label="Pflicht-Raumtyp"
+                data-testid="subject-required-room-type-select"
+              >
+                <SelectValue placeholder="Kein Pflichtraum" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={NO_REQUIRED_ROOM}>
+                  Kein Pflichtraum
+                </SelectItem>
+                {ROOM_TYPE_OPTIONS.map((opt) => (
+                  <SelectItem key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-muted-foreground mt-1">
+              Der Solver wählt für dieses Fach nur passende Räume (#69).
+            </p>
           </div>
 
           <div

--- a/apps/web/src/hooks/useSubjects.ts
+++ b/apps/web/src/hooks/useSubjects.ts
@@ -25,6 +25,7 @@ export interface SubjectDto {
   subjectType: string;
   lehrverpflichtungsgruppe?: string | null;
   werteinheitenFactor?: number | null;
+  requiredRoomType?: string | null;
   classSubjects?: Array<{
     id: string;
     classId: string;
@@ -136,6 +137,7 @@ export interface CreateSubjectPayload {
   subjectType?: string;
   lehrverpflichtungsgruppe?: string;
   werteinheitenFactor?: number;
+  requiredRoomType?: string;
 }
 
 export function useCreateSubject(schoolId: string) {

--- a/packages/shared/src/schemas/subject.schema.ts
+++ b/packages/shared/src/schemas/subject.schema.ts
@@ -21,6 +21,19 @@ export const SubjectTypeEnum = z.enum([
 ]);
 export type SubjectTypeInput = z.infer<typeof SubjectTypeEnum>;
 
+// Issue #69: kept in sync with the Prisma `RoomType` enum
+// (apps/api/prisma/schema.prisma). Drives the solver roomTypeRequirement
+// constraint when set on a Subject.
+export const RoomTypeEnum = z.enum([
+  'KLASSENZIMMER',
+  'TURNSAAL',
+  'EDV_RAUM',
+  'WERKRAUM',
+  'LABOR',
+  'MUSIKRAUM',
+]);
+export type RoomTypeInput = z.infer<typeof RoomTypeEnum>;
+
 /**
  * SubjectCreateSchema — used by SubjectFormDialog (create mode) + FE→BE POST.
  *
@@ -39,12 +52,17 @@ export const SubjectCreateSchema = z.object({
   subjectType: SubjectTypeEnum.default('PFLICHT'),
   lehrverpflichtungsgruppe: z.string().optional(),
   werteinheitenFactor: z.number().optional(),
+  // Issue #69: optional, null = no requirement (solver picks freely).
+  requiredRoomType: RoomTypeEnum.optional(),
 });
 
 /**
  * SubjectUpdateSchema — all fields optional (PATCH-style partial update).
+ * requiredRoomType also accepts explicit null to clear the assignment.
  */
-export const SubjectUpdateSchema = SubjectCreateSchema.partial();
+export const SubjectUpdateSchema = SubjectCreateSchema.partial().extend({
+  requiredRoomType: RoomTypeEnum.nullable().optional(),
+});
 
 export type SubjectCreateInput = z.infer<typeof SubjectCreateSchema>;
 export type SubjectUpdateInput = z.infer<typeof SubjectUpdateSchema>;


### PR DESCRIPTION
Closes #69.

## Summary

Second occurrence of the exact same pattern as #67. The Java solver shipped a \`roomTypeRequirement\` constraint and \`Lesson.requiredRoomType\` field months ago, but the data never reached it: \`solver-input.service.ts:289-291\` was hardcoded \`requiredRoomType = null\` and the underlying \`Subject\` table didn't have a \`required_room_type\` column. Result: BSP (Bewegung und Sport) and any other subject with a room requirement landed wherever the solver picked first.

This PR fills in the missing layers (DB + DTO + Service + Solver-Input + Frontend + E2E) and removes the hardcoded null.

## Layers touched

| Layer | Status before | Change |
| ----- | ------------- | ------ |
| Java \`TimetableConstraintProvider.roomTypeRequirement\` | ✓ existed | — |
| Java \`Lesson.requiredRoomType\` | ✓ existed | — |
| Prisma \`Subject.requiredRoomType\` | ✗ | nullable \`RoomType?\` enum field |
| Migration | — | \`20260511211704_add_subject_required_room_type\` (single ALTER TABLE) |
| Subject DTOs (\`create\`, \`update\`, \`response\`) | ✗ | optional \`requiredRoomType\`, nullable on update with \`ValidateIf(v !== null)\` |
| \`SubjectService\` create/update | ✗ | persists the field; undefined = no-op, null = SET NULL |
| \`solver-input.service.ts:289\` | hardcoded \`null\` | passes \`cs.subject.requiredRoomType\` |
| Shared Zod schemas | ✗ | \`RoomTypeEnum\` + optional/nullable extensions of Create/Update |
| Frontend \`SubjectFormDialog\` | ✗ | Pflicht-Raumtyp Select with "Kein Pflichtraum" clear-option |
| Seed defaults | none | BSP → TURNSAAL (both create + update branches for self-healing) |
| E2E spec | — | \`admin-subjects-required-room-type.spec.ts\` (CREATE / EDIT-ASSIGN / EDIT-CLEAR) |

## Live-stack validation

Seed school, 2 classes, \`maxSolveSeconds=30\`:

| Before (only #67) | After (#67 + #69) |
| --- | --- |
| BSP 1A → Raum 1A ❌ | BSP 1A → Turnsaal ✓ |
| BSP 1B → Raum 2A ❌ | BSP 1B → Turnsaal ✓ |
| D/E/M → home rooms | D/E/M → home rooms (unchanged) |

The two solver constraints (#67 \`homeRoomPreference\` + #69 \`roomTypeRequirement\`) stack cleanly — BSP escapes the home-room preference because the room-type requirement takes precedence (\`roomTypeRequirement\` is the harder constraint, \`homeRoomPreference\` is the soft fallback for subjects without a specific room need).

## Specs

- [x] \`pnpm --filter @schoolflow/api test --run\` — 759 passed / 65 todo
- [x] \`pnpm --filter @schoolflow/shared test --run\` — 193 passed
- [x] \`pnpm --filter web exec playwright test admin-subjects-required-room-type --project=desktop\` — 3 passed (CREATE + EDIT-ASSIGN + EDIT-CLEAR)
- [x] Same spec on \`--project=desktop-firefox\` — 3 skipped (race-family scope per project_e2e_parallel_cleanup_race_family.md)

## Convention compliance

Per the CLAUDE.md "Bug-Fix Regression-Schutz via E2E — hard rule" introduced in #68: this bug-fix ships with the E2E that would have caught the original symptom. \`admin-subjects-required-room-type.spec.ts:EDIT-ASSIGN\` would have failed on main without the schema column + solver-input plumbing — the regression test exists before the fix would silently be reverted by a future "this field isn't used anywhere" cleanup.

## Pattern of record

This is now the **second** identical incident of the "Java-side ready, schema/API/UI missing" pattern:
- #67 — \`SchoolClass.homeRoomId\` (Heimraum)
- #69 — \`Subject.requiredRoomType\` (Pflicht-Raumtyp)

There may be more — \`Lesson.requiredEquipment\` exists in the Java DTO but is hardcoded \`[]\` in solver-input.service.ts:314. Not in scope here, but worth a triage check before more fields surface as user-reported symptoms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)