### PR TITLE
chore(e2e): Classbook Inhalt-Tab auto-save (#81)

### DIFF
--- a/apps/web/e2e/classbook-lesson-content.spec.ts
+++ b/apps/web/e2e/classbook-lesson-content.spec.ts
@@ -1,0 +1,132 @@
+/**
+ * Issue #81 — Classbook Lesson-Content E2E coverage.
+ *
+ * Second sub-spec for the Klassenbuch surface (after #89 attendance).
+ * Locks the auto-save flow on the "Inhalt" tab of /classbook/$lessonId:
+ *   1. Open the lesson page with ?tab=inhalt.
+ *   2. Fill the Thema textarea, blur (debounced 1 s PATCH /content).
+ *   3. Wait for the per-field "Gespeichert" indicator (the only stable
+ *      signal that the mutation committed — without it a reload would
+ *      race the debounce).
+ *   4. Reload → assert the value persists.
+ *
+ * Why this slice: it exercises the LessonContentForm blur-save loop, the
+ * PATCH /classbook/:entryId/content endpoint, and the by-timetable-lesson
+ * resolver chain (TimetableLesson → ClassBookEntry auto-create).
+ * Lehrstoff + Hausaufgabe share the exact same hook + endpoint, so locking
+ * one field locks all three at the wire level; field-specific UI quirks
+ * (e.g. Thema character counter at >50 chars) can be added in a follow-up
+ * spec when they become regression-prone.
+ *
+ * Chromium-only-skip per the race-family precedent — every spec on this
+ * surface mutates the SAME seeded ClassBookEntry. Same pattern as
+ * classbook-attendance.spec.ts.
+ */
+import { test, expect } from '@playwright/test';
+import { loginAsAdmin } from './helpers/login';
+import {
+  CLASSBOOK_SCHOOL_ID,
+  resetLessonContent,
+  resolveEntryByTimetableLesson,
+} from './helpers/classbook';
+import {
+  cleanupTimetableRun,
+  seedTimetableRun,
+  type TimetableRunFixture,
+} from './fixtures/timetable-run';
+
+test.describe('Issue #81 — Classbook Lesson-Content (desktop)', () => {
+  test.skip(
+    ({ isMobile }) => isMobile,
+    'Content form is identical across viewports — desktop only for the first lock.',
+  );
+  test.skip(
+    ({ browserName }) => browserName !== 'chromium',
+    'Mutates the shared seed ClassBookEntry — parallel projects race.',
+  );
+
+  // Per-test seeding — describe-level test.skip does NOT gate beforeAll
+  // (CI lesson from #81 attendance run). Per-test hooks ARE gated.
+  let fixture: TimetableRunFixture | undefined;
+
+  test.beforeEach(async ({ page }) => {
+    fixture = await seedTimetableRun(CLASSBOOK_SCHOOL_ID);
+    await loginAsAdmin(page);
+  });
+
+  test.afterEach(async ({ request }) => {
+    if (!fixture) return;
+    // Reset content fields BEFORE cascade-deleting the run. The
+    // ClassBookEntry is NOT FK-linked to TimetableRun (it's keyed on
+    // classSubjectId + date + period + weekType — schema.prisma:950), so
+    // the run's cascade-delete does not remove the entry. Without this
+    // reset, the next test would auto-resolve to an entry pre-populated
+    // with this test's Thema content.
+    const entry = await resolveEntryByTimetableLesson(
+      request,
+      CLASSBOOK_SCHOOL_ID,
+      fixture.lessonId,
+    );
+    await resetLessonContent(request, CLASSBOOK_SCHOOL_ID, entry.id);
+    await cleanupTimetableRun(fixture);
+    fixture = undefined;
+  });
+
+  test('CB-CONTENT-01: fill Thema → blur → "Gespeichert" → reload persists', async ({
+    page,
+    request,
+  }) => {
+    if (!fixture) throw new Error('fixture not seeded');
+
+    // API-side baseline: clear content fields. A previously killed run
+    // could otherwise leave a Thema value in the row, and the reload
+    // assertion below would pass against state we didn't put there.
+    const entry = await resolveEntryByTimetableLesson(
+      request,
+      CLASSBOOK_SCHOOL_ID,
+      fixture.lessonId,
+    );
+    await resetLessonContent(request, CLASSBOOK_SCHOOL_ID, entry.id);
+
+    await page.goto(`/classbook/${fixture.lessonId}?tab=inhalt`);
+
+    const themaField = page.getByLabel('Thema', { exact: true });
+    await expect(themaField).toBeVisible();
+    await expect(
+      themaField,
+      'Thema must start empty — reset wiped any prior content',
+    ).toHaveValue('');
+
+    // Timestamped value guards against the (unlikely) case that a sibling
+    // spec writes a fixed-string Thema between our PATCH-reset and the
+    // page reload. If we asserted on a literal like "Photosynthese" and
+    // a parallel test wrote the same, the persistence check would pass
+    // against state we didn't produce.
+    const themaValue = `E2E Thema ${Date.now()}`;
+    await themaField.fill(themaValue);
+
+    // Trigger blur — the LessonContentForm's onBlur handler debounces
+    // 1 s before firing the PATCH (LessonContentForm.tsx:73). Clicking
+    // the Lehrstoff label moves focus off Thema reliably.
+    await page.getByLabel('Lehrstoff', { exact: true }).click();
+
+    // "Gespeichert" inline indicator fades after 2 s — assert while it's
+    // still up (LessonContentForm.tsx:93). The indicator is the only
+    // wire-confirmed signal that the PATCH succeeded; without it the
+    // reload below would race the 1 s debounce.
+    await expect(
+      page.getByText('Gespeichert').first(),
+      'per-field "Gespeichert" indicator must appear after blur-save commits',
+    ).toBeVisible({ timeout: 5_000 });
+
+    await page.reload();
+
+    // After reload, the page re-resolves entry → reads back the persisted
+    // thema → initial state populates the textarea (route file uses
+    // entry.thema as initialData — $lessonId.tsx:144).
+    await expect(
+      page.getByLabel('Thema', { exact: true }),
+      'Thema value must persist across a reload — proves PATCH committed and entry.thema is round-tripped',
+    ).toHaveValue(themaValue);
+  });
+});

--- a/apps/web/e2e/helpers/classbook.ts
+++ b/apps/web/e2e/helpers/classbook.ts
@@ -68,3 +68,41 @@ export async function resetAttendanceForEntry(
     );
   }
 }
+
+/**
+ * Clear thema/lehrstoff/hausaufgabe on a ClassBookEntry so the next test
+ * sees blank inputs. The ClassBookEntry row is NOT linked to the
+ * TimetableRun fixture (its primary key chain is classSubjectId + date +
+ * period + weekType — see schema.prisma:950) so `cleanupTimetableRun()`
+ * does NOT cascade to it. Without this reset the spec's "Thema persists
+ * after reload" lock would mask a later test that silently inherits the
+ * E2E-flavoured content.
+ *
+ * UpdateLessonContentDto enforces `@IsString()` on each field, so we send
+ * empty strings (not `null`) — the service-side spread guards on
+ * `!== undefined` so empty strings get written through to Prisma verbatim
+ * (lesson-content.service.ts:28).
+ */
+export async function resetLessonContent(
+  request: APIRequestContext,
+  schoolId: string,
+  entryId: string,
+): Promise<void> {
+  const token = await getAdminToken(request);
+  const res = await request.patch(
+    `${CLASSBOOK_API}/schools/${schoolId}/classbook/${entryId}/content`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      data: { thema: '', lehrstoff: '', hausaufgabe: '' },
+    },
+  );
+  if (!res.ok() && res.status() !== 404) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[classbook] resetLessonContent soft-failed (${res.status()}); continuing`,
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Second sub-spec for #81 (Klassenbuch) — locks the **Inhalt** tab's auto-save loop on `/classbook/$lessonId`. Companion to #89 (Attendance).

## What's new

- `apps/web/e2e/classbook-lesson-content.spec.ts` — 1 test, chromium-only, fill-Thema → blur → "Gespeichert" → reload → assert persistence. Timestamped Thema value guards against sibling-spec collision.
- `apps/web/e2e/helpers/classbook.ts:resetLessonContent` — afterEach helper to clear thema/lehrstoff/hausaufgabe. Required because `ClassBookEntry` is keyed on `classSubjectId + date + period + weekType` (no FK to TimetableRun), so the run's cascade-delete doesn't reach it.

## Coverage delta

Issue #81 sub-spec list:
- [x] `classbook-attendance.spec.ts` — #89
- [x] `classbook-lesson-content.spec.ts` — this PR
- [ ] `classbook-grades.spec.ts`
- [ ] `classbook-student-notes.spec.ts`
- [ ] `classbook-realtime.spec.ts` (optional)

## Verification

5x parallel race-run with the classbook + timetable-mutating cluster:
\`\`\`
pnpm --filter @schoolflow/web exec playwright test \\
  e2e/classbook-lesson-content.spec.ts \\
  e2e/classbook-attendance.spec.ts \\
  e2e/timetable-non-admin-views.spec.ts \\
  e2e/timetable-generation-flow.spec.ts \\
  e2e/admin-timetable-edit-dnd.spec.ts \\
  --workers=2
\`\`\`
→ 5/5 stable green

## Test plan

- [ ] Playwright E2E CI grün (per D3 — kein Merge ohne grün)
- [ ] CB-CONTENT-01 passt auf desktop chromium
- [ ] Keine Regression im classbook-attendance Spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)