### PR TITLE
chore(e2e): Excuses parent-submit flow (#83)

### DIFF
--- a/apps/web/e2e/excuses-parent-submit.spec.ts
+++ b/apps/web/e2e/excuses-parent-submit.spec.ts
@@ -1,0 +1,105 @@
+/**
+ * Issue #83 — Excuses parent-submit flow.
+ *
+ * First sub-spec of the Entschuldigungen coverage gap. Locks the
+ * Eltern-side submission flow on /excuses:
+ *   1. kc-eltern (Franz Huber, parent of Lisa Huber in 1A) logs in.
+ *   2. Page mounts the ParentExcuseView with the ExcuseForm.
+ *   3. Form auto-fills today as Von + Bis (default) and Lisa Huber as
+ *      the only child (the Kind field renders as a text label, not a
+ *      Select, when children.length === 1 — ExcuseForm.tsx:137).
+ *   4. Pick "Krank" as Grund, type a timestamped note, submit.
+ *   5. Wait for the "Entschuldigung eingereicht" toast (wire-confirmed
+ *      signal; without it the list assertion races the mutation).
+ *   6. New excuse appears in "Eingereichte Entschuldigungen" with the
+ *      timestamped note + a PENDING status badge.
+ *
+ * Exercises POST /classbook/excuses + useCreateExcuse invalidation +
+ * GET /excuses refetch + ExcuseCard rendering. Teacher-review and
+ * attachment upload are deferred to follow-up sub-specs.
+ *
+ * Chromium-only-skip per the race-family precedent — every spec writes
+ * AbsenceExcuse rows for the same kc-eltern parent. The cleanup sweep
+ * is scoped to a note-prefix so parallel specs only delete their own.
+ */
+import { test, expect } from '@playwright/test';
+import { loginAsRole } from './helpers/login';
+import { EXCUSES_NOTE_PREFIX, cleanupE2EExcuses } from './helpers/excuses';
+
+test.describe('Issue #83 — Excuses parent submit (desktop)', () => {
+  test.skip(
+    ({ isMobile }) => isMobile,
+    'Form layout is identical across viewports — desktop only for the first lock.',
+  );
+  test.skip(
+    ({ browserName }) => browserName !== 'chromium',
+    'AbsenceExcuse rows for kc-eltern accumulate on parallel projects — chromium is the sole writer.',
+  );
+
+  test.afterEach(async () => {
+    // Sweep ALL E2E-EXC- excuses, not just the one created here. A
+    // killed previous run could leave parallel siblings behind, and
+    // those would clutter the list assertion below the next time the
+    // spec runs against an unclean DB.
+    await cleanupE2EExcuses();
+  });
+
+  test('EXC-PARENT-01: eltern submits an excuse → toast → row visible in submitted list with PENDING badge', async ({
+    page,
+  }) => {
+    await loginAsRole(page, 'eltern');
+    await page.goto('/excuses');
+
+    // Page chrome must mount — proves the route loaded before we assert
+    // on the form. The h1 is rendered verbatim by index.tsx:73.
+    await expect(
+      page.getByRole('heading', { name: 'Entschuldigungen', level: 1 }),
+    ).toBeVisible();
+
+    // Kind field renders as plain text when children.length === 1 —
+    // Lisa Huber is the only seed child of Franz Huber (kc-eltern).
+    // The cross-tenant assertion here is that Lisa's name appears, not
+    // a sibling-tenant child or an empty value.
+    await expect(
+      page.getByText('Lisa Huber'),
+      'Kind field must render Lisa Huber for Franz Huber (kc-eltern) per the seed ParentStudent link',
+    ).toBeVisible();
+
+    // Grund select — pick "Krank" (KRANK enum). The form's submit is
+    // gated on `studentId && reason` (ExcuseForm.tsx:97), so the
+    // reason pick must succeed before Submit is enabled.
+    await page.getByRole('combobox', { name: 'Grund' }).click();
+    await page.getByRole('option', { name: 'Krank', exact: true }).click();
+
+    // Timestamped note — keeps this run's row distinguishable from
+    // sibling specs' rows in the list assertion. EXCUSES_NOTE_PREFIX
+    // is what the cleanup sweep uses, so this stamp doubles as the
+    // cleanup discriminator.
+    const note = `${EXCUSES_NOTE_PREFIX}${Date.now()} — Lisa hat Fieber`;
+    await page.getByLabel(/Anmerkung/).fill(note);
+
+    await page
+      .getByRole('button', { name: 'Entschuldigung einreichen' })
+      .click();
+
+    await expect(
+      page.getByText('Entschuldigung eingereicht'),
+      'success toast must appear after the POST commits',
+    ).toBeVisible({ timeout: 5_000 });
+
+    // After the toast, useCreateExcuse invalidates useExcuses → refetch
+    // lands → the new excuse renders as an ExcuseCard below the form.
+    // The cross-cutting regression-lock is the timestamped note + the
+    // PENDING status — both are pulled from the API response, so a
+    // backend bug that drops the note or mis-defaults the status would
+    // be visible here.
+    await expect(
+      page.getByText(note),
+      'newly-created excuse must surface in "Eingereichte Entschuldigungen" with the timestamped note',
+    ).toBeVisible();
+    await expect(
+      page.getByText('Ausstehend').first(),
+      'newly-created excuse must render the PENDING status label (ExcuseCard renders "Ausstehend" for status=PENDING)',
+    ).toBeVisible();
+  });
+});

--- a/apps/web/e2e/helpers/excuses.ts
+++ b/apps/web/e2e/helpers/excuses.ts
@@ -1,0 +1,80 @@
+/**
+ * Excuses E2E helpers — #83.
+ *
+ * Phase 6 AbsenceExcuse REST contract:
+ *   - POST   /schools/:schoolId/classbook/excuses          — parent submits
+ *   - GET    /schools/:schoolId/classbook/excuses          — list (role-scoped)
+ *   - PATCH  /schools/:schoolId/classbook/excuses/:id/review — Klassenvorstand reviews
+ *
+ * There is NO DELETE endpoint on the excuses API (parents cannot withdraw
+ * a submitted excuse; teachers can only review). For test cleanup we go
+ * direct-to-Prisma, mirroring the `fixtures/timetable-run.ts` CommonJS-
+ * bridge pattern. The sweep is scoped to a note-prefix every spec stamps
+ * onto its excuse — that way two specs running in parallel can each
+ * clean up only their own rows.
+ */
+import 'dotenv/config';
+import { config as dotenvConfig } from 'dotenv';
+import { createRequire } from 'node:module';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+dotenvConfig({ path: path.resolve(__dirname, '../../../../.env') });
+
+const require = createRequire(import.meta.url);
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { PrismaClient } = require('../../../api/dist/config/database/generated/client.js') as {
+  PrismaClient: new (opts?: { adapter?: unknown }) => {
+    absenceExcuse: {
+      deleteMany: (args: {
+        where: Record<string, unknown>;
+      }) => Promise<{ count: number }>;
+    };
+    $disconnect: () => Promise<void>;
+  };
+};
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { PrismaPg } = require('../../../api/node_modules/@prisma/adapter-pg') as {
+  PrismaPg: new (opts: { connectionString: string }) => unknown;
+};
+
+/**
+ * Prefix every E2E-generated excuse note with this string so the cleanup
+ * sweep can find them. Two parallel specs CAN safely use the same
+ * prefix — `deleteMany` is idempotent and the per-row write is the only
+ * shared state.
+ */
+export const EXCUSES_NOTE_PREFIX = 'E2E-EXC-';
+
+/**
+ * Delete every AbsenceExcuse whose `note` field starts with the supplied
+ * prefix. Best-effort: swallows errors so a half-applied fixture from a
+ * previously killed run doesn't block the next test's setup.
+ *
+ * The `excuse_attachments` table cascade-deletes via the FK
+ * (schema.prisma) so explicit attachment cleanup is not needed.
+ */
+export async function cleanupE2EExcuses(
+  prefix: string = EXCUSES_NOTE_PREFIX,
+): Promise<void> {
+  const prisma = new PrismaClient({
+    adapter: new PrismaPg({ connectionString: process.env.DATABASE_URL ?? '' }),
+  });
+  try {
+    await prisma.absenceExcuse.deleteMany({
+      where: { note: { startsWith: prefix } },
+    });
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[excuses] cleanupE2EExcuses soft-failed:`,
+      err,
+    );
+  } finally {
+    await prisma.$disconnect();
+  }
+}


### PR DESCRIPTION
## Summary

First sub-spec for #83 (Entschuldigungen) — locks the Eltern-side submission flow on \`/excuses\`. Independent surface from in-flight PRs (#96), no cross-spec contention with the classbook cluster.

## What's new

- \`apps/web/e2e/excuses-parent-submit.spec.ts\` — 1 test, chromium-only: eltern login → /excuses → pick "Krank" → timestamped note → submit → toast → row with PENDING badge in submitted list.
- \`apps/web/e2e/helpers/excuses.ts\` — new helper module. Prisma-direct cleanup (excuses API has NO DELETE endpoint) using the same CommonJS-bridge pattern as \`fixtures/timetable-run.ts\`. Scoped to a note-prefix so parallel specs only sweep their own rows.

## Coverage delta

Issue #83 sub-spec list:
- [x] \`excuses-parent-submit.spec.ts\` — this PR
- [ ] \`excuses-teacher-review.spec.ts\` — next slice (Klassenvorstand approve/reject flow)
- [ ] \`excuses-attachments.spec.ts\` (optional) — PDF upload

## Verification

5x parallel race-run with the classbook + substitutions cluster:
\`\`\`
pnpm --filter @schoolflow/web exec playwright test \\
  e2e/excuses-parent-submit.spec.ts \\
  e2e/classbook-attendance.spec.ts \\
  e2e/classbook-lesson-content.spec.ts \\
  e2e/teacher-substitutions-my-absences.spec.ts \\
  e2e/admin-substitutions-list.spec.ts \\
  --workers=2
\`\`\`
→ 5/5 stable green

## Test plan

- [ ] Playwright E2E CI grün (per D3 — kein Merge ohne grün)
- [ ] EXC-PARENT-01 passt auf desktop chromium
- [ ] Keine Regression im classbook + substitutions cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)