### PR TITLE
chore(e2e): pre-run sweep of E2E leftover rows

### DIFF
--- a/apps/web/e2e/e2e-sweep-canary.spec.ts
+++ b/apps/web/e2e/e2e-sweep-canary.spec.ts
@@ -1,0 +1,142 @@
+/**
+ * Regression-Lock for #79 — verifies `sweepE2ELeftovers()` actually
+ * removes the row types it claims to. Per the CLAUDE.md Bug-Fix-
+ * Regression-Schutz rule: every fix ships with an E2E that would have
+ * caught the original symptom.
+ *
+ * Without the sweep helper this test would fail because the canary row
+ * inserted in the arrange step would still be visible after the call.
+ *
+ * Strategy: insert one `E2E-CANARY-…` row per swept table directly via
+ * Prisma (mirroring the orphan-year fixture pattern), call the sweep,
+ * and assert every canary is gone. Direct DB I/O — no HTTP — so the
+ * sweep helper is exercised in the same path globalSetup uses.
+ *
+ * Chromium-only: matches the parallel-cleanup race-family precedent
+ * (`project_e2e_parallel_cleanup_race_family.md`). Two browser projects
+ * inserting + sweeping concurrently would race each other.
+ */
+import 'dotenv/config';
+import { config as dotenvConfig } from 'dotenv';
+import { test, expect } from '@playwright/test';
+import { createRequire } from 'node:module';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { sweepE2ELeftovers, totalSwept } from './helpers/sweep-leftovers';
+import { SEED_SCHOOL_UUID } from './fixtures/seed-uuids';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+dotenvConfig({ path: path.resolve(__dirname, '../../../.env') });
+
+const require = createRequire(import.meta.url);
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { PrismaClient } = require('../../api/dist/config/database/generated/client.js') as {
+  PrismaClient: new (opts?: { adapter?: unknown }) => {
+    person: { create: (args: { data: Record<string, unknown> }) => Promise<{ id: string }> };
+    schoolClass: { create: (args: { data: Record<string, unknown> }) => Promise<{ id: string }> };
+    subject: { create: (args: { data: Record<string, unknown> }) => Promise<{ id: string }> };
+    room: { create: (args: { data: Record<string, unknown> }) => Promise<{ id: string }> };
+    dsfaEntry: { create: (args: { data: Record<string, unknown> }) => Promise<{ id: string }> };
+    schoolYear: {
+      findFirst: (args: {
+        where: Record<string, unknown>;
+        select?: Record<string, true>;
+      }) => Promise<{ id: string } | null>;
+    };
+    $disconnect: () => Promise<void>;
+  };
+};
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { PrismaPg } = require('../../api/node_modules/@prisma/adapter-pg') as {
+  PrismaPg: new (opts: { connectionString: string }) => unknown;
+};
+
+test.describe('Issue #79 — E2E sweep regression lock', () => {
+  test.skip(
+    ({ isMobile }) => isMobile,
+    'Sweep is viewport-agnostic — desktop chromium is enough.',
+  );
+  test.skip(
+    ({ browserName }) => browserName !== 'chromium',
+    'Parallel browser projects would race on the canary rows (#79 race-family precedent).',
+  );
+
+  test('CANARY-SWEEP-01: sweepE2ELeftovers removes E2E-prefixed rows in persons / school_classes / subjects / rooms / dsfa_entries', async () => {
+    const prisma = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: process.env.DATABASE_URL ?? '' }),
+    });
+
+    const ts = Date.now();
+    const personFirstName = `E2E-CANARY-PERSON-${ts}`;
+    const classNameLit = `E2E-CANARY-CLASS-${ts}`;
+    const subjectName = `E2E-CANARY-SUB-${ts}`;
+    const roomName = `E2E-CANARY-ROOM-${ts}`;
+    const dsfaTitle = `e2e-15-canary-dsfa-${ts}`;
+
+    try {
+      const year = await prisma.schoolYear.findFirst({
+        where: { schoolId: SEED_SCHOOL_UUID },
+        select: { id: true },
+      });
+      expect(year, 'seed school must have at least one SchoolYear').not.toBeNull();
+      const schoolYearId = year!.id;
+
+      await prisma.person.create({
+        data: {
+          schoolId: SEED_SCHOOL_UUID,
+          personType: 'STUDENT',
+          firstName: personFirstName,
+          lastName: 'Canary',
+        },
+      });
+      await prisma.schoolClass.create({
+        data: {
+          schoolId: SEED_SCHOOL_UUID,
+          name: classNameLit,
+          yearLevel: 1,
+          schoolYearId,
+        },
+      });
+      await prisma.subject.create({
+        data: {
+          schoolId: SEED_SCHOOL_UUID,
+          name: subjectName,
+          shortName: `EC-${ts.toString().slice(-4)}`,
+          subjectType: 'PFLICHT',
+        },
+      });
+      await prisma.room.create({
+        data: {
+          schoolId: SEED_SCHOOL_UUID,
+          name: roomName,
+          roomType: 'KLASSENZIMMER',
+          capacity: 20,
+        },
+      });
+      await prisma.dsfaEntry.create({
+        data: {
+          schoolId: SEED_SCHOOL_UUID,
+          title: dsfaTitle,
+          description: 'canary',
+          dataCategories: [],
+        },
+      });
+
+      // Pre-sweep assertion — canary rows MUST be visible. If this fails
+      // the test setup is broken, not the sweep.
+      const preCounts = await sweepE2ELeftovers();
+      const preTotal = totalSwept(preCounts);
+      expect(
+        preTotal,
+        'sweep should have found at least the 5 canary rows we just inserted',
+      ).toBeGreaterThanOrEqual(5);
+
+      // Post-sweep — re-running sweep should find nothing.
+      const postCounts = await sweepE2ELeftovers();
+      expect(totalSwept(postCounts), 'sweep is idempotent — second run is a no-op').toBe(0);
+    } finally {
+      await prisma.$disconnect();
+    }
+  });
+});

--- a/apps/web/e2e/helpers/global-setup.ts
+++ b/apps/web/e2e/helpers/global-setup.ts
@@ -1,13 +1,25 @@
 /**
  * Phase 10.3 — Playwright globalSetup.
  *
- * Runs once before any worker spins up. Health-checks the dev stack so
- * Playwright fails fast with a clear message instead of the opaque
- * Keycloak redirect loop that happens when Vite or the API is down.
+ * Runs once before any worker spins up. Two responsibilities:
+ *
+ *   1. Health-checks the dev stack so Playwright fails fast with a clear
+ *      message instead of the opaque Keycloak redirect loop that happens
+ *      when Vite or the API is down.
+ *
+ *   2. Pre-run sweep of E2E leftover rows in the dev DB (#79). Per-spec
+ *      `afterEach` hooks delete their own rows, but a hard-killed run
+ *      skips `afterEach` and leaves E2E-prefixed rows in the live app DB.
+ *      Sweeping at the START of every session guarantees a clean slate
+ *      regardless of how the previous session ended.
+ *
+ * Opt-out: `E2E_SKIP_PRE_SWEEP=1` for the rare case of inspecting leftover
+ * rows mid-debug.
  *
  * Intentionally silent on success — CI logs stay readable.
  */
 import type { FullConfig } from '@playwright/test';
+import { sweepE2ELeftovers, totalSwept } from './sweep-leftovers';
 
 async function healthCheck(url: string, label: string, timeoutMs = 5_000): Promise<void> {
   const controller = new AbortController();
@@ -45,4 +57,16 @@ export default async function globalSetup(_config: FullConfig): Promise<void> {
     healthCheck(webUrl, 'Web/Vite'),
     healthCheck(solverUrl, '[E2E-PRECHECK] Timefold sidecar'),
   ]);
+
+  if (process.env.E2E_SKIP_PRE_SWEEP === '1') return;
+
+  const counts = await sweepE2ELeftovers();
+  const total = totalSwept(counts);
+  if (total > 0) {
+    const nonZero = Object.entries(counts)
+      .filter(([, n]) => n > 0)
+      .map(([tbl, n]) => `${tbl}=${n}`)
+      .join(', ');
+    console.log(`[e2e-sweep] removed ${total} leftover row(s): ${nonZero}`);
+  }
 }

--- a/apps/web/e2e/helpers/sweep-leftovers.ts
+++ b/apps/web/e2e/helpers/sweep-leftovers.ts
@@ -1,0 +1,197 @@
+/**
+ * Sweep helper — removes left-over E2E test data from the dev DB.
+ *
+ * Closes the cleanup gap described in #79: per-spec `afterEach` hooks
+ * delete their own rows, but a hard-killed run (Ctrl+C, OOM, CI cancel)
+ * skips `afterEach` and leaves E2E-prefixed rows in the live app DB.
+ *
+ * Hooked from `global-setup.ts` so every Playwright run starts clean
+ * regardless of how the previous run ended. Also exposed as a standalone
+ * script via `pnpm e2e:sweep`.
+ *
+ * Prisma-direct (not REST) because:
+ *   - Hits all tables in one pass, no per-resource list/delete round-trips.
+ *   - Uses FK cascades declared in `apps/api/prisma/schema.prisma`
+ *     (Person → Teacher/Student/Parent/GroupMembership/ConsentRecord;
+ *      SchoolClass → Group/ClassSubject; Subject → TeacherSubject; etc.)
+ *     so each `deleteMany` here implicitly handles its children.
+ *   - No admin token, no Keycloak round-trip — faster + works even when
+ *     Keycloak is slow to warm up.
+ *
+ * Mirrors the Prisma 7 adapter pattern from `fixtures/orphan-year.ts`.
+ */
+import 'dotenv/config';
+import { config as dotenvConfig } from 'dotenv';
+import { createRequire } from 'node:module';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+// Belt-and-braces dotenv — Playwright workers run with CWD=apps/web.
+dotenvConfig({ path: path.resolve(__dirname, '../../../../.env') });
+
+const require = createRequire(import.meta.url);
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { PrismaClient } = require('../../../api/dist/config/database/generated/client.js') as {
+  PrismaClient: new (opts?: { adapter?: unknown }) => PrismaLike;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { PrismaPg } = require('../../../api/node_modules/@prisma/adapter-pg') as {
+  PrismaPg: new (opts: { connectionString: string }) => unknown;
+};
+
+interface DeleteManyResult {
+  count: number;
+}
+interface PrismaModel {
+  deleteMany: (args: { where: Record<string, unknown> }) => Promise<DeleteManyResult>;
+}
+interface PrismaLike {
+  person: PrismaModel;
+  schoolClass: PrismaModel;
+  group: PrismaModel;
+  subject: PrismaModel;
+  room: PrismaModel;
+  resource: PrismaModel;
+  role: PrismaModel;
+  dsfaEntry: PrismaModel;
+  vvzEntry: PrismaModel;
+  retentionPolicy: PrismaModel;
+  constraintWeightOverride: PrismaModel;
+  permissionOverride: PrismaModel;
+  importJob: PrismaModel;
+  $disconnect: () => Promise<void>;
+}
+
+export type SweepCounts = Record<string, number>;
+
+/**
+ * Prefix conventions enforced by `apps/web/e2e/helpers/*.ts`:
+ *   - `E2E-…`  (uppercase) — every CRUD-style spec (Persons / Classes /
+ *     Groups / Subjects / Rooms / Resources / Roles / etc.).
+ *   - `e2e-15-…` (lowercase, Phase 15) — DSGVO admin specs
+ *     (`apps/web/e2e/helpers/dsgvo.ts:33`).
+ *
+ * Top-level entities only: cascade FKs handle the children (see schema
+ * `onDelete: Cascade` on Teacher/Student/Parent/Group/GroupMembership/
+ * ConsentRecord/ClassSubject/TeacherSubject/RoomBooking/ResourceBooking/
+ * Permission/UserRole).
+ *
+ * Deliberately NOT swept:
+ *   - `consent_records` — preserved by design in `dsgvo.ts:21-24` (state
+ *     machine: granted → withdrawn). Cascades via `personId` when the
+ *     E2E person is removed.
+ *   - `constraint_templates` — no name field to filter on; per-spec
+ *     cleanup-by-templateType is sufficient (`constraints.ts:121`).
+ *   - `audit_entries` — auditable trail; let retention policy handle them.
+ */
+export async function sweepE2ELeftovers(): Promise<SweepCounts> {
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    throw new Error(
+      'sweepE2ELeftovers: DATABASE_URL not set. Source .env or apps/api/.env first.',
+    );
+  }
+  const prisma = new PrismaClient({
+    adapter: new PrismaPg({ connectionString }),
+  });
+  const counts: SweepCounts = {};
+  try {
+    counts['persons'] = (
+      await prisma.person.deleteMany({
+        where: {
+          OR: [
+            { firstName: { startsWith: 'E2E-' } },
+            { lastName: { startsWith: 'E2E-' } },
+            { firstName: { startsWith: 'e2e-15-' } },
+            { lastName: { startsWith: 'e2e-15-' } },
+          ],
+        },
+      })
+    ).count;
+
+    counts['school_classes'] = (
+      await prisma.schoolClass.deleteMany({
+        where: { name: { startsWith: 'E2E-' } },
+      })
+    ).count;
+
+    counts['groups'] = (
+      await prisma.group.deleteMany({
+        where: { name: { startsWith: 'E2E-' } },
+      })
+    ).count;
+
+    counts['subjects'] = (
+      await prisma.subject.deleteMany({
+        where: { name: { startsWith: 'E2E-' } },
+      })
+    ).count;
+
+    counts['rooms'] = (
+      await prisma.room.deleteMany({
+        where: { name: { startsWith: 'E2E-' } },
+      })
+    ).count;
+
+    counts['resources'] = (
+      await prisma.resource.deleteMany({
+        where: { name: { startsWith: 'E2E-' } },
+      })
+    ).count;
+
+    counts['roles'] = (
+      await prisma.role.deleteMany({
+        where: { name: { startsWith: 'E2E-' } },
+      })
+    ).count;
+
+    counts['dsfa_entries'] = (
+      await prisma.dsfaEntry.deleteMany({
+        where: { title: { startsWith: 'e2e-15-' } },
+      })
+    ).count;
+
+    counts['vvz_entries'] = (
+      await prisma.vvzEntry.deleteMany({
+        where: { activityName: { startsWith: 'e2e-15-' } },
+      })
+    ).count;
+
+    counts['retention_policies'] = (
+      await prisma.retentionPolicy.deleteMany({
+        where: { dataCategory: { startsWith: 'e2e-15-' } },
+      })
+    ).count;
+
+    counts['constraint_weight_overrides'] = (
+      await prisma.constraintWeightOverride.deleteMany({
+        where: { constraintName: { startsWith: 'E2E-' } },
+      })
+    ).count;
+
+    counts['permission_overrides'] = (
+      await prisma.permissionOverride.deleteMany({
+        where: { reason: { startsWith: 'E2E-USR-' } },
+      })
+    ).count;
+
+    counts['import_jobs'] = (
+      await prisma.importJob.deleteMany({
+        where: { fileName: { startsWith: 'E2E-' } },
+      })
+    ).count;
+
+    return counts;
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+/** Total row count across all swept tables. Used by callers to decide whether to log. */
+export function totalSwept(counts: SweepCounts): number {
+  return Object.values(counts).reduce((sum, n) => sum + n, 0);
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,7 @@
     "test:e2e": "playwright test",
     "test:e2e:desktop": "playwright test --project=desktop",
     "test:e2e:mobile": "playwright test --project=mobile-375",
+    "e2e:sweep": "tsx scripts/e2e-sweep.ts",
     "lint": "echo lint-placeholder"
   },
   "dependencies": {
@@ -73,6 +74,7 @@
     "dotenv": "^17.4.2",
     "jsdom": "^29.0.1",
     "tailwindcss": "^4.2.0",
+    "tsx": "^4.21.0",
     "typescript": "~6.0.0",
     "vite": "^8.0.0",
     "vitest": "^4.1.0",

--- a/apps/web/scripts/e2e-sweep.ts
+++ b/apps/web/scripts/e2e-sweep.ts
@@ -1,0 +1,26 @@
+/**
+ * `pnpm e2e:sweep` — standalone sweep of E2E leftover rows in the dev DB.
+ *
+ * Same logic that runs in `globalSetup` before every Playwright session,
+ * exposed for ad-hoc use (e.g. cleaning up after a hard-killed UAT session
+ * before showing the app to a stakeholder). See #79.
+ */
+import { sweepE2ELeftovers, totalSwept } from '../e2e/helpers/sweep-leftovers';
+
+async function main(): Promise<void> {
+  const counts = await sweepE2ELeftovers();
+  const total = totalSwept(counts);
+  if (total === 0) {
+    console.log('e2e-sweep: no leftover rows (DB already clean).');
+    return;
+  }
+  console.log(`e2e-sweep: removed ${total} leftover row(s):`);
+  for (const [table, count] of Object.entries(counts)) {
+    if (count > 0) console.log(`  ${table.padEnd(28)} ${count}`);
+  }
+}
+
+main().catch((err) => {
+  console.error('e2e-sweep failed:', err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -346,6 +346,9 @@ importers:
       tailwindcss:
         specifier: ^4.2.0
         version: 4.2.2
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       typescript:
         specifier: ~6.0.0
         version: 6.0.2


### PR DESCRIPTION
## Summary

- Pre-run sweep of E2E leftover rows in `globalSetup` so every Playwright session starts clean, even after Ctrl+C / OOM / CI-cancel killed the previous run mid-flight.
- Standalone `pnpm e2e:sweep` script for ad-hoc cleanup.
- Canary regression spec per CLAUDE.md Bug-Fix-Regression-Schutz hard rule.

Closes #79.

## Why

Per-spec `afterEach` hooks do their job when tests finish normally. But when a run is hard-killed, `afterEach` never runs and `E2E-…` / `e2e-15-…` rows survive into the live dev DB. Today's check found 14 such leftovers from yesterday's killed runs (8 persons + 6 school_classes). They were visible in the app UI when the user opened the Eltern/Klassen views.

## How

- `apps/web/e2e/helpers/sweep-leftovers.ts` — Prisma-direct `deleteMany` over the top-level entities. Cascade FKs (declared `onDelete: Cascade` in `prisma/schema.prisma`) handle children (Teachers / Students / Parents / GroupMemberships / ConsentRecords / Groups / ClassSubjects / TeacherSubjects / Room+Resource bookings / Permissions / UserRoles).
- `apps/web/e2e/helpers/global-setup.ts` — invoke sweep AFTER health checks, so a missing API still fails fast with a clear message. Opt-out via `E2E_SKIP_PRE_SWEEP=1` for the rare mid-debug case.
- `apps/web/scripts/e2e-sweep.ts` + `e2e:sweep` package script — standalone CLI for ad-hoc use.
- `apps/web/e2e/e2e-sweep-canary.spec.ts` — inserts a canary in each of 5 swept tables, asserts the sweep removes them, and asserts idempotency on a second sweep. Chromium-only to avoid the parallel-cleanup race-family (see `project_e2e_parallel_cleanup_race_family.md`).

## Tradeoffs

- **Direct Prisma vs API DELETE:** Direct is faster, doesn't need a Keycloak round-trip, and handles all tables in one pass. Per-spec helpers still use the API to exercise the full request stack — only the safety-net sweep skips it.
- **Deliberately NOT swept:** `consent_records` (state machine, preserved by `dsgvo.ts:21-24`; cascades when person is deleted), `constraint_templates` (no name field; per-spec cleanup is sufficient), `audit_entries` (auditable trail).

## Test plan

- [x] Local: `pnpm e2e:sweep` removed today's 14 leftover rows.
- [x] Local: `playwright test e2e-sweep-canary.spec.ts --project=desktop` green (251 ms).
- [x] Local: post-test verification `SELECT COUNT(*) FROM persons WHERE first_name LIKE 'E2E-%'` → 0 across all swept tables.
- [x] Local: `pnpm --filter @schoolflow/web build` green.
- [ ] CI: Playwright E2E green on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)