### PR TITLE
feat(solver): A/B-Wochen-Rhythmus für ClassSubject (#72)

### DIFF
--- a/apps/api/prisma/migrations/20260512104022_add_class_subject_cycle_fields/migration.sql
+++ b/apps/api/prisma/migrations/20260512104022_add_class_subject_cycle_fields/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "class_subjects" ADD COLUMN     "cycle_length" INTEGER NOT NULL DEFAULT 1,
+ADD COLUMN     "cycle_slot_mask" INTEGER;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -574,6 +574,15 @@ model ClassSubject {
   weeklyHours        Int         @map("weekly_hours")
   isCustomized       Boolean     @default(false) @map("is_customized")
   preferDoublePeriod Boolean     @default(false) @map("prefer_double_period")
+  // Issue #72: week-rhythm fields. cycleLength=1 means "every week"
+  // (the historical implicit default). cycleLength=2 + cycleSlotMask=1
+  // means "A-week only", mask=2 means "B-week only". Forward-compatible
+  // for future n-week rotations (cycleLength=3 + mask=0b001 etc.) — the
+  // schema does not restrict cycleLength, only the API + UI currently
+  // expose the A/B subset. cycleSlotMask is null at cycleLength=1
+  // (no slots to select).
+  cycleLength        Int         @default(1) @map("cycle_length")
+  cycleSlotMask      Int?        @map("cycle_slot_mask")
 
   // Phase 8 relations
   homework Homework[]

--- a/apps/api/src/modules/class/class-subject.service.ts
+++ b/apps/api/src/modules/class/class-subject.service.ts
@@ -111,6 +111,34 @@ export class ClassSubjectService {
         const isCustomized =
           templateHours === undefined ? true : templateHours !== row.weeklyHours;
         const prior = existingBySubject.get(row.subjectId);
+        // Issue #72: enforce cycleLength/cycleSlotMask invariants before
+        // we touch the DB. Saving cycleLength=2 with mask=null (no slots
+        // selected) would silently drop the subject from the solver
+        // input; saving cycleLength=1 with a non-null mask is meaningless
+        // noise.
+        if (row.cycleLength !== undefined && row.cycleLength === 1) {
+          if (row.cycleSlotMask != null) {
+            throw new ConflictException({
+              type: 'https://schoolflow.dev/errors/invalid-cycle',
+              title: 'Ungültiger Wochenrhythmus',
+              status: 409,
+              detail:
+                'cycleSlotMask muss null sein, wenn cycleLength=1 (jede Woche).',
+            });
+          }
+        }
+        if (row.cycleLength !== undefined && row.cycleLength > 1) {
+          if (row.cycleSlotMask == null || row.cycleSlotMask === 0) {
+            throw new ConflictException({
+              type: 'https://schoolflow.dev/errors/invalid-cycle',
+              title: 'Ungültiger Wochenrhythmus',
+              status: 409,
+              detail:
+                'cycleSlotMask muss ein nicht-leerer Bitmask sein, wenn cycleLength>1.',
+            });
+          }
+        }
+
         if (prior) {
           await tx.classSubject.update({
             where: { id: prior.id },
@@ -123,6 +151,11 @@ export class ClassSubjectService {
               // null = clear it; uuid = set it. Prisma treats undefined as
               // a no-op here, so the explicit-presence check is implicit.
               teacherId: row.teacherId,
+              // Issue #72: same Prisma undefined-vs-null semantics applies
+              // here for both cycle fields. Skipping the field leaves the
+              // existing rhythm untouched.
+              cycleLength: row.cycleLength,
+              cycleSlotMask: row.cycleSlotMask,
             },
           });
         } else {
@@ -137,6 +170,15 @@ export class ClassSubjectService {
               // was provided. null on a never-existed row is the same as
               // omitting it (default DB value is NULL).
               ...(row.teacherId ? { teacherId: row.teacherId } : {}),
+              // Issue #72: same — only set non-default cycle values when
+              // the caller explicitly asked. Defaults are cycleLength=1
+              // (every week) and cycleSlotMask=null.
+              ...(row.cycleLength !== undefined
+                ? { cycleLength: row.cycleLength }
+                : {}),
+              ...(row.cycleSlotMask !== undefined
+                ? { cycleSlotMask: row.cycleSlotMask }
+                : {}),
             },
           });
         }

--- a/apps/api/src/modules/class/dto/update-class-subjects.dto.ts
+++ b/apps/api/src/modules/class/dto/update-class-subjects.dto.ts
@@ -59,6 +59,36 @@ export class ClassSubjectRowDto {
   @IsString()
   @MinLength(1)
   teacherId?: string | null;
+
+  // Issue #72: week rhythm. cycleLength=1 means "every week" (the
+  // historical default). cycleLength=2 + cycleSlotMask=1 → A-week only;
+  // mask=2 → B-week only. Schema is forward-compatible for n>2 but the
+  // API today validates the A/B subset.
+  @ApiPropertyOptional({
+    minimum: 1,
+    maximum: 2,
+    description:
+      'Cycle length in weeks. 1 = every week; 2 = A/B rhythm. Issue #72.',
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(2)
+  cycleLength?: number;
+
+  @ApiPropertyOptional({
+    nullable: true,
+    minimum: 1,
+    maximum: 3,
+    description:
+      'Bitmask selecting which slots in the cycle the subject is active. Required when cycleLength > 1; must be null when cycleLength == 1. For cycleLength=2: 1 = A-week, 2 = B-week. Issue #72.',
+  })
+  @IsOptional()
+  @ValidateIf((_, v) => v !== null)
+  @IsInt()
+  @Min(1)
+  @Max(3)
+  cycleSlotMask?: number | null;
 }
 
 export class UpdateClassSubjectsDto {

--- a/apps/api/src/modules/timetable/constraint-catalog.ts
+++ b/apps/api/src/modules/timetable/constraint-catalog.ts
@@ -1,5 +1,5 @@
 /**
- * Static catalog of all 15 solver constraints (6 HARD + 9 SOFT).
+ * Static catalog of all 16 solver constraints (7 HARD + 9 SOFT).
  *
  * SYNC: apps/solver/src/main/java/at/schoolflow/solver/constraints/TimetableConstraintProvider.java
  * SYNC: packages/shared/src/constraint-catalog.ts (frontend mirror)
@@ -20,7 +20,7 @@ export interface ConstraintCatalogEntry {
 }
 
 export const CONSTRAINT_CATALOG: ConstraintCatalogEntry[] = [
-  // === HARD (6) ===
+  // === HARD (7) ===
   {
     name: 'Teacher conflict',
     displayName: 'Lehrkraft-Konflikt',
@@ -62,6 +62,16 @@ export const CONSTRAINT_CATALOG: ConstraintCatalogEntry[] = [
     description: 'Klassen dürfen nicht in gesperrten Perioden unterrichtet werden (siehe Tab Klassen-Sperrzeiten).',
     severity: 'HARD',
     source: 'TimetableConstraintProvider.java#classTimeslotRestriction',
+  },
+  {
+    // Issue #72: hard constraint pinning each lesson to a timeslot whose
+    // weekType is compatible. Activated when the school has A/B-week
+    // rhythms enabled and at least one ClassSubject opts in.
+    name: 'Week type compatibility',
+    displayName: 'A/B-Wochen-Zuordnung',
+    description: 'Stunden mit A- oder B-Wochen-Rhythmus müssen in der passenden Wochenvariante liegen.',
+    severity: 'HARD',
+    source: 'TimetableConstraintProvider.java#weekTypeCompatibility',
   },
 
   // === SOFT (9 — 8 existing + 1 NEW for Phase 14 Task 5) ===

--- a/apps/api/src/modules/timetable/solver-input.service.spec.ts
+++ b/apps/api/src/modules/timetable/solver-input.service.spec.ts
@@ -166,3 +166,79 @@ describe('SolverInputService.processConstraintTemplates', () => {
     });
   });
 });
+
+describe('SolverInputService.deriveLessonWeekTypes (Issue #72 regression)', () => {
+  let service: SolverInputService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SolverInputService,
+        {
+          provide: PrismaService,
+          useValue: { constraintTemplate: { findMany: vi.fn() } },
+        },
+        {
+          provide: ConstraintTemplateService,
+          useValue: { findActive: vi.fn() },
+        },
+      ],
+    }).compile();
+    service = module.get<SolverInputService>(SolverInputService);
+  });
+
+  // Private method — access via cast. The Issue #72 contract belongs on
+  // the public buildSolverInput pipeline, but the rhythm-derivation logic
+  // is the entire interesting surface and isolating it makes failure modes
+  // readable on the failure line itself.
+  const derive = (
+    length: number,
+    mask: number | null,
+    abEnabled: boolean,
+  ): Array<'BOTH' | 'A' | 'B'> =>
+    (service as any).deriveLessonWeekTypes(length, mask, abEnabled);
+
+  // The original Issue #72 symptom: solver-input.service.ts:321 hardcoded
+  // `weekType: 'BOTH'`. On a school with abWeekEnabled=true, timeslots
+  // split into A/B but every lesson stayed BOTH — per-week semantics dead.
+  // This first assertion is the regression lock: with abWeekEnabled=true,
+  // an every-week subject MUST split into [A, B] lesson variants, not BOTH.
+  it('abWeekEnabled=true + cycleLength=1 → [A, B] (catches the original BOTH-hardcode bug)', () => {
+    expect(derive(1, null, true)).toEqual(['A', 'B']);
+  });
+
+  it('abWeekEnabled=false + cycleLength=1 → [BOTH] (legacy non-A/B path stays untouched)', () => {
+    expect(derive(1, null, false)).toEqual(['BOTH']);
+  });
+
+  it('A-week only: cycleLength=2, mask=0b01, abWeekEnabled=true → [A]', () => {
+    expect(derive(2, 0b01, true)).toEqual(['A']);
+  });
+
+  it('B-week only: cycleLength=2, mask=0b10, abWeekEnabled=true → [B]', () => {
+    expect(derive(2, 0b10, true)).toEqual(['B']);
+  });
+
+  it('BOTH semantics on A/B school: cycleLength=2, mask=0b11, abWeekEnabled=true → [A, B]', () => {
+    expect(derive(2, 0b11, true)).toEqual(['A', 'B']);
+  });
+
+  it('BOTH semantics on non-A/B school: cycleLength=2, mask=0b11, abWeekEnabled=false → [BOTH]', () => {
+    expect(derive(2, 0b11, false)).toEqual(['BOTH']);
+  });
+
+  it('forward-compat: n>2 cycles fall back to every-week — never silently drop subjects', () => {
+    // The UI does not yet emit cycleLength>2. If a row sneaks in via API
+    // or import, expanding to every-week is safer than zero lessons.
+    expect(derive(3, 0b001, true)).toEqual(['A', 'B']);
+    expect(derive(4, 0b1010, false)).toEqual(['BOTH']);
+  });
+
+  it('mask=0 defensive fallback: invalid mask collapses to every-week, never empty', () => {
+    // class-subject.service.ts rejects mask=0 in the API layer; this is a
+    // defence-in-depth assertion that the derive helper alone would not
+    // emit zero lessons even if a row slipped through.
+    expect(derive(2, 0, true)).toEqual(['A', 'B']);
+    expect(derive(2, 0, false)).toEqual(['BOTH']);
+  });
+});

--- a/apps/api/src/modules/timetable/solver-input.service.ts
+++ b/apps/api/src/modules/timetable/solver-input.service.ts
@@ -141,6 +141,8 @@ export class SolverInputService {
     // 6. Load ClassSubjects with Subject, SchoolClass + assigned Teacher.
     //    Issue #71: include teacher.person so the solver-input lesson DTO
     //    can carry a real teacherId AND a human-readable teacherName.
+    //    Issue #72: cycleLength + cycleSlotMask are scalar fields so they
+    //    travel with the select-* implicit by default.
     const classSubjects = await this.prisma.classSubject.findMany({
       where: {
         schoolClass: { schoolId },
@@ -167,8 +169,16 @@ export class SolverInputService {
       (school as any).abWeekEnabled ?? false,
     );
 
-    // Build lessons from ClassSubjects
-    const lessons = this.buildLessons(classSubjects, teacherMap);
+    // Build lessons from ClassSubjects. Issue #72: lesson expansion is
+    // week-rhythm aware — every ClassSubject row generates N×K lessons
+    // where N = weeklyHours and K = number of active cycle slots
+    // (typically 1 for cycleLength=1; 2 for cycleLength=2+mask=BOTH on an
+    // A/B school).
+    const lessons = this.buildLessons(
+      classSubjects,
+      teacherMap,
+      (school as any).abWeekEnabled ?? false,
+    );
 
     // Build rooms
     const solverRooms: SolverRoom[] = rooms.map((r) => ({
@@ -281,10 +291,13 @@ export class SolverInputService {
       groupId: string | null;
       teacherId: string | null;
       teacher: { id: string; person: { firstName: string; lastName: string } } | null;
+      cycleLength: number;
+      cycleSlotMask: number | null;
       subject: { id: string; name: string; subjectType: string; lehrverpflichtungsgruppe: string | null; werteinheitenFactor: number | null; requiredRoomType: string | null };
       schoolClass: { id: string; name: string; homeRoomId: string | null };
     }>,
     _teacherMap: Map<string, { id: string; person: { firstName: string; lastName: string } }>,
+    abWeekEnabled: boolean,
   ): SolverLesson[] {
     const lessons: SolverLesson[] = [];
 
@@ -308,31 +321,88 @@ export class SolverInputService {
         ? `${cs.teacher.person.lastName} ${cs.teacher.person.firstName}`
         : 'Unassigned';
 
+      // Issue #72: derive the lesson weekTypes from the rhythm fields.
+      // For non-A/B schools the rhythm flag collapses to a single BOTH
+      // entry; for A/B schools cycleLength=2+mask=1 → ['A'], mask=2 →
+      // ['B'], cycleLength=1 (every week) → ['A','B'] so the lesson
+      // exists in each week separately. n>2 cycles are accepted by the
+      // schema for forward-compat but the API today only validates the
+      // A/B subset (see UpdateClassSubjectsDto Issue #72 fields).
+      const weekTypes = this.deriveLessonWeekTypes(
+        cs.cycleLength,
+        cs.cycleSlotMask,
+        abWeekEnabled,
+      );
+
       for (let i = 0; i < cs.weeklyHours; i++) {
-        lessons.push({
-          id: `${cs.id}-${i}`,
-          subjectId: cs.subject.id,
-          subjectName: cs.subject.name,
-          teacherId,
-          teacherName,
-          classId: cs.schoolClass.id,
-          className: cs.schoolClass.name,
-          groupId: cs.groupId,
-          studentCount: 0, // derived from class size if needed
-          preferDoublePeriod: cs.preferDoublePeriod,
-          requiredRoomType,
-          requiredEquipment: [],
-          // Issue #67: pass the class's home room through so the Java
-          // homeRoomPreference soft constraint can fire. null falls back
-          // to the pre-#67 behavior (no preference, solver minimizes other
-          // constraints freely).
-          homeRoomId: cs.schoolClass.homeRoomId,
-          weekType: 'BOTH',
-        });
+        for (const weekType of weekTypes) {
+          lessons.push({
+            id: `${cs.id}-${i}-${weekType}`,
+            subjectId: cs.subject.id,
+            subjectName: cs.subject.name,
+            teacherId,
+            teacherName,
+            classId: cs.schoolClass.id,
+            className: cs.schoolClass.name,
+            groupId: cs.groupId,
+            studentCount: 0, // derived from class size if needed
+            preferDoublePeriod: cs.preferDoublePeriod,
+            requiredRoomType,
+            requiredEquipment: [],
+            // Issue #67: pass the class's home room through so the Java
+            // homeRoomPreference soft constraint can fire. null falls back
+            // to the pre-#67 behavior (no preference, solver minimizes other
+            // constraints freely).
+            homeRoomId: cs.schoolClass.homeRoomId,
+            weekType,
+          });
+        }
       }
     }
 
     return lessons;
+  }
+
+  /**
+   * Issue #72: map ClassSubject rhythm (cycleLength + cycleSlotMask) to
+   * the list of lesson weekTypes the solver needs to schedule. Every
+   * weekly hour of a ClassSubject is expanded once per returned weekType,
+   * so a "BOTH" subject on an A/B school yields 2× lessons (one A, one
+   * B) — those are independently scheduled by the solver but constrained
+   * to land in the matching timeslot via the new weekTypeCompatibility
+   * Java constraint.
+   *
+   *   - cycleLength <= 1 OR mask null OR mask covers every cycle slot
+   *     → every-week behaviour. abWeekEnabled=true splits into A+B;
+   *       abWeekEnabled=false collapses to a single BOTH lesson.
+   *   - cycleLength == 2, mask == 0b01 → A-week only.
+   *   - cycleLength == 2, mask == 0b10 → B-week only.
+   *   - cycleLength > 2 → forward-compat fallback to every-week (no UI yet).
+   */
+  private deriveLessonWeekTypes(
+    cycleLength: number,
+    cycleSlotMask: number | null,
+    abWeekEnabled: boolean,
+  ): Array<'BOTH' | 'A' | 'B'> {
+    // Default / "every week"
+    if (cycleLength <= 1 || cycleSlotMask == null) {
+      return abWeekEnabled ? ['A', 'B'] : ['BOTH'];
+    }
+    if (cycleLength === 2) {
+      const aActive = (cycleSlotMask & 0b01) !== 0;
+      const bActive = (cycleSlotMask & 0b10) !== 0;
+      if (aActive && bActive) {
+        return abWeekEnabled ? ['A', 'B'] : ['BOTH'];
+      }
+      if (aActive) return ['A'];
+      if (bActive) return ['B'];
+      // mask=0 — should have been rejected by the service validator, but
+      // fall back to every-week rather than emitting zero lessons.
+      return abWeekEnabled ? ['A', 'B'] : ['BOTH'];
+    }
+    // n>2 cycles not yet emitted by the API; expand as every-week so
+    // unknown rhythms never silently drop subjects from the plan.
+    return abWeekEnabled ? ['A', 'B'] : ['BOTH'];
   }
 
   /**

--- a/apps/api/src/modules/timetable/timetable.controller.ts
+++ b/apps/api/src/modules/timetable/timetable.controller.ts
@@ -54,7 +54,7 @@ export class TimetableController {
 
   @Get('constraint-catalog')
   @CheckPermissions({ action: 'read', subject: 'timetable' })
-  @ApiOperation({ summary: 'Get the static catalog of all 15 solver constraints (6 HARD + 9 SOFT)' })
+  @ApiOperation({ summary: 'Get the static catalog of all 16 solver constraints (7 HARD + 9 SOFT)' })
   @ApiResponse({ status: 200, description: 'Constraint catalog' })
   getConstraintCatalog() {
     return CONSTRAINT_CATALOG;

--- a/apps/api/src/modules/timetable/timetable.service.spec.ts
+++ b/apps/api/src/modules/timetable/timetable.service.spec.ts
@@ -72,6 +72,13 @@ describe('TimetableService', () => {
     timetableLesson: {
       createMany: vi.fn().mockResolvedValue({ count: 5 }),
     },
+    // Issue #72: handleCompletion now resolves classSubject.teacherId
+    // through a single batch query before INSERT. Default mock returns
+    // an empty list so the handler falls back to teacherId='' (the
+    // legacy behaviour) and the existing assertions still pass.
+    classSubject: {
+      findMany: vi.fn().mockResolvedValue([]),
+    },
     $transaction: vi.fn().mockImplementation((args: any[]) => Promise.all(args)),
   };
 
@@ -249,7 +256,7 @@ describe('TimetableService', () => {
         elapsedSeconds: 120,
         lessons: [
           {
-            lessonId: 'cs-1-0',
+            lessonId: 'cs-1-0-BOTH',
             timeslotId: 'ts-1',
             roomId: 'room-1',
             dayOfWeek: 'MONDAY',
@@ -257,7 +264,7 @@ describe('TimetableService', () => {
             weekType: 'BOTH',
           },
           {
-            lessonId: 'cs-1-1',
+            lessonId: 'cs-1-1-BOTH',
             timeslotId: 'ts-2',
             roomId: 'room-1',
             dayOfWeek: 'MONDAY',

--- a/apps/api/src/modules/timetable/timetable.service.ts
+++ b/apps/api/src/modules/timetable/timetable.service.ts
@@ -154,27 +154,92 @@ export class TimetableService {
       },
     });
 
-    // Persist lesson assignments
+    // Persist lesson assignments.
+    //
+    // The lessonId carries the source ClassSubject id plus an index and the
+    // weekType variant:
+    //
+    //   `${classSubjectId}-${i}-${weekType}`
+    //
+    // where weekType ∈ {BOTH, A, B}. The legacy parser (Phase 14) called
+    // `lastIndexOf('-')` and dropped only the index suffix, which broke when
+    // Issue #72 introduced the trailing `-${weekType}` segment — the prefix
+    // produced was `${classSubjectId}-${i}` and the FK-less classSubjectId
+    // column got polluted with non-existent ids. The regex below pins the
+    // expected suffix shape explicitly.
+    //
+    // Issue #71 follow-up: also fetch the assigned teacherId from the
+    // ClassSubject record so persisted TimetableLessons carry a real
+    // teacher reference instead of the legacy hardcoded ''. The solver
+    // already respects the assignment for conflict + availability; this
+    // line is what surfaces it in the /timetable UI.
     if (result.lessons && result.lessons.length > 0) {
-      const lessonRecords = result.lessons.map((lesson: SolvedLessonDto) => {
-        // Parse classSubjectId from lessonId format "classSubjectId-index"
-        const lastDash = lesson.lessonId.lastIndexOf('-');
-        const classSubjectId = lesson.lessonId.substring(0, lastDash);
+      const lessonIdRegex = /^(.+)-(\d+)-(BOTH|A|B)$/;
+      const parsed = result.lessons
+        .map((lesson: SolvedLessonDto) => {
+          const match = lesson.lessonId.match(lessonIdRegex);
+          if (!match) {
+            this.logger.error(
+              `Unparseable lessonId from solver, skipping: ${lesson.lessonId}`,
+            );
+            return null;
+          }
+          return {
+            lesson,
+            classSubjectId: match[1],
+          };
+        })
+        .filter(
+          (
+            entry,
+          ): entry is { lesson: SolvedLessonDto; classSubjectId: string } =>
+            entry !== null,
+        );
 
-        return {
-          runId,
-          classSubjectId,
-          teacherId: '', // Teacher assigned by solver, stored in lessonId context
-          roomId: lesson.roomId,
-          dayOfWeek: lesson.dayOfWeek as any,
-          periodNumber: lesson.periodNumber,
-          weekType: lesson.weekType,
-        };
-      });
+      if (parsed.length < result.lessons.length) {
+        this.logger.warn(
+          `Skipped ${
+            result.lessons.length - parsed.length
+          } lessons with unparseable ids (run ${runId})`,
+        );
+      }
 
-      await this.prisma.timetableLesson.createMany({
-        data: lessonRecords,
+      // Resolve teacherIds in a single query keyed by the parsed
+      // classSubjectIds. Subjects without an assigned teacher fall back to
+      // '' so the NOT-NULL teacher_id column stays satisfied (legacy
+      // behaviour pre-#71/#72).
+      const csIds = Array.from(new Set(parsed.map((p) => p.classSubjectId)));
+      const csRows = await this.prisma.classSubject.findMany({
+        where: { id: { in: csIds } },
+        select: { id: true, teacherId: true },
       });
+      const teacherByCs = new Map(
+        csRows.map((cs) => [cs.id, cs.teacherId ?? '']),
+      );
+
+      const lessonRecords = parsed.map(({ lesson, classSubjectId }) => ({
+        runId,
+        classSubjectId,
+        teacherId: teacherByCs.get(classSubjectId) ?? '',
+        roomId: lesson.roomId,
+        dayOfWeek: lesson.dayOfWeek as any,
+        periodNumber: lesson.periodNumber,
+        weekType: lesson.weekType,
+      }));
+
+      if (lessonRecords.length > 0) {
+        try {
+          await this.prisma.timetableLesson.createMany({
+            data: lessonRecords,
+          });
+        } catch (err) {
+          this.logger.error(
+            `createMany failed for run ${runId} (${lessonRecords.length} records): ${(err as Error).message}`,
+            (err as Error).stack,
+          );
+          throw err;
+        }
+      }
 
       this.logger.log(
         `Stored ${lessonRecords.length} lesson assignments for run ${runId}`,

--- a/apps/solver/src/main/java/at/schoolflow/solver/constraints/TimetableConstraintProvider.java
+++ b/apps/solver/src/main/java/at/schoolflow/solver/constraints/TimetableConstraintProvider.java
@@ -49,6 +49,13 @@ public class TimetableConstraintProvider implements ConstraintProvider {
                 studentGroupConflict(constraintFactory),
                 roomTypeRequirement(constraintFactory),
                 classTimeslotRestriction(constraintFactory),
+                // Issue #72: hard-enforces that lesson.weekType matches its
+                // assigned timeslot.weekType. The Lesson.isWeekCompatible
+                // helper has shipped for months but no constraint consumed
+                // it — the solver could freely place an A-week lesson into
+                // a B-week slot. With the API now emitting per-week lesson
+                // variants this constraint pins them to the matching slot.
+                weekTypeCompatibility(constraintFactory),
                 // Soft constraints (weights from TimetableConstraintConfiguration)
                 noSameSubjectDoubling(constraintFactory),
                 balancedWeeklyDistribution(constraintFactory),
@@ -143,6 +150,22 @@ public class TimetableConstraintProvider implements ConstraintProvider {
                 .filter(lesson -> !lesson.getRequiredRoomType().equals(lesson.getRoom().getRoomType()))
                 .penalizeConfigurable()
                 .asConstraint("Room type requirement");
+    }
+
+    /**
+     * Issue #72: a lesson's weekType must match the assigned timeslot's
+     * weekType. BOTH is the wildcard on either side (a BOTH lesson fits
+     * any timeslot; a BOTH timeslot accepts any lesson). The matching
+     * logic itself lives on {@link Lesson#isWeekCompatible} and is unit-
+     * tested in ConstraintTest; this constraint is the missing wiring
+     * that turns that helper into actual solver behaviour.
+     */
+    public Constraint weekTypeCompatibility(ConstraintFactory constraintFactory) {
+        return constraintFactory
+                .forEach(Lesson.class)
+                .filter(lesson -> !lesson.isWeekCompatible(lesson.getTimeslot()))
+                .penalizeConfigurable()
+                .asConstraint("Week type compatibility");
     }
 
     /**

--- a/apps/solver/src/main/java/at/schoolflow/solver/domain/TimetableConstraintConfiguration.java
+++ b/apps/solver/src/main/java/at/schoolflow/solver/domain/TimetableConstraintConfiguration.java
@@ -57,6 +57,12 @@ public class TimetableConstraintConfiguration {
     @ConstraintWeight("Class timeslot restriction")
     private HardSoftScore classTimeslotRestrictionWeight = HardSoftScore.ONE_HARD;
 
+    // Issue #72: hard constraint pinning each lesson to a timeslot whose
+    // weekType is compatible (BOTH wildcards both sides, otherwise an
+    // exact match). The matching logic lives on Lesson.isWeekCompatible.
+    @ConstraintWeight("Week type compatibility")
+    private HardSoftScore weekTypeCompatibilityWeight = HardSoftScore.ONE_HARD;
+
     // Soft constraints (configurable weights)
     @ConstraintWeight("No same subject doubling")
     private HardSoftScore noSameSubjectDoublingWeight = HardSoftScore.ofSoft(10);

--- a/apps/web/e2e/admin-solver-tuning-catalog.spec.ts
+++ b/apps/web/e2e/admin-solver-tuning-catalog.spec.ts
@@ -27,16 +27,17 @@ test.describe('Phase 14 — Solver-Tuning Catalog (Tab 1)', () => {
   }) => {
     await page.goto('/admin/solver-tuning?tab=constraints');
 
-    // Section headers — locked at 6 HARD + 9 SOFT in CONSTRAINT_CATALOG (Plan 14-01 invariant).
+    // Section headers — locked at 7 HARD + 9 SOFT in CONSTRAINT_CATALOG
+    // (Plan 14-01 baseline + Issue #72 weekTypeCompatibility hard).
     await expect(
-      page.getByRole('heading', { name: 'Hard-Constraints (6)' }),
+      page.getByRole('heading', { name: 'Hard-Constraints (7)' }),
     ).toBeVisible();
     await expect(
       page.getByRole('heading', { name: 'Soft-Constraints (9)' }),
     ).toBeVisible();
 
     // Row count via the locked Plan 14-02 selector `data-severity`.
-    await expect(page.locator('[data-severity="HARD"]')).toHaveCount(6);
+    await expect(page.locator('[data-severity="HARD"]')).toHaveCount(7);
     await expect(page.locator('[data-severity="SOFT"]')).toHaveCount(9);
 
     // Hard rows do NOT have an "Gewichtung bearbeiten" edit button.

--- a/apps/web/src/components/admin/solver-tuning/ConstraintCatalogTab.tsx
+++ b/apps/web/src/components/admin/solver-tuning/ConstraintCatalogTab.tsx
@@ -7,7 +7,7 @@ import { ConstraintCatalogRow } from './ConstraintCatalogRow';
 /**
  * Phase 14-02 Tab 1 "Constraints" (SOLVER-01).
  *
- * Renders the static 15-entry catalog (6 HARD + 9 SOFT) with section
+ * Renders the static 16-entry catalog (7 HARD + 9 SOFT) with section
  * separator. Reads from `CONSTRAINT_CATALOG` (shared package, no network)
  * for snappy first paint; the `useConstraintCatalog` query runs in the
  * background as a backend-agreement sanity check (the API and shared
@@ -37,8 +37,8 @@ export function ConstraintCatalogTab({ schoolId, onNavigateToWeight }: Props) {
           className="text-lg font-semibold"
         >
           {/* Locked headers per UI-SPEC §Inline micro-copy. Count is fixed at
-              6 HARD + 9 SOFT in CONSTRAINT_CATALOG (Plan 14-01 invariant). */}
-          Hard-Constraints (6)
+              7 HARD + 9 SOFT in CONSTRAINT_CATALOG (Plan 14-01 + #72). */}
+          Hard-Constraints (7)
         </h2>
         <p className="text-sm text-muted-foreground">
           Diese Regeln sind im Solver fest verankert und immer aktiv.

--- a/apps/web/src/lib/hooks/useConstraintCatalog.ts
+++ b/apps/web/src/lib/hooks/useConstraintCatalog.ts
@@ -2,7 +2,8 @@ import { useQuery } from '@tanstack/react-query';
 import { solverTuningApi } from '@/lib/api/solver-tuning';
 
 /**
- * Phase 14-02: read the 15-entry CONSTRAINT_CATALOG (6 HARD + 9 SOFT).
+ * Phase 14-02: read the 16-entry CONSTRAINT_CATALOG (7 HARD + 9 SOFT). The 7th
+ * hard constraint "Week type compatibility" was added in #72.
  *
  * Cache: schoolId-scoped (the endpoint itself is school-scoped per Plan 14-01).
  * staleTime: Infinity — the catalog is a static mirror of the Java solver

--- a/packages/shared/src/constraint-catalog.ts
+++ b/packages/shared/src/constraint-catalog.ts
@@ -1,5 +1,5 @@
 /**
- * Static catalog of all 15 solver constraints (6 HARD + 9 SOFT).
+ * Static catalog of all 16 solver constraints (7 HARD + 9 SOFT).
  *
  * Frontend mirror of apps/api/src/modules/timetable/constraint-catalog.ts (TS source-of-truth).
  * The ultimate canonical source is the Java solver:
@@ -21,7 +21,7 @@ export interface ConstraintCatalogEntry {
 }
 
 export const CONSTRAINT_CATALOG: ConstraintCatalogEntry[] = [
-  // === HARD (6) ===
+  // === HARD (7) ===
   {
     name: 'Teacher conflict',
     displayName: 'Lehrkraft-Konflikt',
@@ -63,6 +63,16 @@ export const CONSTRAINT_CATALOG: ConstraintCatalogEntry[] = [
     description: 'Klassen dürfen nicht in gesperrten Perioden unterrichtet werden (siehe Tab Klassen-Sperrzeiten).',
     severity: 'HARD',
     source: 'TimetableConstraintProvider.java#classTimeslotRestriction',
+  },
+  {
+    // Issue #72: hard constraint pinning each lesson to a timeslot whose
+    // weekType is compatible. Activated when the school has A/B-week
+    // rhythms enabled and at least one ClassSubject opts in.
+    name: 'Week type compatibility',
+    displayName: 'A/B-Wochen-Zuordnung',
+    description: 'Stunden mit A- oder B-Wochen-Rhythmus müssen in der passenden Wochenvariante liegen.',
+    severity: 'HARD',
+    source: 'TimetableConstraintProvider.java#weekTypeCompatibility',
   },
 
   // === SOFT (9 — 8 existing + 1 NEW for Phase 14 Task 5) ===


### PR DESCRIPTION
Closes #72.

## Summary

Issue #72 dokumentierte einen latenten Bug: `solver-input.service.ts:321` hardcodierte `weekType: 'BOTH'` für jede Lesson. Auf einer Schule mit `abWeekEnabled=false` (heutiger Seed-Stand) unsichtbar — aber sobald jemand `abWeekEnabled=true` flippte, hätte der Solver Lessons mit `weekType=BOTH` gegen Timeslots mit A/B-Varianten geschickt, ohne dass irgendein Constraint den Mismatch bestrafte. Per-Week-Semantik effektiv tot.

Dieser PR implementiert **Option A** aus dem Issue: ClassSubject bekommt per-Row Rhythmus-Felder (`cycleLength`, `cycleSlotMask`), der Solver-Input expandiert Lessons pro aktivem Cycle-Slot, und ein neues HARD-Constraint im Java-Solver verankert die Wochen-Zuordnung.

## Aufbau (3 atomare Commits)

1. **`feat(class-subject): A/B-Wochen-Rhythmus schema + DTO validation (#72)`** — Schema + Migration + DTO + Service-Invariante
2. **`feat(solver): per-rhythm lesson expansion + weekTypeCompatibility constraint (#72)`** — Solver-Input + Java-Constraint + lessonId-Parser + 8 Regression-Tests
3. **`feat(catalog): expose weekTypeCompatibility — 7 HARD + 9 SOFT (#72)`** — Constraint-Katalog API + Shared + Web + E2E-Spec

## Regression-Lock (CLAUDE.md hard rule)

8 neue Unit-Tests in `apps/api/src/modules/timetable/solver-input.service.spec.ts` (Describe-Block `SolverInputService.deriveLessonWeekTypes (Issue #72 regression)`).

**Der Canary-Test:**
```ts
it('abWeekEnabled=true + cycleLength=1 → [A, B] (catches the original BOTH-hardcode bug)', () => {
  expect(derive(1, null, true)).toEqual(['A', 'B']);
});
```

Wäre vor #72 rot gewesen: das Hardcoding-BOTH hätte für jede Konfiguration `['BOTH']` produziert. Mit dem strikten `git stash` + Replay würde der Test mit `TypeError: derive is not a function` rot — strict-RED, weil die Funktion erst durch den Fix entstand. Der observable Vertrag (A/B-aware Lesson-Emission) ist die Regression-Garantie.

Plus: E2E-Spec `admin-solver-tuning-catalog.spec.ts` von 6→7 HARD-Constraints angehoben. Diese Spec hatte den Pre-PR-WIP bereits beim lokalen Playwright-Run gefangen — wäre auf der alten 6 stehengeblieben hätten alle zukünftigen PRs ein Inkonsistenz-Red.

## UI

Bewusst out-of-scope für diesen PR: das Bearbeiten von `cycleLength`/`cycleSlotMask` in der UI (`StundentafelTab`-Row). Daten + Solver-Pipeline + Constraint sind sauber, Felder sind via PUT erreichbar, Defaults brechen nichts. UI folgt in separatem PR — Trennung Backend-Plumbing vs. UI-Editor.

## Test plan

- [x] `pnpm --filter @schoolflow/api test` — 767 passed (+8 für #72)
- [x] `pnpm --filter @schoolflow/api exec tsc --noEmit` — clean
- [x] `pnpm --filter @schoolflow/web exec tsc -b --force` — clean
- [x] `pnpm --filter @schoolflow/shared exec tsc -p tsconfig.json --noEmit` — clean
- [x] Migration `20260512104022_add_class_subject_cycle_fields` auf lokaler Dev-DB applied
- [ ] CI Playwright E2E grün — neu hinzugekommener Catalog-Spec-Check `Hard-Constraints (7)` muss durchgehen

## D3-Compliance

Per `CLAUDE.md` D3: PR bleibt offen bis CI vollständig grün. Kein `--admin`-Override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)