### PR TITLE
chore(e2e): Admin Offene Vertretungen panel

### DIFF
--- a/apps/web/e2e/admin-substitutions-list.spec.ts
+++ b/apps/web/e2e/admin-substitutions-list.spec.ts
@@ -1,0 +1,113 @@
+/**
+ * Issue #85 — Admin "Offene Vertretungen" panel.
+ *
+ * First sub-spec of the Substitutions coverage gap. Locks the admin-side
+ * view of auto-generated substitutions:
+ *
+ *   1. Seed an active TimetableRun with one lesson at MONDAY/period-1
+ *      for class 1A, taught by kc-lehrer (Maria Mueller).
+ *   2. POST an absence for kc-lehrer covering the upcoming Monday →
+ *      backend auto-expands to one Substitution row.
+ *   3. Admin opens /admin/substitutions?tab=open → OpenSubstitutionsPanel
+ *      surfaces the row with the absent teacher's name.
+ *
+ * Why this slice first: it exercises three load-bearing layers in one
+ * test — backend absence-to-substitution expansion (4 .createMany
+ * branch in teacher-absence.service.ts), useSubstitutions list fetch,
+ * and OpenSubstitutionsPanel rendering. The UI-driven AbsenceForm
+ * flow and the "assign substitute" / Entfall / Stillarbeit actions are
+ * deferred to follow-up sub-specs.
+ *
+ * Chromium-only-skip per the race-family precedent — shared seed-school
+ * mutating specs collide on parallel browser projects (TimetableRun is
+ * the canonical race surface).
+ */
+import { test, expect } from '@playwright/test';
+import { loginAsAdmin } from './helpers/login';
+import {
+  cancelAbsenceViaAPI,
+  createAbsenceViaAPI,
+  nextMondayISODate,
+  type CreatedAbsence,
+} from './helpers/substitutions';
+import {
+  cleanupTimetableRun,
+  seedTimetableRun,
+  type TimetableRunFixture,
+} from './fixtures/timetable-run';
+import { SEED_SCHOOL_UUID } from './fixtures/seed-uuids';
+
+test.describe('Issue #85 — Admin Offene Vertretungen (desktop)', () => {
+  test.skip(
+    ({ isMobile }) => isMobile,
+    'Panel rendering is identical across viewports — desktop only for the first lock.',
+  );
+  test.skip(
+    ({ browserName }) => browserName !== 'chromium',
+    'Race-family: mutates the shared seed-school TimetableRun.',
+  );
+
+  // Per-test seeding — describe-level test.skip does NOT gate
+  // beforeAll/afterAll (CI lesson from #81/#86). Per-test hooks ARE
+  // gated and the `if (!x)` guards belt-and-brace the cleanup against
+  // any half-applied state.
+  let fixture: TimetableRunFixture | undefined;
+  let absence: CreatedAbsence | undefined;
+
+  test.beforeEach(async ({ page }) => {
+    fixture = await seedTimetableRun(SEED_SCHOOL_UUID);
+    await loginAsAdmin(page);
+  });
+
+  test.afterEach(async ({ request }) => {
+    if (absence) {
+      await cancelAbsenceViaAPI(request, absence.id);
+      absence = undefined;
+    }
+    if (fixture) {
+      await cleanupTimetableRun(fixture);
+      fixture = undefined;
+    }
+  });
+
+  test('SUB-ADMIN-01: absence for kc-lehrer surfaces a substitution row in OpenSubstitutionsPanel', async ({
+    page,
+    request,
+  }) => {
+    if (!fixture) throw new Error('fixture not seeded');
+
+    // Absence covering the upcoming Monday — aligns with the seed
+    // lesson's day-of-week so the expansion algorithm produces one
+    // substitution row (teacher-absence.service.ts:138 eachDayOfInterval
+    // → filter by activeDaySet → match lesson by runId+teacherId+
+    // dayOfWeek).
+    const monday = nextMondayISODate();
+    absence = await createAbsenceViaAPI(request, {
+      teacherId: fixture.teacherId,
+      dateFrom: monday,
+      dateTo: monday,
+      reason: 'KRANK',
+    });
+    expect(
+      absence.affectedLessonCount ?? 0,
+      'absence-expansion must create at least one substitution row',
+    ).toBeGreaterThan(0);
+
+    await page.goto('/admin/substitutions?tab=open');
+    await expect(
+      page.getByRole('heading', { name: 'Vertretungsplanung' }),
+    ).toBeVisible();
+
+    // Empty-state card "Keine offenen Vertretungen" must NOT appear —
+    // the absence we just created should have populated the panel.
+    await expect(page.getByText('Keine offenen Vertretungen')).toHaveCount(0);
+
+    // The OpenSubstitutionsPanel renders "Vertretung fuer: <originalTeacherName>"
+    // (apps/web/src/components/substitution/OpenSubstitutionsPanel.tsx:125).
+    // kc-lehrer's Person record is Maria Mueller (apps/api/prisma/seed.ts).
+    await expect(
+      page.getByText(/Vertretung fuer:\s*Maria Mueller/),
+      'panel must show the absent teacher name',
+    ).toBeVisible();
+  });
+});

--- a/apps/web/e2e/helpers/substitutions.ts
+++ b/apps/web/e2e/helpers/substitutions.ts
@@ -1,0 +1,116 @@
+/**
+ * Substitutions E2E helpers — #85.
+ *
+ * Phase 6 absence + substitution REST contract:
+ *   - POST   /schools/:schoolId/absences          — admin creates a teacher absence
+ *                                                    backend auto-generates substitutions
+ *                                                    for every TimetableLesson in range
+ *   - DELETE /schools/:schoolId/absences/:id      — cascade-cancels substitutions
+ *
+ * Specs lean on this helper to seed an absence directly via the API
+ * (faster + deterministic) and let the UI render the resulting
+ * substitution rows. The Compose-via-UI flow for the AbsenceForm is
+ * deliberately deferred to a follow-up sub-spec; this slice focuses on
+ * the admin's "Offene Vertretungen" panel rendering its data correctly.
+ */
+import { expect, type APIRequestContext } from '@playwright/test';
+import { getAdminToken } from './login';
+import { SEED_SCHOOL_UUID } from '../fixtures/seed-uuids';
+
+export const SUBSTITUTIONS_API =
+  process.env.E2E_API_URL ?? 'http://localhost:3000/api/v1';
+export const SUBSTITUTIONS_SCHOOL_ID =
+  process.env.E2E_SCHOOL_ID ?? SEED_SCHOOL_UUID;
+
+export interface CreateAbsenceInput {
+  teacherId: string;
+  dateFrom: string;
+  dateTo: string;
+  reason?: string;
+  note?: string;
+}
+
+export interface CreatedAbsence {
+  id: string;
+  affectedLessonCount: number;
+}
+
+/**
+ * POST /absences as admin. Returns the new absence id so afterEach can
+ * cancel it (cascade-deletes any auto-generated substitutions).
+ */
+export async function createAbsenceViaAPI(
+  request: APIRequestContext,
+  input: CreateAbsenceInput,
+): Promise<CreatedAbsence> {
+  const token = await getAdminToken(request);
+  const res = await request.post(
+    `${SUBSTITUTIONS_API}/schools/${SUBSTITUTIONS_SCHOOL_ID}/absences`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      data: {
+        teacherId: input.teacherId,
+        dateFrom: input.dateFrom,
+        dateTo: input.dateTo,
+        reason: input.reason ?? 'KRANK',
+        note: input.note,
+      },
+    },
+  );
+  expect(
+    res.ok(),
+    `POST /absences seed → ${res.status()} ${await res.text()}`,
+  ).toBeTruthy();
+  // Response shape: `{ absence: { id, ... }, affectedLessonCount }`
+  // (teacher-absence.service.ts:192). The `id` is nested under `absence`,
+  // not at the top level — a previous version of this helper read it
+  // from the root and silently leaked uncancellable absences.
+  const body = (await res.json()) as {
+    absence: { id: string };
+    affectedLessonCount: number;
+  };
+  return {
+    id: body.absence.id,
+    affectedLessonCount: body.affectedLessonCount,
+  };
+}
+
+/**
+ * Cancel an absence via DELETE. Soft-fails on 404 (already gone) so a
+ * second cleanup call from a flaky retry doesn't crash the suite.
+ */
+export async function cancelAbsenceViaAPI(
+  request: APIRequestContext,
+  absenceId: string,
+): Promise<void> {
+  const token = await getAdminToken(request);
+  const res = await request.delete(
+    `${SUBSTITUTIONS_API}/schools/${SUBSTITUTIONS_SCHOOL_ID}/absences/${absenceId}`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+  if (!res.ok() && res.status() !== 404) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[substitutions] cancelAbsence soft-failed (${res.status()}); continuing`,
+    );
+  }
+}
+
+/**
+ * Compute the YYYY-MM-DD string for the next MONDAY at-or-after the
+ * given anchor date (defaults to today). Used to align test absences
+ * with the seedTimetableRun fixture's MONDAY/period-1 lesson so the
+ * absence-expansion algorithm produces exactly one substitution row.
+ */
+export function nextMondayISODate(anchor: Date = new Date()): string {
+  const d = new Date(anchor);
+  // getDay(): 0=Sun, 1=Mon, …, 6=Sat. We want the upcoming Monday; if
+  // today is Monday, use today (zero-day offset).
+  const jsDay = d.getDay();
+  const offset = jsDay === 1 ? 0 : (8 - jsDay) % 7;
+  d.setDate(d.getDate() + offset);
+  return d.toISOString().slice(0, 10);
+}


### PR DESCRIPTION
## Summary

First sub-spec of #85 Substitutions coverage. Locks the admin's view of auto-generated substitutions end-to-end:

- `seedTimetableRun` fixture seeds an active TimetableRun + lesson at MONDAY/period-1 (kc-lehrer / class 1A)
- `POST /absences` for kc-lehrer covering next Monday → backend auto-expands to one Substitution row
- Admin opens `/admin/substitutions?tab=open` → `OpenSubstitutionsPanel` renders **Vertretung fuer: Maria Mueller**

Refs #85.

## Why this slice first

Exercises three load-bearing layers in one test:
1. Backend absence-to-substitution expansion (`teacher-absence.service.ts:138-189`).
2. `useSubstitutions` list fetch.
3. `OpenSubstitutionsPanel` rendering.

A bug in any of them surfaces as a missing row or wrong teacher name. The "assign substitute", Entfall, Stillarbeit, teacher-side view, and handover-note specs build on top of this surface and are deferred to follow-up PRs.

## How

- `apps/web/e2e/helpers/substitutions.ts` — `createAbsenceViaAPI` / `cancelAbsenceViaAPI` + `nextMondayISODate()` so the absence date stays aligned with the fixture's MONDAY lesson regardless of when the suite runs.
- `apps/web/e2e/admin-substitutions-list.spec.ts` — `SUB-ADMIN-01` chromium-only, per-test `beforeEach/afterEach` with `if (!x)` guards (same pattern as #81 / #86 fixes).

## Would-fail-without-fix check

Pointed `createAbsenceViaAPI` at a non-kc-lehrer teacher (`f0000000-…-000003`): backend produced 0 substitution rows → `expect(affectedLessonCount).toBeGreaterThan(0)` failed red. Restored to `fixture.teacherId` before commit.

## Bug caught while writing

POST `/absences` actually returns `{ absence: { id, … }, affectedLessonCount }` — id is **nested** under `absence`, not at the root. First version of the helper read `body.id` and silently leaked uncancellable absences (cancel hit 404 → soft-fail → leak). Fixed; verified DB stays clean across runs (0 PENDING substitutions, CANCELLED audit-trail absences preserved by design).

## Test plan

- [x] Local: `playwright test admin-substitutions-list.spec.ts --project=desktop --project=desktop-firefox` — chromium passes 3.0 s, firefox properly skipped (no `cleanupTimetableRun(undefined)` regression).
- [x] Would-fail check verified.
- [x] DB state post-run: 0 active absences, 0 PENDING substitutions, 0 active TimetableRuns.
- [ ] CI: Playwright E2E green on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)