### PR TITLE
fix(e2e): stabilize REGRESSION-DND-TRANSFORM (drag-active assertion)

### DIFF
--- a/apps/web/e2e/admin-timetable-edit-dnd.spec.ts
+++ b/apps/web/e2e/admin-timetable-edit-dnd.spec.ts
@@ -241,31 +241,80 @@ test.describe('Phase 04 regression — DnD timetable-edit (commit de9ee2b)', () 
       .first();
     await expect(sourceLesson).toBeVisible();
 
-    const sBox = await sourceLesson.boundingBox();
-    if (!sBox) throw new Error('source bounding box missing');
+    // Resolve the OUTER useDraggable element by walking up to the nearest
+    // ancestor with `aria-roledescription="draggable"` — the attribute is
+    // emitted by useDraggable's `attributes` object and is the explicit
+    // proof that React has committed the draggable wrapper AND the
+    // setNodeRef callback has fired so dnd-kit knows where to attach its
+    // pointerdown listener. Waiting on `sourceLesson` (the inner text
+    // node) alone is not enough: in CI under load the inner text can be
+    // rendered while the outer DraggableLesson is still pending its
+    // first useEffect tick, so the pointerdown lands on an element that
+    // does not yet route through the dnd-kit sensor and the drag is
+    // silently lost (Issue tracking the CI flake recurrence: see PR
+    // description for the original 25757844169 evidence).
+    const draggableSource = sourceLesson.locator(
+      'xpath=ancestor::*[@aria-roledescription="draggable"][1]',
+    );
+    await expect(draggableSource).toBeVisible();
+
+    // Drive coordinates off the OUTER draggable, not the inner text. The
+    // text's bbox is a small subset of the cell and centering on it left
+    // little margin against subpixel layout drift; the outer bbox is the
+    // actual hit target dnd-kit registered.
+    const sBox = await draggableSource.boundingBox();
+    if (!sBox) throw new Error('draggable bounding box missing');
     const sx = sBox.x + sBox.width / 2;
     const sy = sBox.y + sBox.height / 2;
 
     await page.mouse.move(sx, sy);
     await page.mouse.down();
+    // Give React one microtask tick to commit any state triggered by the
+    // pointerdown handler before the threshold-crossing pointermove
+    // arrives. Cheap insurance against the CI-load race where the
+    // pointerdown event is delivered before dnd-kit's document-level
+    // pointermove listener has been attached.
+    await page.waitForTimeout(50);
     // Cross the 8px PointerSensor activation threshold and STOP — do NOT
     // release. We want to inspect the DOM mid-drag.
     await page.mouse.move(sx + 30, sy + 30, { steps: 8 });
 
-    // While drag is active, DraggableLesson sets `data-dragging-source`
-    // on its inner cell (DraggableLesson.tsx:66). The OUTER element (the
-    // one carrying useDraggable's setNodeRef) is the parent of the inner
-    // cell — that outer element is where the regressed CSS transform
-    // would be applied. Wait until the inner attribute appears so the
-    // assertion below cannot race against drag-start.
-    const innerSource = page.locator(
-      `[data-dragging-source="${fixture.lessonId}"]`,
-    );
+    // Active-drag detection via `aria-pressed="true"` on the OUTER
+    // useDraggable element. dnd-kit's `attributes` object sets
+    // `aria-pressed` to true while the draggable's own `isDragging`
+    // is true — same source-of-truth as the inner-cell
+    // `data-dragging-source` attribute, but bound to the element the
+    // test already located instead of a separate selector keyed on
+    // `fixture.lessonId`.
+    //
+    // The pre-fix inner-data-attribute approach was unreliable for two
+    // reasons. (1) Playwright's `toBeVisible` heuristics returned
+    // false intermittently under CI load, likely because the
+    // DragOverlay portal momentarily occludes the source cell's bbox
+    // and Playwright's visibility check briefly considered it
+    // offscreen. (2) The selector keyed on `fixture.lessonId` could
+    // mismatch the lessonId actually rendered in the grid when the
+    // page-query saw an in-flight DB state from a partially-completed
+    // cleanup of the previous test in a repeat-each batch (a stale
+    // ClassSubject still pointed the page-fetched lesson back to the
+    // previous run's id while the fixture variable already held the
+    // new one). The aria-pressed signal sidesteps both: it is
+    // intrinsic to the actually-dragged element regardless of which
+    // lessonId rendered.
+    //
+    // Timeout lifted to 20s (vs the global expect default of 10s) so
+    // a stalled CI worker does not RED-flag a drag that simply needs
+    // an extra rerender tick to commit the attribute.
     await expect(
-      innerSource,
-      'drag must be active (inner cell carries data-dragging-source attribute)',
-    ).toBeVisible();
-    const outerSource = innerSource.locator('xpath=..');
+      draggableSource,
+      'drag must be active (outer draggable carries aria-pressed=true)',
+    ).toHaveAttribute('aria-pressed', 'true', { timeout: 20_000 });
+
+    // The outer draggable IS the setNodeRef-bearing element; this is
+    // where any regressed CSS transform would land (DragOverlay handles
+    // the visual preview separately via portal, so the original must
+    // stay put).
+    const outerSource = draggableSource;
 
     const inlineTransform = await outerSource.evaluate(
       (el: HTMLElement) => el.style.transform || '',


### PR DESCRIPTION
## Summary

Stabilizes the Phase 04 DnD-regression spec's "no CSS transform on source during drag" assertion that flaked at ~33% locally under \`--repeat-each\` and went red on PR #77's CI [25757844169](https://github.com/martinvidec/openaustria-school-flow/actions/runs/25757844169) without any DnD touchpoint.

## Root cause

Debug dumps from \`--repeat-each=3\` runs revealed two compounding races:

1. **fixture.lessonId vs rendered lessonId mismatch.** The "drag active" check used \`[data-dragging-source="\${fixture.lessonId}"]\`. The DOM did have the data attribute, but on a different UUID than \`fixture.lessonId\` — the page-fetched timetable lesson saw an in-flight DB state from a partially-completed cleanup of the previous repeat. The fixture variable already held the new lesson id, the page still showed the old one.

2. **Text-bbox vs draggable-bbox.** \`sourceLesson\` targeted a \`<text>\` node inside the cell. Its bbox is a small subset of the outer draggable's bbox; mouse coordinates centered on the text-node center left little margin against subpixel layout drift.

## Fix

- **aria-pressed signal** instead of the lessonId-keyed inner attribute. dnd-kit's \`attributes\` object sets \`aria-pressed="true"\` on the OUTER useDraggable element from the same \`isDragging\` source that gates the inner \`data-dragging-source\`. The check stays semantically identical but the selector is intrinsic to the element the test already resolved (via \`aria-roledescription="draggable"\` ancestor walk), so no fixture-id round-trip.
- **Drive mouse off the outer draggable's bbox**, not the text node.
- **50ms post-pointerdown settle** as cheap insurance against the CI-load race where dnd-kit's document-level pointermove listener attaches after the threshold-crossing pointermove arrives.
- **Timeout lifted to 20s** for the activation wait (vs the global 10s default) so a stalled CI worker does not RED-flag a drag that only needs an extra rerender tick.

## Verification

\`\`\`bash
pnpm --filter @schoolflow/web exec playwright test \\
  admin-timetable-edit-dnd.spec.ts:228 --project=desktop --repeat-each=10
\`\`\`

- **Before fix**: ~33% failure rate (2-3 of 10 fail with \`element(s) not found\` for the data-dragging-source locator)
- **After fix**: 10/10 green

## D3-compliance

Per \`CLAUDE.md\` D3 (Main bleibt sauber, merge erst nach grünem CI):
- This PR is the stabilization-not-skip path the directive prescribes for flaky tests.
- Will not be merged before its own CI is green.

## Unblocks

PR #77 (A/B-Wochen-Rhythmus für ClassSubject, Issue #72) — currently CI-red purely because of this flake inherited from main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)