### PR TITLE
chore(e2e): Messaging conversation list + detail

### DIFF
--- a/apps/web/e2e/helpers/messaging.ts
+++ b/apps/web/e2e/helpers/messaging.ts
@@ -1,0 +1,104 @@
+/**
+ * Messaging E2E helpers — #84.
+ *
+ * Phase 7 Conversation REST API:
+ *   - POST /schools/:schoolId/conversations          — create + scope-expand
+ *   - GET  /schools/:schoolId/conversations           — list for current user
+ *   - DELETE /schools/:schoolId/conversations/:id     — admin-only cleanup
+ *
+ * Per-spec cleanup follows the established prefix-isolation pattern
+ * (`helpers/students.ts`, `helpers/teachers.ts`): every E2E-created
+ * conversation carries `E2E-MSG-…` in its subject so afterEach can sweep
+ * by listing + filtering + deleting.
+ */
+import { expect, type APIRequestContext } from '@playwright/test';
+import { getAdminToken } from './login';
+import { SEED_SCHOOL_UUID } from '../fixtures/seed-uuids';
+
+export const MESSAGING_API =
+  process.env.E2E_API_URL ?? 'http://localhost:3000/api/v1';
+export const MESSAGING_SCHOOL_ID =
+  process.env.E2E_SCHOOL_ID ?? SEED_SCHOOL_UUID;
+
+/** Spec ID prefix locked at issue-level for matrix traceability. */
+export const MESSAGING_PREFIX = 'E2E-MSG-';
+
+export interface CreateBroadcastInput {
+  subject: string;
+  body: string;
+  scopeId: string;
+  scope?: 'CLASS' | 'YEAR_GROUP' | 'SCHOOL';
+}
+
+export interface CreatedConversation {
+  id: string;
+  subject: string | null;
+}
+
+/**
+ * Create a broadcast conversation as the admin user. Returns the new
+ * conversation's id + subject so the spec can drive assertions off the
+ * exact same row the API created.
+ *
+ * Defaults to scope=CLASS so the most common spec pattern (Lehrer →
+ * Class) is a one-liner. Override `scope` for YEAR_GROUP / SCHOOL.
+ */
+export async function createBroadcastConversation(
+  request: APIRequestContext,
+  input: CreateBroadcastInput,
+): Promise<CreatedConversation> {
+  const token = await getAdminToken(request);
+  const res = await request.post(
+    `${MESSAGING_API}/schools/${MESSAGING_SCHOOL_ID}/conversations`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      data: {
+        scope: input.scope ?? 'CLASS',
+        scopeId: input.scopeId,
+        subject: input.subject,
+        body: input.body,
+      },
+    },
+  );
+  expect(
+    res.ok(),
+    `POST /conversations seed (${input.subject}) → ${res.status()}`,
+  ).toBeTruthy();
+  const body = (await res.json()) as { id: string; subject: string | null };
+  return { id: body.id, subject: body.subject };
+}
+
+/**
+ * Best-effort cleanup: list conversations the admin can see, filter by
+ * subject prefix, and delete each. Swallows per-row errors so a parallel
+ * spec deleting the same row mid-flight doesn't crash this sweep — same
+ * pattern as `cleanupE2EParents`.
+ */
+export async function cleanupE2EConversations(
+  request: APIRequestContext,
+  prefix: string = MESSAGING_PREFIX,
+): Promise<void> {
+  const token = await getAdminToken(request);
+  const listRes = await request.get(
+    `${MESSAGING_API}/schools/${MESSAGING_SCHOOL_ID}/conversations?limit=200`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+  if (!listRes.ok()) return;
+  const body = (await listRes.json()) as {
+    data?: Array<{ id: string; subject?: string | null }>;
+  };
+  const list = body.data ?? [];
+  await Promise.all(
+    list
+      .filter((c) => (c.subject ?? '').startsWith(prefix))
+      .map((c) =>
+        request.delete(
+          `${MESSAGING_API}/schools/${MESSAGING_SCHOOL_ID}/conversations/${c.id}`,
+          { headers: { Authorization: `Bearer ${token}` } },
+        ),
+      ),
+  );
+}

--- a/apps/web/e2e/messaging-conversation-list.spec.ts
+++ b/apps/web/e2e/messaging-conversation-list.spec.ts
@@ -1,0 +1,101 @@
+/**
+ * Issue #84 — Messaging conversation list + detail view.
+ *
+ * Slice 1/n of the Messaging coverage gap. Locks the recipient-side flow:
+ * a broadcast that the admin (Lehrer-equivalent) sends to class 1A must
+ * surface in the parents' /messages list, and clicking it must show the
+ * actual message body in ConversationView.
+ *
+ * Why this slice first: it exercises three load-bearing layers in one
+ * test — conversation creation + scope expansion (backend membership
+ * resolution), useConversations list fetch (frontend hook), and the
+ * MessageBubble render (UI rendering of the first message). A bug in
+ * any one of them surfaces here as a missing-row or missing-body
+ * assertion.
+ *
+ * Multi-tab realtime, polls, and 1:1 direct-message specs are
+ * intentionally deferred to follow-up PRs so this one stays reviewable.
+ *
+ * Chromium-only-skip per the race-family precedent — shared seed-school
+ * mutating specs collide on parallel browser projects.
+ */
+import { test, expect } from '@playwright/test';
+import { loginAsRole } from './helpers/login';
+import {
+  MESSAGING_PREFIX,
+  cleanupE2EConversations,
+  createBroadcastConversation,
+  type CreatedConversation,
+} from './helpers/messaging';
+
+const SEED_CLASS_1A_ID = 'seed-class-1a';
+
+test.describe('Issue #84 — Messaging conversation list + detail (desktop)', () => {
+  test.skip(
+    ({ isMobile }) => isMobile,
+    'List-detail two-pane layout is desktop-only; mobile has a separate route the next slice will cover.',
+  );
+  test.skip(
+    ({ browserName }) => browserName !== 'chromium',
+    'Conversation rows on the shared seed school race on parallel browser projects.',
+  );
+
+  let created: CreatedConversation | null = null;
+
+  test.afterEach(async ({ request }) => {
+    // Sweep ALL `E2E-MSG-` rows, not just the one created in beforeEach.
+    // A killed previous run could leave parallel siblings behind, and
+    // their members include the eltern-user — which would clutter the
+    // ConversationList assertion below the next time this spec runs.
+    await cleanupE2EConversations(request, MESSAGING_PREFIX);
+    created = null;
+  });
+
+  test('MSG-LIST-01: broadcast to class 1A shows up in eltern-user list and opens with message body', async ({
+    page,
+    request,
+  }) => {
+    const ts = Date.now();
+    const subject = `${MESSAGING_PREFIX}LIST-${ts}`;
+    const body = `${MESSAGING_PREFIX}BODY-${ts} — Hallo Eltern, dies ist eine Test-Nachricht.`;
+
+    created = await createBroadcastConversation(request, {
+      scope: 'CLASS',
+      scopeId: SEED_CLASS_1A_ID,
+      subject,
+      body,
+    });
+    expect(created.subject, 'API must echo back the subject we sent').toBe(
+      subject,
+    );
+
+    await loginAsRole(page, 'eltern');
+    await page.goto('/messages');
+
+    // Page chrome must be visible — proves the route loaded before we
+    // assert on list rows.
+    await expect(
+      page.getByRole('heading', { name: 'Nachrichten' }),
+    ).toBeVisible();
+
+    // The ConversationListItem renders the subject as its title (see
+    // apps/web/src/components/messaging/ConversationListItem.tsx:34).
+    // Use a precise match so a future spec's row doesn't accidentally
+    // pass this one.
+    const row = page.getByRole('button', { name: new RegExp(subject) });
+    await expect(
+      row,
+      'eltern-user (Franz Huber, parent of Lisa in 1A) must be a member of the broadcast',
+    ).toBeVisible();
+
+    await row.click();
+
+    // ConversationView renders the first message via MessageBubble
+    // (apps/web/src/components/messaging/MessageBubble.tsx:90), so the
+    // body text is a real on-page string after navigation.
+    await expect(
+      page.getByText(body),
+      'first message body must appear in ConversationView after click',
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

First sub-spec of #84 Messaging coverage. Locks the recipient-side flow end-to-end:

- Admin creates a broadcast conversation to class 1A via API
- eltern-user (Franz Huber, parent of Lisa in 1A) opens `/messages`
- Conversation appears in `ConversationList` with the broadcast subject
- Click → `ConversationView` renders the message body via `MessageBubble`

Refs #84.

## Why this slice first

It exercises three load-bearing layers in one test:
1. **Backend scope expansion** — `CLASS` broadcast must materialize membership rows for all parents/students/teachers of class 1A.
2. **Frontend list fetch** — `useConversations()` must return the conversation for the recipient.
3. **Detail view rendering** — `MessageBubble` must render the first message body.

A bug in any of them surfaces here as a missing-row or missing-body assertion. The other proposed sub-specs (1:1 direct, polls, realtime) build on top of this surface.

## How

New helper `apps/web/e2e/helpers/messaging.ts`:
- `createBroadcastConversation()` — posts as admin
- `cleanupE2EConversations()` — sweeps `E2E-MSG-` subjects in afterEach (also catches leftovers from killed runs)

Spec `apps/web/e2e/messaging-conversation-list.spec.ts` (MSG-LIST-01) — chromium-only, asserts the row by subject and the body by text.

## Would-fail-without-fix check

Pointed the test at `scope=YEAR_GROUP, scopeId=99` (non-matching year) — eltern-user is not a member, conversation does NOT appear, test fails red on the `toBeVisible()`. Restored to `scope=CLASS, scopeId=seed-class-1a` before commit.

## Tradeoffs

- **Single test per PR** — same approach as #89. Multi-tab realtime, polls, and 1:1 direct messages are deferred to follow-up PRs so each is reviewable in isolation.
- **Chromium-only-skip** — shared seed-school broadcast races on parallel browser projects (race-family precedent).
- **Subject-based assertion** — the `E2E-MSG-{timestamp}` prefix makes the locator collision-free even when previous runs left siblings; the afterEach prefix sweep cleans them up regardless.

## Test plan

- [x] Local: `playwright test messaging-conversation-list.spec.ts --project=desktop` green (2.1 s).
- [x] Would-fail check verified.
- [x] DB clean post-test (cleanupE2EConversations swept).
- [ ] CI: Playwright E2E green on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)