### PR TITLE
fix(solver): wire ClassSubject.teacherId — restores teacherConflict + teacherAvailability HARD constraints (#71)

### DIFF
--- a/apps/api/prisma/migrations/20260511214924_add_class_subject_teacher_id/migration.sql
+++ b/apps/api/prisma/migrations/20260511214924_add_class_subject_teacher_id/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "class_subjects" ADD COLUMN     "teacher_id" TEXT;
+
+-- AddForeignKey
+ALTER TABLE "class_subjects" ADD CONSTRAINT "class_subjects_teacher_id_fkey" FOREIGN KEY ("teacher_id") REFERENCES "teachers"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -364,6 +364,7 @@ model Teacher {
   availabilityRules      AvailabilityRule[]
   reductions             TeachingReduction[]
   klassenvorstandClasses SchoolClass[]       @relation("Klassenvorstand")
+  classSubjectAssignments ClassSubject[]     @relation("ClassSubjectTeacher")
 
   // Phase 6 relations
   absences TeacherAbsence[]
@@ -562,6 +563,13 @@ model ClassSubject {
   schoolClass        SchoolClass @relation(fields: [classId], references: [id], onDelete: Cascade)
   subjectId          String      @map("subject_id")
   subject            Subject     @relation(fields: [subjectId], references: [id], onDelete: Cascade)
+  // Issue #71: the teacher actually assigned to teach this subject in this
+  // class. TeacherSubject is a qualifications table (which teacher CAN
+  // teach the subject); this is the assignment (which teacher DOES). Null
+  // means unassigned — the solver falls back to its pre-#71 behavior
+  // (lesson.teacherId='' which broke teacherConflict + teacherAvailability).
+  teacherId          String?     @map("teacher_id")
+  teacher            Teacher?    @relation("ClassSubjectTeacher", fields: [teacherId], references: [id], onDelete: SetNull)
   groupId            String?     @map("group_id")
   weeklyHours        Int         @map("weekly_hours")
   isCustomized       Boolean     @default(false) @map("is_customized")

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -823,12 +823,16 @@ async function main() {
 
   // --- ClassSubjects (AHS_UNTER year 1 Stundentafel applied to both classes) ---
 
-  // Core AHS_UNTER year 1 subjects from Stundentafel (4 seeded subjects)
+  // Core AHS_UNTER year 1 subjects from Stundentafel (4 seeded subjects).
+  // Issue #71: each entry carries a teacherId so the solver's
+  // teacherConflict + teacherAvailability hard constraints have real
+  // teacher keys to join on. Mapping mirrors the qualifications seeded
+  // above: teacher1 owns D + E, teacher2 owns M, teacher3 owns BSP.
   const classSubjectEntries = [
-    { subjectId: subjectDeutsch.id, weeklyHours: 4 },
-    { subjectId: subjectMathematik.id, weeklyHours: 4 },
-    { subjectId: subjectEnglisch.id, weeklyHours: 4 },
-    { subjectId: subjectBSP.id, weeklyHours: 4 },
+    { subjectId: subjectDeutsch.id, weeklyHours: 4, teacherId: teacher1.id },
+    { subjectId: subjectMathematik.id, weeklyHours: 4, teacherId: teacher2.id },
+    { subjectId: subjectEnglisch.id, weeklyHours: 4, teacherId: teacher1.id },
+    { subjectId: subjectBSP.id, weeklyHours: 4, teacherId: teacher3.id },
   ];
 
   for (const cls of [class1A, class1B]) {
@@ -844,7 +848,16 @@ async function main() {
             subjectId: entry.subjectId,
             weeklyHours: entry.weeklyHours,
             isCustomized: false,
+            teacherId: entry.teacherId,
           },
+        });
+      } else if (!existing.teacherId) {
+        // Backfill: rows that pre-date #71 have teacherId=null. Only
+        // patch when the assignment is missing — don't stomp on edits
+        // an admin made via the UI.
+        await prisma.classSubject.update({
+          where: { id: existing.id },
+          data: { teacherId: entry.teacherId },
         });
       }
     }

--- a/apps/api/src/modules/class/class-subject.service.ts
+++ b/apps/api/src/modules/class/class-subject.service.ts
@@ -29,7 +29,10 @@ export class ClassSubjectService {
   async findByClass(classId: string) {
     return this.prisma.classSubject.findMany({
       where: { classId },
-      include: { subject: true },
+      // Issue #71: include the assigned teacher so the Stundentafel UI can
+      // render the Lehrer column and so the solver-input service can read
+      // the relation without a second query.
+      include: { subject: true, teacher: { include: { person: true } } },
       orderBy: { subject: { shortName: 'asc' } },
     });
   }
@@ -116,6 +119,10 @@ export class ClassSubjectService {
               isCustomized,
               preferDoublePeriod:
                 row.preferDoublePeriod ?? prior.preferDoublePeriod,
+              // Issue #71: undefined = leave the assignment unchanged;
+              // null = clear it; uuid = set it. Prisma treats undefined as
+              // a no-op here, so the explicit-presence check is implicit.
+              teacherId: row.teacherId,
             },
           });
         } else {
@@ -126,6 +133,10 @@ export class ClassSubjectService {
               weeklyHours: row.weeklyHours,
               isCustomized,
               preferDoublePeriod: row.preferDoublePeriod ?? false,
+              // Issue #71: only set teacherId on create when a real value
+              // was provided. null on a never-existed row is the same as
+              // omitting it (default DB value is NULL).
+              ...(row.teacherId ? { teacherId: row.teacherId } : {}),
             },
           });
         }
@@ -133,7 +144,7 @@ export class ClassSubjectService {
 
       return tx.classSubject.findMany({
         where: { classId },
-        include: { subject: true },
+        include: { subject: true, teacher: { include: { person: true } } },
         orderBy: { subject: { shortName: 'asc' } },
       });
     });
@@ -182,7 +193,7 @@ export class ClassSubjectService {
 
       return tx.classSubject.findMany({
         where: { classId },
-        include: { subject: true },
+        include: { subject: true, teacher: { include: { person: true } } },
         orderBy: { subject: { shortName: 'asc' } },
       });
     });

--- a/apps/api/src/modules/class/dto/update-class-subjects.dto.ts
+++ b/apps/api/src/modules/class/dto/update-class-subjects.dto.ts
@@ -1,4 +1,4 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import {
   ArrayMinSize,
@@ -10,6 +10,7 @@ import {
   Max,
   Min,
   MinLength,
+  ValidateIf,
   ValidateNested,
 } from 'class-validator';
 
@@ -44,6 +45,20 @@ export class ClassSubjectRowDto {
   @IsOptional()
   @IsBoolean()
   preferDoublePeriod?: boolean;
+
+  // Issue #71: optional Teacher assignment per ClassSubject row. null
+  // explicitly clears the assignment, undefined leaves it unchanged.
+  // ValidateIf gate is needed because @IsString rejects null.
+  @ApiPropertyOptional({
+    nullable: true,
+    description:
+      'Teacher assigned to teach this subject in this class. Drives the solver teacherConflict + teacherAvailability constraints (issue #71). Pass null to clear.',
+  })
+  @IsOptional()
+  @ValidateIf((_, v) => v !== null)
+  @IsString()
+  @MinLength(1)
+  teacherId?: string | null;
 }
 
 export class UpdateClassSubjectsDto {

--- a/apps/api/src/modules/timetable/solver-input.service.ts
+++ b/apps/api/src/modules/timetable/solver-input.service.ts
@@ -138,7 +138,9 @@ export class SolverInputService {
       },
     });
 
-    // 6. Load ClassSubjects with Subject, SchoolClass relations
+    // 6. Load ClassSubjects with Subject, SchoolClass + assigned Teacher.
+    //    Issue #71: include teacher.person so the solver-input lesson DTO
+    //    can carry a real teacherId AND a human-readable teacherName.
     const classSubjects = await this.prisma.classSubject.findMany({
       where: {
         schoolClass: { schoolId },
@@ -146,6 +148,7 @@ export class SolverInputService {
       include: {
         subject: true,
         schoolClass: true,
+        teacher: { include: { person: true } },
       },
     });
 
@@ -276,10 +279,12 @@ export class SolverInputService {
       weeklyHours: number;
       preferDoublePeriod: boolean;
       groupId: string | null;
+      teacherId: string | null;
+      teacher: { id: string; person: { firstName: string; lastName: string } } | null;
       subject: { id: string; name: string; subjectType: string; lehrverpflichtungsgruppe: string | null; werteinheitenFactor: number | null; requiredRoomType: string | null };
       schoolClass: { id: string; name: string; homeRoomId: string | null };
     }>,
-    teacherMap: Map<string, { id: string; person: { firstName: string; lastName: string } }>,
+    _teacherMap: Map<string, { id: string; person: { firstName: string; lastName: string } }>,
   ): SolverLesson[] {
     const lessons: SolverLesson[] = [];
 
@@ -291,13 +296,17 @@ export class SolverInputService {
       // picks freely (the pre-#69 default for every lesson).
       const requiredRoomType: string | null = cs.subject.requiredRoomType;
 
-      // Resolve teacher name
-      // Note: ClassSubject doesn't have a direct teacherId in the schema
-      // The teacher assignment comes from TeacherSubject qualifications
-      // For solver purposes, we need a teacher assigned per ClassSubject
-      // This will be resolved when ClassSubject gets a teacherId field
-      const teacherName = 'Unassigned';
-      const teacherId = '';
+      // Issue #71: read the assignment off the ClassSubject row instead of
+      // hardcoding ''. teacherId='' is what historically broke both
+      // teacherConflict and teacherAvailability hard constraints (the join
+      // on TeacherAvailability.teacherId never matched). When the
+      // assignment is null we still send '', which keeps the lesson
+      // schedulable but unconstrained — the same fallback behaviour the
+      // pre-#71 code shipped, isolated to genuinely unassigned subjects.
+      const teacherId = cs.teacherId ?? '';
+      const teacherName = cs.teacher
+        ? `${cs.teacher.person.lastName} ${cs.teacher.person.firstName}`
+        : 'Unassigned';
 
       for (let i = 0; i < cs.weeklyHours; i++) {
         lessons.push({

--- a/apps/web/e2e/admin-stundentafel-teacher-assignment.spec.ts
+++ b/apps/web/e2e/admin-stundentafel-teacher-assignment.spec.ts
@@ -1,0 +1,259 @@
+/**
+ * Issue #71 — Stundentafel teacher assignment.
+ *
+ * Covers the per-ClassSubject teacher picker shipped in the teacherId PR:
+ *   - E2E-CLS-TEACHER-ASSIGN: open Stundentafel tab, pick a teacher for
+ *     the first row, save → PUT body carries the chosen teacherId for
+ *     that row, value persists across reload.
+ *   - E2E-CLS-TEACHER-CLEAR:  pre-assigned row → "Nicht zugewiesen" →
+ *     save → PUT body teacherId=null, DB reflects clear.
+ *
+ * DOM contract:
+ *   - StundentafelEditorTable.tsx — per row a `<SelectTrigger
+ *     data-testid="stundentafel-teacher-${shortName}" aria-label="…">`.
+ *   - Sentinel `__no_teacher__` clears the assignment (Radix Select
+ *     does not accept empty string as a value).
+ *
+ * Scoped to desktop + chromium-only per the parallel-cleanup race family
+ * — same pattern as admin-classes-home-room.spec.ts (#67) and
+ * admin-subjects-required-room-type.spec.ts (#69).
+ */
+import { expect, test } from '@playwright/test';
+import { getAdminToken, loginAsAdmin } from './helpers/login';
+import {
+  cleanupE2EClasses,
+  createClassViaAPI,
+} from './helpers/students';
+import { SEED_SCHOOL_UUID } from './fixtures/seed-uuids';
+
+const PREFIX = 'E2E-TA-';
+const API = 'http://localhost:3000/api/v1';
+
+interface TeacherSummary {
+  id: string;
+  firstName: string;
+  lastName: string;
+}
+
+interface ClassSubjectRow {
+  id: string;
+  subjectId: string;
+  teacherId: string | null;
+  subject: { id: string; shortName: string };
+  teacher?: { id: string; person: { firstName: string; lastName: string } } | null;
+}
+
+async function listTeachers(
+  request: import('@playwright/test').APIRequestContext,
+): Promise<TeacherSummary[]> {
+  const token = await getAdminToken(request);
+  const res = await request.get(
+    `${API}/teachers?schoolId=${SEED_SCHOOL_UUID}&limit=20`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+  expect(res.ok(), 'GET /teachers').toBeTruthy();
+  const body = (await res.json()) as {
+    data?: Array<{ id: string; person?: { firstName?: string; lastName?: string } }>;
+  };
+  return (body.data ?? [])
+    .filter((t) => t.person)
+    .map((t) => ({
+      id: t.id,
+      firstName: t.person!.firstName ?? '',
+      lastName: t.person!.lastName ?? '',
+    }));
+}
+
+async function listClassSubjects(
+  request: import('@playwright/test').APIRequestContext,
+  classId: string,
+): Promise<ClassSubjectRow[]> {
+  const token = await getAdminToken(request);
+  const res = await request.get(`${API}/classes/${classId}/subjects`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  expect(res.ok(), `GET /classes/${classId}/subjects`).toBeTruthy();
+  return (await res.json()) as ClassSubjectRow[];
+}
+
+async function applyStundentafel(
+  request: import('@playwright/test').APIRequestContext,
+  classId: string,
+  schoolType: string,
+): Promise<void> {
+  const token = await getAdminToken(request);
+  const res = await request.post(
+    `${API}/classes/${classId}/apply-stundentafel`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      data: { schoolType },
+    },
+  );
+  expect(
+    res.ok(),
+    `POST apply-stundentafel must succeed, got ${res.status()}`,
+  ).toBeTruthy();
+}
+
+test.describe('Issue #71 — Stundentafel Teacher-Zuweisung (desktop)', () => {
+  test.skip(
+    ({ isMobile }) => isMobile,
+    'Stundentafel teacher picker uses identical Select on mobile — desktop is enough.',
+  );
+  test.skip(
+    ({ browserName }) => browserName !== 'chromium',
+    'flaky on parallel browser projects — shared seed-school race.',
+  );
+
+  test.beforeEach(async ({ page }) => {
+    await loginAsAdmin(page);
+  });
+
+  test.afterEach(async ({ request }) => {
+    await cleanupE2EClasses(request, PREFIX);
+  });
+
+  test('E2E-CLS-TEACHER-ASSIGN: pick teacher → save → PUT body + persist', async ({
+    page,
+    request,
+  }) => {
+    const ts = Date.now().toString().slice(-6);
+    const cls = await createClassViaAPI(request, {
+      name: `${PREFIX}A-${ts}`,
+      yearLevel: 1,
+    });
+    // Apply the AHS_UNTER year-1 Stundentafel so the new class has rows
+    // (4 seeded subjects).
+    await applyStundentafel(request, cls.id, 'AHS_UNTER');
+
+    const rowsBefore = await listClassSubjects(request, cls.id);
+    expect(
+      rowsBefore.length,
+      'Stundentafel applied → at least one row',
+    ).toBeGreaterThan(0);
+    expect(
+      rowsBefore.every((r) => r.teacherId === null),
+      'all rows start unassigned',
+    ).toBe(true);
+
+    const teachers = await listTeachers(request);
+    const target = teachers[0];
+    expect(target, 'at least one seeded teacher').toBeTruthy();
+
+    // Pick a row deterministically — Deutsch ("D") is in every AHS_UNTER
+    // year-1 Stundentafel.
+    const targetRow = rowsBefore.find((r) => r.subject.shortName === 'D');
+    expect(targetRow, 'D row exists').toBeTruthy();
+    if (!targetRow) return;
+
+    await page.goto(`/admin/classes/${cls.id}?tab=stundentafel`);
+
+    // Open the teacher Select for D, pick the target teacher.
+    const trigger = page.getByTestId('stundentafel-teacher-D');
+    await trigger.click();
+    await page
+      .getByRole('option', { name: `${target.lastName} ${target.firstName}` })
+      .click();
+
+    // Save and capture the PUT.
+    const putPromise = page.waitForResponse(
+      (res) =>
+        res.url().endsWith(`/classes/${cls.id}/subjects`) &&
+        res.request().method() === 'PUT',
+      { timeout: 15_000 },
+    );
+    await page.getByRole('button', { name: 'Speichern' }).first().click();
+    const putRes = await putPromise;
+    expect(putRes.ok(), 'PUT must succeed').toBeTruthy();
+    const reqBody = JSON.parse(putRes.request().postData() ?? '{}') as {
+      rows: Array<{ subjectId: string; teacherId: string | null }>;
+    };
+    const dRow = reqBody.rows.find((r) => r.subjectId === targetRow.subjectId);
+    expect(
+      dRow?.teacherId,
+      'PUT body carries the picked teacherId for the D row',
+    ).toBe(target.id);
+
+    // DB persistence.
+    const rowsAfter = await listClassSubjects(request, cls.id);
+    const persisted = rowsAfter.find((r) => r.subject.shortName === 'D');
+    expect(persisted?.teacherId).toBe(target.id);
+  });
+
+  test('E2E-CLS-TEACHER-CLEAR: switch teacher → Nicht zugewiesen → PUT body null', async ({
+    page,
+    request,
+  }) => {
+    const ts = Date.now().toString().slice(-6);
+    const cls = await createClassViaAPI(request, {
+      name: `${PREFIX}C-${ts}`,
+      yearLevel: 1,
+    });
+    await applyStundentafel(request, cls.id, 'AHS_UNTER');
+
+    const teachers = await listTeachers(request);
+    const target = teachers[0];
+    expect(target, 'at least one seeded teacher').toBeTruthy();
+
+    // Pre-assign the D row via the PUT endpoint so the clear flow has
+    // something to clear.
+    const rowsBefore = await listClassSubjects(request, cls.id);
+    const dRow = rowsBefore.find((r) => r.subject.shortName === 'D');
+    expect(dRow, 'D row exists').toBeTruthy();
+    if (!dRow) return;
+    const token = await getAdminToken(request);
+    await request.put(`${API}/classes/${cls.id}/subjects`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      data: {
+        rows: rowsBefore.map((r) => ({
+          id: r.id,
+          subjectId: r.subjectId,
+          weeklyHours: 4,
+          teacherId: r.subjectId === dRow.subjectId ? target.id : null,
+        })),
+      },
+    });
+
+    const verifySeed = await listClassSubjects(request, cls.id);
+    expect(
+      verifySeed.find((r) => r.subject.shortName === 'D')?.teacherId,
+    ).toBe(target.id);
+
+    await page.goto(`/admin/classes/${cls.id}?tab=stundentafel`);
+
+    // Open the teacher Select for D, pick "Nicht zugewiesen".
+    await page.getByTestId('stundentafel-teacher-D').click();
+    await page.getByRole('option', { name: 'Nicht zugewiesen' }).click();
+
+    const putPromise = page.waitForResponse(
+      (res) =>
+        res.url().endsWith(`/classes/${cls.id}/subjects`) &&
+        res.request().method() === 'PUT',
+      { timeout: 15_000 },
+    );
+    await page.getByRole('button', { name: 'Speichern' }).first().click();
+    const putRes = await putPromise;
+    expect(putRes.ok(), 'PUT must succeed').toBeTruthy();
+    const reqBody = JSON.parse(putRes.request().postData() ?? '{}') as {
+      rows: Array<{ subjectId: string; teacherId: string | null }>;
+    };
+    const clearedRow = reqBody.rows.find(
+      (r) => r.subjectId === dRow.subjectId,
+    );
+    expect(
+      clearedRow?.teacherId,
+      'PUT body sets teacherId=null for the D row',
+    ).toBeNull();
+
+    const rowsAfter = await listClassSubjects(request, cls.id);
+    expect(
+      rowsAfter.find((r) => r.subject.shortName === 'D')?.teacherId,
+    ).toBeNull();
+  });
+});

--- a/apps/web/src/components/admin/class/StundentafelEditorTable.tsx
+++ b/apps/web/src/components/admin/class/StundentafelEditorTable.tsx
@@ -18,6 +18,11 @@ export interface EditorRow {
   weeklyHours: number;
   isCustomized?: boolean;
   preferDoublePeriod?: boolean;
+  // Issue #71: per-row teacher assignment. null = explicit clear,
+  // undefined = leave unchanged on save. The display name keeps the
+  // select trigger label stable across re-renders without re-fetching.
+  teacherId?: string | null;
+  teacherDisplayName?: string;
 }
 
 interface SubjectOption {
@@ -26,11 +31,22 @@ interface SubjectOption {
   shortName: string;
 }
 
+interface TeacherOption {
+  id: string;
+  firstName: string;
+  lastName: string;
+}
+
 interface Props {
   rows: EditorRow[];
   onChange: (rows: EditorRow[]) => void;
   availableSubjects: SubjectOption[];
+  availableTeachers: TeacherOption[];
 }
+
+// Radix Select cannot use empty string as a value — the unassigned
+// sentinel maps to `teacherId=null` on save (clears the assignment).
+const NO_TEACHER = '__no_teacher__';
 
 /**
  * StundentafelEditorTable — SUBJECT-04 Wochenstunden editor.
@@ -40,7 +56,12 @@ interface Props {
  * manages the flag server-side; this UI reflects the value coming from the
  * backend after save).
  */
-export function StundentafelEditorTable({ rows, onChange, availableSubjects }: Props) {
+export function StundentafelEditorTable({
+  rows,
+  onChange,
+  availableSubjects,
+  availableTeachers,
+}: Props) {
   const usedSubjectIds = new Set(rows.map((r) => r.subjectId));
   const addableSubjects = availableSubjects.filter((s) => !usedSubjectIds.has(s.id));
 
@@ -54,6 +75,25 @@ export function StundentafelEditorTable({ rows, onChange, availableSubjects }: P
 
   const handleDelete = (index: number) => {
     onChange(rows.filter((_, i) => i !== index));
+  };
+
+  const handleTeacherChange = (index: number, value: string) => {
+    const next = [...rows];
+    if (value === NO_TEACHER) {
+      next[index] = {
+        ...next[index],
+        teacherId: null,
+        teacherDisplayName: undefined,
+      };
+    } else {
+      const t = availableTeachers.find((tt) => tt.id === value);
+      next[index] = {
+        ...next[index],
+        teacherId: value,
+        teacherDisplayName: t ? `${t.lastName} ${t.firstName}` : undefined,
+      };
+    }
+    onChange(next);
   };
 
   const handleAdd = (subjectId: string) => {
@@ -77,6 +117,7 @@ export function StundentafelEditorTable({ rows, onChange, availableSubjects }: P
           <tr>
             <th className="px-3 py-2 font-semibold">Fach</th>
             <th className="px-3 py-2 font-semibold tabular-nums w-32">Wochenstunden</th>
+            <th className="px-3 py-2 font-semibold w-56">Lehrkraft</th>
             <th className="px-3 py-2 font-semibold w-28">Status</th>
             <th className="px-3 py-2 w-10" aria-label="Entfernen"></th>
           </tr>
@@ -104,6 +145,27 @@ export function StundentafelEditorTable({ rows, onChange, availableSubjects }: P
                 />
               </td>
               <td className="px-3 py-2">
+                <Select
+                  value={row.teacherId ?? NO_TEACHER}
+                  onValueChange={(v) => handleTeacherChange(idx, v)}
+                >
+                  <SelectTrigger
+                    aria-label={`Lehrkraft für ${row.subjectShortName ?? row.subjectId}`}
+                    data-testid={`stundentafel-teacher-${row.subjectShortName ?? row.subjectId}`}
+                  >
+                    <SelectValue placeholder="Nicht zugewiesen" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={NO_TEACHER}>Nicht zugewiesen</SelectItem>
+                    {availableTeachers.map((t) => (
+                      <SelectItem key={t.id} value={t.id}>
+                        {t.lastName} {t.firstName}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </td>
+              <td className="px-3 py-2">
                 {row.isCustomized ? (
                   <Badge className="bg-amber-100 text-amber-900 hover:bg-amber-100">
                     Angepasst
@@ -126,7 +188,7 @@ export function StundentafelEditorTable({ rows, onChange, availableSubjects }: P
           ))}
           {addableSubjects.length > 0 && (
             <tr className="border-t bg-muted/10">
-              <td className="px-3 py-2" colSpan={4}>
+              <td className="px-3 py-2" colSpan={5}>
                 <div className="flex items-center gap-2">
                   <Select value="" onValueChange={handleAdd}>
                     <SelectTrigger className="w-[240px]" aria-label="Fach hinzufügen">

--- a/apps/web/src/components/admin/class/StundentafelMobileCards.tsx
+++ b/apps/web/src/components/admin/class/StundentafelMobileCards.tsx
@@ -2,17 +2,37 @@ import { Trash2 } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import type { EditorRow } from './StundentafelEditorTable';
+
+interface TeacherOption {
+  id: string;
+  firstName: string;
+  lastName: string;
+}
 
 interface Props {
   rows: EditorRow[];
   onChange: (rows: EditorRow[]) => void;
+  availableTeachers: TeacherOption[];
 }
+
+const NO_TEACHER = '__no_teacher__';
 
 /**
  * Mobile (<640px) collapse of the Stundentafel editor — stacked Cards.
  */
-export function StundentafelMobileCards({ rows, onChange }: Props) {
+export function StundentafelMobileCards({
+  rows,
+  onChange,
+  availableTeachers,
+}: Props) {
   const handleHoursChange = (index: number, value: string) => {
     const num = Number(value);
     if (Number.isNaN(num)) return;
@@ -25,14 +45,33 @@ export function StundentafelMobileCards({ rows, onChange }: Props) {
     onChange(rows.filter((_, i) => i !== index));
   };
 
+  const handleTeacherChange = (index: number, value: string) => {
+    const next = [...rows];
+    if (value === NO_TEACHER) {
+      next[index] = {
+        ...next[index],
+        teacherId: null,
+        teacherDisplayName: undefined,
+      };
+    } else {
+      const t = availableTeachers.find((tt) => tt.id === value);
+      next[index] = {
+        ...next[index],
+        teacherId: value,
+        teacherDisplayName: t ? `${t.lastName} ${t.firstName}` : undefined,
+      };
+    }
+    onChange(next);
+  };
+
   return (
     <div className="sm:hidden space-y-2">
       {rows.map((row, idx) => (
         <div
           key={row.id ?? `new-${row.subjectId}`}
-          className="rounded-md border bg-card p-3"
+          className="rounded-md border bg-card p-3 space-y-2"
         >
-          <div className="flex items-center justify-between mb-2">
+          <div className="flex items-center justify-between">
             <span className="font-semibold">{row.subjectShortName ?? row.subjectId}</span>
             {row.isCustomized && (
               <Badge className="bg-amber-100 text-amber-900 hover:bg-amber-100">
@@ -61,6 +100,24 @@ export function StundentafelMobileCards({ rows, onChange }: Props) {
               <Trash2 className="h-4 w-4" />
             </Button>
           </div>
+          <Select
+            value={row.teacherId ?? NO_TEACHER}
+            onValueChange={(v) => handleTeacherChange(idx, v)}
+          >
+            <SelectTrigger
+              aria-label={`Lehrkraft für ${row.subjectShortName ?? row.subjectId}`}
+            >
+              <SelectValue placeholder="Nicht zugewiesen" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={NO_TEACHER}>Nicht zugewiesen</SelectItem>
+              {availableTeachers.map((t) => (
+                <SelectItem key={t.id} value={t.id}>
+                  {t.lastName} {t.firstName}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         </div>
       ))}
     </div>

--- a/apps/web/src/components/admin/class/StundentafelTab.tsx
+++ b/apps/web/src/components/admin/class/StundentafelTab.tsx
@@ -31,6 +31,12 @@ interface SubjectDto {
   shortName: string;
 }
 
+interface TeacherDto {
+  id: string;
+  firstName: string;
+  lastName: string;
+}
+
 function useSubjectsList(schoolId: string | undefined) {
   return useQuery({
     queryKey: ['subjects', schoolId],
@@ -46,9 +52,41 @@ function useSubjectsList(schoolId: string | undefined) {
   });
 }
 
+// Issue #71: light-weight teacher list for the Stundentafel teacher
+// picker. Shape mirrors what `availableTeachers` expects in the editor
+// components; pulled from the existing /teachers endpoint which already
+// supports tenant scoping via `?schoolId=`.
+function useTeacherOptions(schoolId: string | undefined) {
+  return useQuery({
+    queryKey: ['teachers:stundentafel-options', schoolId],
+    queryFn: async (): Promise<TeacherDto[]> => {
+      if (!schoolId) return [];
+      const res = await apiFetch(
+        `/api/v1/teachers?schoolId=${schoolId}&limit=500`,
+      );
+      if (!res.ok) return [];
+      const body = await res.json();
+      const items: Array<{
+        id: string;
+        person?: { firstName?: string; lastName?: string };
+      }> = body.data ?? body ?? [];
+      return items
+        .filter((t) => t.person)
+        .map((t) => ({
+          id: t.id,
+          firstName: t.person!.firstName ?? '',
+          lastName: t.person!.lastName ?? '',
+        }));
+    },
+    enabled: !!schoolId,
+    staleTime: 60_000,
+  });
+}
+
 export function StundentafelTab({ schoolId, cls, onDirtyChange }: Props) {
   const classSubjectsQuery = useClassSubjects(cls.id);
   const subjectsQuery = useSubjectsList(schoolId);
+  const teachersQuery = useTeacherOptions(schoolId);
   const schoolQuery = useSchool(schoolId);
 
   const [rows, setRows] = useState<EditorRow[]>([]);
@@ -71,6 +109,13 @@ export function StundentafelTab({ schoolId, cls, onDirtyChange }: Props) {
           weeklyHours: cs.weeklyHours,
           isCustomized: cs.isCustomized,
           preferDoublePeriod: cs.preferDoublePeriod,
+          // Issue #71: hydrate the teacher assignment from the server
+          // include so the Select trigger renders the saved value
+          // without a follow-up fetch.
+          teacherId: cs.teacherId ?? null,
+          teacherDisplayName: cs.teacher
+            ? `${cs.teacher.person.lastName} ${cs.teacher.person.firstName}`
+            : undefined,
         })),
       );
     }
@@ -81,7 +126,13 @@ export function StundentafelTab({ schoolId, cls, onDirtyChange }: Props) {
     rows.length !== serverRows.length ||
     rows.some((r) => {
       const server = serverRows.find((s) => s.subjectId === r.subjectId);
-      return !server || server.weeklyHours !== r.weeklyHours;
+      if (!server) return true;
+      if (server.weeklyHours !== r.weeklyHours) return true;
+      // Issue #71: treat a teacher change as dirty too. Compare nulls
+      // explicitly (server.teacherId can be null, undefined, or a uuid).
+      const serverTeacher = server.teacherId ?? null;
+      const localTeacher = r.teacherId ?? null;
+      return serverTeacher !== localTeacher;
     });
 
   useEffect(() => {
@@ -96,6 +147,10 @@ export function StundentafelTab({ schoolId, cls, onDirtyChange }: Props) {
           subjectId: r.subjectId,
           weeklyHours: r.weeklyHours,
           preferDoublePeriod: r.preferDoublePeriod,
+          // Issue #71: explicit null clears, undefined would leave it
+          // alone — but `r.teacherId` is always set after hydration
+          // (null or uuid), so we forward it verbatim.
+          teacherId: r.teacherId ?? null,
         })),
       });
       setSavedOnce(true);
@@ -157,9 +212,14 @@ export function StundentafelTab({ schoolId, cls, onDirtyChange }: Props) {
           rows={rows}
           onChange={setRows}
           availableSubjects={subjectsQuery.data ?? []}
+          availableTeachers={teachersQuery.data ?? []}
         />
       </div>
-      <StundentafelMobileCards rows={rows} onChange={setRows} />
+      <StundentafelMobileCards
+        rows={rows}
+        onChange={setRows}
+        availableTeachers={teachersQuery.data ?? []}
+      />
 
       <div className="flex justify-end gap-2">
         <Button

--- a/apps/web/src/hooks/useClassSubjects.ts
+++ b/apps/web/src/hooks/useClassSubjects.ts
@@ -63,6 +63,9 @@ export interface UpdateClassSubjectsPayload {
     subjectId: string;
     weeklyHours: number;
     preferDoublePeriod?: boolean;
+    // Issue #71: null clears the assignment, undefined leaves it
+    // unchanged, uuid sets it.
+    teacherId?: string | null;
   }>;
 }
 

--- a/apps/web/src/hooks/useClasses.ts
+++ b/apps/web/src/hooks/useClasses.ts
@@ -71,6 +71,11 @@ export interface ClassSubjectDto {
   classId: string;
   subjectId: string;
   groupId?: string | null;
+  teacherId?: string | null;
+  teacher?: {
+    id: string;
+    person: { firstName: string; lastName: string };
+  } | null;
   weeklyHours: number;
   isCustomized: boolean;
   preferDoublePeriod: boolean;


### PR DESCRIPTION
Closes #71. Critical: this restores **two HARD solver constraints** that were silently no-ops on every solve.

## Summary

Third occurrence of the same pattern as #67 + #69. The Java solver shipped two HARD constraints depending on a real teacher key per Lesson:

- \`teacherConflict\` — \`forEachUniquePair(Lesson, Joiners.equal(Lesson::getTeacherId))\`
- \`teacherAvailability\` — \`join(TeacherAvailability, equal(Lesson.teacherId, TA.teacherId))\`

But \`solver-input.service.ts:299-300\` was hardcoded:

\`\`\`ts
const teacherName = 'Unassigned';
const teacherId = '';
\`\`\`

Effects pre-fix:
- \`teacherConflict\` saw every lesson sharing \`''\` → only worked by accident (32 lessons fit into 80 slots; 5+ classes would have collapsed).
- \`teacherAvailability\` join **never matched** — \`AvailabilityRule\` and \`BLOCK_TIMESLOT\` template entries were silently ignored. Admins setting blocked periods got no protection from the solver.
- UI: every lesson showed "Unassigned" as the teacher.

Root cause was structural: \`ClassSubject\` had no \`teacherId\`. \`TeacherSubject\` is qualifications (CAN teach), not assignment (DOES teach).

## Layers touched

| Layer | Status before | Change |
| --- | --- | --- |
| Java \`teacherConflict\` + \`teacherAvailability\` constraints | ✓ existed | — |
| Java \`Lesson.teacherId\` + \`teacherName\` | ✓ existed | — |
| Prisma \`ClassSubject.teacherId\` | ✗ | nullable FK on Teacher, \`ON DELETE SET NULL\` |
| Migration | — | \`20260511214924_add_class_subject_teacher_id\` |
| ClassSubject UpdateRow DTO | ✗ | optional + nullable \`teacherId\` with \`ValidateIf(v !== null)\` |
| ClassSubjectService | ✗ | persists \`teacherId\` on create + update; includes \`teacher.person\` on every read path |
| \`solver-input.service.ts:299-300\` | hardcoded \`''\` + \`'Unassigned'\` | \`cs.teacherId\` + \`cs.teacher.person.lastName + firstName\` |
| Frontend \`useClasses.ClassSubjectDto\` + \`useClassSubjects.UpdateClassSubjectsPayload\` | ✗ | extended with \`teacherId\` |
| Frontend \`StundentafelEditorTable\` | ✗ | new Lehrkraft column with per-row Select; \`data-testid="stundentafel-teacher-\${shortName}"\` |
| Frontend \`StundentafelMobileCards\` | ✗ | same Select stacked on the row card |
| Frontend \`StundentafelTab\` | ✗ | new \`useTeacherOptions\` hook, hydration, dirty-aware, save forwards \`teacherId\` |
| Seed defaults | none | teacher1 → D + E, teacher2 → M, teacher3 → BSP |
| E2E spec | — | \`admin-stundentafel-teacher-assignment.spec.ts\` (ASSIGN + CLEAR) |

## Live-stack validation

Seed school, 2 classes × 4 subjects = 8 ClassSubjects, \`maxSolveSeconds=30\`:

\`\`\`sql
SELECT p.last_name AS teacher, day_of_week, period_number, COUNT(*)
FROM timetable_lessons tl JOIN teachers t ON t.id = tl.teacher_id
JOIN persons p ON p.id = t.person_id
WHERE tl.run_id = (SELECT id FROM timetable_runs WHERE is_active=true)
GROUP BY 1,2,3 HAVING COUNT(*) > 1;
\`\`\`

| Before | After |
| --- | --- |
| \`tl.teacher_id\` was always NULL → query returns nothing useful | \`0 rows\` — no teacher double-booked |
| Score: hard=0, soft=-7 (soft was deceptively low) | Score: hard=0, soft=-16 (real teacherConflict competing with balancedWeeklyDistribution — healthy trade-off) |

Same teacher (Mustermann Max) now teaches D + E in both 1A and 1B = 16 lessons. Solver respects the real constraint and spreads them across distinct slots. Pre-fix this would have been silent.

## Specs

- [x] \`pnpm --filter @schoolflow/api test --run\` — 759 passed / 65 todo
- [x] \`pnpm --filter @schoolflow/shared test --run\` — 193 passed
- [x] \`pnpm --filter web exec playwright test admin-stundentafel-teacher-assignment --project=desktop\` — 2 passed (ASSIGN + CLEAR)

## Convention compliance

Per CLAUDE.md "Bug-Fix Regression-Schutz via E2E — hard rule" (introduced in #68): regression-lock spec exists; \`git stash && playwright test && git stash pop\` would surface a red CLEAR test on the previous main.

## Pattern of record

This is the **third** identical incident of the "Java-side ready, schema/API/UI missing" pattern in one session:
- #67 — \`SchoolClass.homeRoomId\` (Heimraum)
- #69 — \`Subject.requiredRoomType\` (Pflicht-Raumtyp)
- #71 — \`ClassSubject.teacherId\` (Teacher assignment) ← this PR

The remaining open issues from the audit (#72 weekType hardcoded BOTH, #73 studentCount + requiredEquipment latent) are queued by criticality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)