### PR TITLE
chore(e2e): Classbook Attendance happy-path

### DIFF
--- a/apps/web/e2e/classbook-attendance.spec.ts
+++ b/apps/web/e2e/classbook-attendance.spec.ts
@@ -5,20 +5,33 @@
  * Lehrer öffnet die Stunde → "Alle anwesend" → cyclet einen Schüler auf
  * ABSENT → speichert (debounced bulk PUT) → reload zeigt den Zustand.
  *
- * Chromium-only-skip because every spec mutates the SAME seed
- * `ClassBookEntry` (the MONDAY-period-1-1A row) — parallel browser
- * projects would race on the same Anwesenheitsliste. Matches the
- * race-family pattern documented in
+ * Chromium-only-skip because every spec mutates the SAME seeded
+ * `ClassBookEntry` — parallel browser projects would race on the same
+ * Anwesenheitsliste. Matches the race-family pattern documented in
  * `project_e2e_parallel_cleanup_race_family.md`.
+ *
+ * CI/local divergence note (2026-05-15): the seed (`apps/api/prisma/seed.ts`)
+ * does NOT create any `TimetableLesson` rows — those are produced by a
+ * solver run, which only happens in local dev. The first commit of this
+ * spec assumed a MONDAY/period-1 seed lesson would exist; CI was red
+ * because it doesn't. Switched to the existing `seedTimetableRun()`
+ * fixture (timetable-generation-flow.spec.ts and the DnD/perspective
+ * specs use the same one) which deterministically seeds one
+ * MONDAY/period-1 lesson for class 1A in `beforeAll`. The fixture
+ * cleanup (`afterAll`) cascade-deletes the run.
  */
 import { test, expect } from '@playwright/test';
 import { loginAsAdmin } from './helpers/login';
 import {
   CLASSBOOK_SCHOOL_ID,
-  getSeedClassbookLesson,
   resetAttendanceForEntry,
   resolveEntryByTimetableLesson,
 } from './helpers/classbook';
+import {
+  cleanupTimetableRun,
+  seedTimetableRun,
+  type TimetableRunFixture,
+} from './fixtures/timetable-run';
 
 test.describe('Issue #81 — Classbook Attendance (desktop)', () => {
   test.skip(
@@ -30,19 +43,28 @@ test.describe('Issue #81 — Classbook Attendance (desktop)', () => {
     'Mutates the shared seed ClassBookEntry — parallel projects race.',
   );
 
+  let fixture: TimetableRunFixture;
+
+  test.beforeAll(async () => {
+    fixture = await seedTimetableRun(CLASSBOOK_SCHOOL_ID);
+  });
+
+  test.afterAll(async () => {
+    await cleanupTimetableRun(fixture);
+  });
+
   test.beforeEach(async ({ page }) => {
     await loginAsAdmin(page);
   });
 
   test.afterEach(async ({ request }) => {
-    // Restore the canonical alle-anwesend state so the next spec / run
+    // Restore the canonical alle-anwesend state so a follow-up retry
     // starts deterministic. Pure read-only assertions in the test body
     // make this cleanup the single source of mutation-resetting truth.
-    const lesson = await getSeedClassbookLesson();
     const entry = await resolveEntryByTimetableLesson(
       request,
       CLASSBOOK_SCHOOL_ID,
-      lesson.id,
+      fixture.lessonId,
     );
     await resetAttendanceForEntry(request, CLASSBOOK_SCHOOL_ID, entry.id);
   });
@@ -51,19 +73,17 @@ test.describe('Issue #81 — Classbook Attendance (desktop)', () => {
     page,
     request,
   }) => {
-    const lesson = await getSeedClassbookLesson();
-
     // Force the API-side baseline before opening the UI. The cycle
     // click below assumes PRESENT → ABSENT after one tap; a previously
     // killed run could otherwise leave a row in LATE or EXCUSED.
     const entry = await resolveEntryByTimetableLesson(
       request,
       CLASSBOOK_SCHOOL_ID,
-      lesson.id,
+      fixture.lessonId,
     );
     await resetAttendanceForEntry(request, CLASSBOOK_SCHOOL_ID, entry.id);
 
-    await page.goto(`/classbook/${lesson.id}?tab=anwesenheit`);
+    await page.goto(`/classbook/${fixture.lessonId}?tab=anwesenheit`);
 
     const list = page.getByRole('list', { name: 'Anwesenheitsliste' });
     await expect(list).toBeVisible();

--- a/apps/web/e2e/classbook-attendance.spec.ts
+++ b/apps/web/e2e/classbook-attendance.spec.ts
@@ -1,0 +1,103 @@
+/**
+ * Issue #81 — Classbook Attendance E2E coverage.
+ *
+ * Locks the most operationally critical sub-surface of `/classbook/$lessonId`:
+ * Lehrer öffnet die Stunde → "Alle anwesend" → cyclet einen Schüler auf
+ * ABSENT → speichert (debounced bulk PUT) → reload zeigt den Zustand.
+ *
+ * Chromium-only-skip because every spec mutates the SAME seed
+ * `ClassBookEntry` (the MONDAY-period-1-1A row) — parallel browser
+ * projects would race on the same Anwesenheitsliste. Matches the
+ * race-family pattern documented in
+ * `project_e2e_parallel_cleanup_race_family.md`.
+ */
+import { test, expect } from '@playwright/test';
+import { loginAsAdmin } from './helpers/login';
+import {
+  CLASSBOOK_SCHOOL_ID,
+  getSeedClassbookLesson,
+  resetAttendanceForEntry,
+  resolveEntryByTimetableLesson,
+} from './helpers/classbook';
+
+test.describe('Issue #81 — Classbook Attendance (desktop)', () => {
+  test.skip(
+    ({ isMobile }) => isMobile,
+    'Attendance contract is identical across viewports — desktop only for the first lock.',
+  );
+  test.skip(
+    ({ browserName }) => browserName !== 'chromium',
+    'Mutates the shared seed ClassBookEntry — parallel projects race.',
+  );
+
+  test.beforeEach(async ({ page }) => {
+    await loginAsAdmin(page);
+  });
+
+  test.afterEach(async ({ request }) => {
+    // Restore the canonical alle-anwesend state so the next spec / run
+    // starts deterministic. Pure read-only assertions in the test body
+    // make this cleanup the single source of mutation-resetting truth.
+    const lesson = await getSeedClassbookLesson();
+    const entry = await resolveEntryByTimetableLesson(
+      request,
+      CLASSBOOK_SCHOOL_ID,
+      lesson.id,
+    );
+    await resetAttendanceForEntry(request, CLASSBOOK_SCHOOL_ID, entry.id);
+  });
+
+  test('CB-ATTEND-01: cycle first student to ABSENT → reload persists', async ({
+    page,
+    request,
+  }) => {
+    const lesson = await getSeedClassbookLesson();
+
+    // Force the API-side baseline before opening the UI. The cycle
+    // click below assumes PRESENT → ABSENT after one tap; a previously
+    // killed run could otherwise leave a row in LATE or EXCUSED.
+    const entry = await resolveEntryByTimetableLesson(
+      request,
+      CLASSBOOK_SCHOOL_ID,
+      lesson.id,
+    );
+    await resetAttendanceForEntry(request, CLASSBOOK_SCHOOL_ID, entry.id);
+
+    await page.goto(`/classbook/${lesson.id}?tab=anwesenheit`);
+
+    const list = page.getByRole('list', { name: 'Anwesenheitsliste' });
+    await expect(list).toBeVisible();
+    const rows = list.getByRole('listitem');
+    expect(
+      await rows.count(),
+      'seed class 1A must have students',
+    ).toBeGreaterThan(0);
+
+    // Cycle order is PRESENT → ABSENT → LATE → EXCUSED. The API-side
+    // baseline above guarantees one click here lands on ABSENT.
+    const firstStatus = rows.nth(0).getByRole('button').first();
+    await expect(firstStatus).toHaveAccessibleName(/anwesend/i);
+    await firstStatus.click();
+
+    // Optimistic UI: aria-label flips immediately before the network
+    // round-trip lands.
+    await expect(firstStatus).toHaveAccessibleName(/abwesend/i);
+
+    // AttendanceGrid debounces the bulk PUT 2 s after the last
+    // interaction (apps/web/src/components/classbook/AttendanceGrid.tsx:74).
+    // The success toast is the stable signal that the mutation
+    // committed; without it a reload would race the debounce.
+    await expect(page.getByText('Anwesenheit gespeichert')).toBeVisible({
+      timeout: 8_000,
+    });
+
+    await page.reload();
+    const firstReloadedStatus = page
+      .getByRole('list', { name: 'Anwesenheitsliste' })
+      .getByRole('listitem')
+      .nth(0)
+      .getByRole('button')
+      .first();
+    await expect(firstReloadedStatus).toHaveAccessibleName(/abwesend/i);
+  });
+});

--- a/apps/web/e2e/classbook-attendance.spec.ts
+++ b/apps/web/e2e/classbook-attendance.spec.ts
@@ -43,30 +43,34 @@ test.describe('Issue #81 — Classbook Attendance (desktop)', () => {
     'Mutates the shared seed ClassBookEntry — parallel projects race.',
   );
 
-  let fixture: TimetableRunFixture;
-
-  test.beforeAll(async () => {
-    fixture = await seedTimetableRun(CLASSBOOK_SCHOOL_ID);
-  });
-
-  test.afterAll(async () => {
-    await cleanupTimetableRun(fixture);
-  });
+  // Per-test seeding instead of beforeAll/afterAll. Reason: describe-
+  // level `test.skip(condition, reason)` does NOT gate beforeAll —
+  // beforeAll runs in EVERY project including skipped ones (CI run
+  // 25905955650 hit `cleanupTimetableRun(undefined)` → TypeError in
+  // the desktop-firefox project). Per-test hooks ARE gated by
+  // test.skip, and `if (!fixture)` matches the existing defensive
+  // pattern in admin-timetable-edit-dnd.spec.ts.
+  let fixture: TimetableRunFixture | undefined;
 
   test.beforeEach(async ({ page }) => {
+    fixture = await seedTimetableRun(CLASSBOOK_SCHOOL_ID);
     await loginAsAdmin(page);
   });
 
   test.afterEach(async ({ request }) => {
-    // Restore the canonical alle-anwesend state so a follow-up retry
-    // starts deterministic. Pure read-only assertions in the test body
-    // make this cleanup the single source of mutation-resetting truth.
+    if (!fixture) return;
+    // Restore the canonical alle-anwesend state on the seeded entry,
+    // then cascade-delete the fixture run. Pure read-only assertions in
+    // the test body make this cleanup the single source of mutation-
+    // resetting truth.
     const entry = await resolveEntryByTimetableLesson(
       request,
       CLASSBOOK_SCHOOL_ID,
       fixture.lessonId,
     );
     await resetAttendanceForEntry(request, CLASSBOOK_SCHOOL_ID, entry.id);
+    await cleanupTimetableRun(fixture);
+    fixture = undefined;
   });
 
   test('CB-ATTEND-01: cycle first student to ABSENT → reload persists', async ({

--- a/apps/web/e2e/helpers/classbook.ts
+++ b/apps/web/e2e/helpers/classbook.ts
@@ -3,87 +3,27 @@
  *
  * The classbook surface is anchored on a `TimetableLesson` ID: clicking a
  * timetable cell navigates to `/classbook/<timetableLessonId>` and the
- * backend resolves it to (or creates) a `ClassBookEntry`. To test the
- * surface deterministically we need a stable lesson ID from the seed.
+ * backend resolves it to (or creates) a `ClassBookEntry`. Specs use the
+ * existing `fixtures/timetable-run.ts:seedTimetableRun()` helper to
+ * deterministically seed one such lesson in `beforeAll` (the standard
+ * prisma:seed creates ZERO TimetableLesson rows — they're produced by
+ * solver runs, which only happens in local dev).
  *
- * `getSeedClassbookLesson()` performs a DB lookup via the Prisma client
- * the API ships with (same pattern as `fixtures/orphan-year.ts`) and
- * returns the FIRST 1A Monday lesson — that row is created by
- * `apps/api/prisma/seed.ts` and is therefore reproducible across runs.
- *
- * Cleanup helpers:
- *   - `resetAttendanceForEntry(request, schoolId, entryId)` calls the
- *     `POST /attendance/all-present` endpoint to put the shared seed
- *     entry back into a known-good state after each test.
+ * This module covers the API-side state plumbing tests need on top of
+ * the lesson fixture:
+ *   - `resolveEntryByTimetableLesson` mirrors the UI's lesson→entry
+ *     resolve endpoint so tests can mix UI actions with API state setup
+ *   - `resetAttendanceForEntry` puts a ClassBookEntry back into the
+ *     canonical "alle anwesend" state for use in afterEach hooks
  */
-import 'dotenv/config';
-import { config as dotenvConfig } from 'dotenv';
-import { createRequire } from 'node:module';
-import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { expect, type APIRequestContext } from '@playwright/test';
 import { getAdminToken } from './login';
 import { SEED_SCHOOL_UUID } from '../fixtures/seed-uuids';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-dotenvConfig({ path: path.resolve(__dirname, '../../../../.env') });
-
-const require = createRequire(import.meta.url);
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const { PrismaClient } = require('../../../api/dist/config/database/generated/client.js') as {
-  PrismaClient: new (opts?: { adapter?: unknown }) => {
-    timetableLesson: {
-      findFirst: (args: {
-        where: Record<string, unknown>;
-        orderBy?: Record<string, 'asc' | 'desc'>;
-        select?: Record<string, true>;
-      }) => Promise<{ id: string } | null>;
-    };
-    $disconnect: () => Promise<void>;
-  };
-};
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const { PrismaPg } = require('../../../api/node_modules/@prisma/adapter-pg') as {
-  PrismaPg: new (opts: { connectionString: string }) => unknown;
-};
 
 export const CLASSBOOK_API =
   process.env.E2E_API_URL ?? 'http://localhost:3000/api/v1';
 export const CLASSBOOK_SCHOOL_ID =
   process.env.E2E_SCHOOL_ID ?? SEED_SCHOOL_UUID;
-
-/**
- * Find the first MONDAY period-1 lesson for class 1A in the seed timetable.
- *
- * This is the lesson that `apps/api/prisma/seed.ts` creates as part of the
- * baseline schedule (Max Mustermann teaches Deutsch). Stable across runs
- * because the seed is deterministic.
- */
-export async function getSeedClassbookLesson(): Promise<{ id: string }> {
-  const connectionString = process.env.DATABASE_URL;
-  if (!connectionString) {
-    throw new Error('getSeedClassbookLesson: DATABASE_URL is not set');
-  }
-  const prisma = new PrismaClient({
-    adapter: new PrismaPg({ connectionString }),
-  });
-  try {
-    const lesson = await prisma.timetableLesson.findFirst({
-      where: { dayOfWeek: 'MONDAY', periodNumber: 1 },
-      orderBy: { id: 'asc' },
-      select: { id: true },
-    });
-    if (!lesson) {
-      throw new Error(
-        'Seed lookup failed — no MONDAY period-1 lesson. Run `pnpm dev:up` to re-seed.',
-      );
-    }
-    return lesson;
-  } finally {
-    await prisma.$disconnect();
-  }
-}
 
 /**
  * Resolve a TimetableLesson ID to its ClassBookEntry via the same endpoint

--- a/apps/web/e2e/helpers/classbook.ts
+++ b/apps/web/e2e/helpers/classbook.ts
@@ -1,0 +1,130 @@
+/**
+ * Classbook E2E helpers — #81.
+ *
+ * The classbook surface is anchored on a `TimetableLesson` ID: clicking a
+ * timetable cell navigates to `/classbook/<timetableLessonId>` and the
+ * backend resolves it to (or creates) a `ClassBookEntry`. To test the
+ * surface deterministically we need a stable lesson ID from the seed.
+ *
+ * `getSeedClassbookLesson()` performs a DB lookup via the Prisma client
+ * the API ships with (same pattern as `fixtures/orphan-year.ts`) and
+ * returns the FIRST 1A Monday lesson — that row is created by
+ * `apps/api/prisma/seed.ts` and is therefore reproducible across runs.
+ *
+ * Cleanup helpers:
+ *   - `resetAttendanceForEntry(request, schoolId, entryId)` calls the
+ *     `POST /attendance/all-present` endpoint to put the shared seed
+ *     entry back into a known-good state after each test.
+ */
+import 'dotenv/config';
+import { config as dotenvConfig } from 'dotenv';
+import { createRequire } from 'node:module';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { expect, type APIRequestContext } from '@playwright/test';
+import { getAdminToken } from './login';
+import { SEED_SCHOOL_UUID } from '../fixtures/seed-uuids';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+dotenvConfig({ path: path.resolve(__dirname, '../../../../.env') });
+
+const require = createRequire(import.meta.url);
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { PrismaClient } = require('../../../api/dist/config/database/generated/client.js') as {
+  PrismaClient: new (opts?: { adapter?: unknown }) => {
+    timetableLesson: {
+      findFirst: (args: {
+        where: Record<string, unknown>;
+        orderBy?: Record<string, 'asc' | 'desc'>;
+        select?: Record<string, true>;
+      }) => Promise<{ id: string } | null>;
+    };
+    $disconnect: () => Promise<void>;
+  };
+};
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { PrismaPg } = require('../../../api/node_modules/@prisma/adapter-pg') as {
+  PrismaPg: new (opts: { connectionString: string }) => unknown;
+};
+
+export const CLASSBOOK_API =
+  process.env.E2E_API_URL ?? 'http://localhost:3000/api/v1';
+export const CLASSBOOK_SCHOOL_ID =
+  process.env.E2E_SCHOOL_ID ?? SEED_SCHOOL_UUID;
+
+/**
+ * Find the first MONDAY period-1 lesson for class 1A in the seed timetable.
+ *
+ * This is the lesson that `apps/api/prisma/seed.ts` creates as part of the
+ * baseline schedule (Max Mustermann teaches Deutsch). Stable across runs
+ * because the seed is deterministic.
+ */
+export async function getSeedClassbookLesson(): Promise<{ id: string }> {
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    throw new Error('getSeedClassbookLesson: DATABASE_URL is not set');
+  }
+  const prisma = new PrismaClient({
+    adapter: new PrismaPg({ connectionString }),
+  });
+  try {
+    const lesson = await prisma.timetableLesson.findFirst({
+      where: { dayOfWeek: 'MONDAY', periodNumber: 1 },
+      orderBy: { id: 'asc' },
+      select: { id: true },
+    });
+    if (!lesson) {
+      throw new Error(
+        'Seed lookup failed — no MONDAY period-1 lesson. Run `pnpm dev:up` to re-seed.',
+      );
+    }
+    return lesson;
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+/**
+ * Resolve a TimetableLesson ID to its ClassBookEntry via the same endpoint
+ * the UI uses. Returns the entry ID for downstream API calls (attendance,
+ * content, etc.) so tests can mix UI actions with API state setup.
+ */
+export async function resolveEntryByTimetableLesson(
+  request: APIRequestContext,
+  schoolId: string,
+  timetableLessonId: string,
+): Promise<{ id: string }> {
+  const token = await getAdminToken(request);
+  const res = await request.get(
+    `${CLASSBOOK_API}/schools/${schoolId}/classbook/by-timetable-lesson/${timetableLessonId}`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+  expect(res.ok(), 'classbook resolve by-timetable-lesson').toBeTruthy();
+  return (await res.json()) as { id: string };
+}
+
+/**
+ * Put a ClassBookEntry's attendance back into the canonical "alle anwesend"
+ * state so the next test starts deterministic. Used in afterEach hooks.
+ */
+export async function resetAttendanceForEntry(
+  request: APIRequestContext,
+  schoolId: string,
+  entryId: string,
+): Promise<void> {
+  const token = await getAdminToken(request);
+  const res = await request.post(
+    `${CLASSBOOK_API}/schools/${schoolId}/classbook/${entryId}/attendance/all-present`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+  // Soft-fail: cleanup must not abort the test. 404 means the entry was
+  // already removed by a parallel run; either way the desired end-state
+  // (no E2E-flavoured attendance) is satisfied.
+  if (!res.ok() && res.status() !== 404) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[classbook] resetAttendance soft-failed (${res.status()}); continuing`,
+    );
+  }
+}


### PR DESCRIPTION
## Summary

First sub-spec of #81 Klassenbuch coverage. Locks the operationally critical Anwesenheit flow.

- New helper `apps/web/e2e/helpers/classbook.ts` — Prisma-direct seed-lesson lookup + API state-reset for cleanup
- New spec `apps/web/e2e/classbook-attendance.spec.ts` — CB-ATTEND-01 chromium-only, locks: open lesson → cycle to ABSENT → reload persists

Refs #81 (stays open — follow-ups for Lesson-Content, Grades, Notes will close it).

## Why this slice first

Anwesenheit is the **operationally most-used** classbook surface (every Lehrer in every Stunde). The other three sub-surfaces (Inhalt, Noten, Notizen) are lower-frequency and benefit from this PR's helper foundation.

## Tradeoffs

- **Shared seed ClassBookEntry** — chromium-only-skip per `project_e2e_parallel_cleanup_race_family.md`. Throwaway-school fixture would unlock parallel browser projects but is outside this PR's scope.
- **2-s debounce** — `AttendanceGrid.tsx:74` debounces the bulk PUT; the spec waits for the success toast as the stable signal that the mutation actually landed. Without that wait the reload races the timer.
- **API baseline before UI cycle** — pre-test `resetAttendanceForEntry()` removes the "killed run left LATE/EXCUSED" race.

## Test plan

- [x] Local: `playwright test classbook-attendance.spec.ts --project=desktop` green (6.3 s).
- [x] Reload assertion lands on `aria-label=/abwesend/i` after the cycle.
- [x] `pnpm --filter @schoolflow/web build` green.
- [x] DB-side: `pnpm e2e:sweep` from #79 sweeps any leftover; this spec doesn't add new prefix data (mutates seed in place + resets in afterEach).
- [ ] CI: Playwright E2E green on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)