### PR TITLE
fix(subject): unblock main CI — widen requiredRoomType to allow null on update

### DIFF
--- a/apps/web/src/hooks/useSubjects.ts
+++ b/apps/web/src/hooks/useSubjects.ts
@@ -137,7 +137,10 @@ export interface CreateSubjectPayload {
   subjectType?: string;
   lehrverpflichtungsgruppe?: string;
   werteinheitenFactor?: number;
-  requiredRoomType?: string;
+  // Update path passes explicit null to clear the requirement
+  // (SubjectFormDialog.tsx:136-139). Create path only ever spreads
+  // truthy values, so the wider type doesn't loosen create semantics.
+  requiredRoomType?: string | null;
 }
 
 export function useCreateSubject(schoolId: string) {


### PR DESCRIPTION
## Summary

- Widens `CreateSubjectPayload.requiredRoomType` from `string | undefined` to `string | null | undefined` so the Update branch in `SubjectFormDialog.tsx:139` (which intentionally passes `null` to clear the requirement) compiles cleanly.
- Unblocks the `Build Web` step in `playwright.yml` — `main` CI has been red since PR #70 ([run 25703730002](https://github.com/martinvidec/openaustria-school-flow/actions/runs/25703730002)) and every PR rebased on `main` inherits the same failure (incl. closed PR #74 / issue #71).

## Root cause

PR #70 added the `requiredRoomType` enum (`feat(subject): add required room type — BSP now goes to Turnsaal`) and the dialog UX where "Kein Pflichtraum" clears the value. The dialog correctly sends `null` on the Update path (per the comment at `SubjectFormDialog.tsx:136`), and the backend `UpdateSubjectDto` accepts `null` at runtime — but the frontend mutation type stayed `string | undefined`, so TS2322 fires at `Build Web` in CI.

Locally this was masked by a stale `tsconfig.app.tsbuildinfo`; force-rebuilding (`rm tsbuildinfo && tsc -b --force`) reproduces the same `error TS2322: Type 'string | null' is not assignable to type 'string | undefined'` that CI hits.

## Why no E2E regression-lock

Per `CLAUDE.md` *Bug-Fix Regression-Schutz via E2E — hard rule*, pure type-fixes without behavioural change are explicitly exempted. Runtime behaviour is unchanged (dialog already sends `null`, backend already accepts it). The `Build Web` step itself is the regression-lock.

## Test plan

- [x] `rm apps/web/tsconfig*.tsbuildinfo && pnpm --filter @schoolflow/web exec tsc -b --force` — green
- [x] `pnpm --filter @schoolflow/web exec vitest run src/components/admin/subject` — green (existing todo placeholders, no behaviour exercised)
- [ ] CI Playwright E2E grün (Build Web + downstream e2e suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)