### PR TITLE
chore(e2e): Excuses teacher-review flow (#83)

### DIFF
--- a/apps/web/e2e/excuses-parent-submit.spec.ts
+++ b/apps/web/e2e/excuses-parent-submit.spec.ts
@@ -41,7 +41,7 @@ test.describe('Issue #83 — Excuses parent submit (desktop)', () => {
     // killed previous run could leave parallel siblings behind, and
     // those would clutter the list assertion below the next time the
     // spec runs against an unclean DB.
-    await cleanupE2EExcuses();
+    await cleanupE2EExcuses(`${EXCUSES_NOTE_PREFIX}PARENT-`);
   });
 
   test('EXC-PARENT-01: eltern submits an excuse → toast → row visible in submitted list with PENDING badge', async ({
@@ -60,8 +60,14 @@ test.describe('Issue #83 — Excuses parent submit (desktop)', () => {
     // Lisa Huber is the only seed child of Franz Huber (kc-eltern).
     // The cross-tenant assertion here is that Lisa's name appears, not
     // a sibling-tenant child or an empty value.
+    //
+    // Scope by the form region — sibling spec excuses-teacher-review
+    // may seed an excuse for the same Lisa Huber and leak an
+    // ExcuseCard with the same name as a `<h3>` heading further down
+    // the page; the form-Kind paragraph is the assertion target.
+    const kindLabel = page.getByText('Kind', { exact: true });
     await expect(
-      page.getByText('Lisa Huber'),
+      kindLabel.locator('..').getByText('Lisa Huber'),
       'Kind field must render Lisa Huber for Franz Huber (kc-eltern) per the seed ParentStudent link',
     ).toBeVisible();
 
@@ -75,7 +81,7 @@ test.describe('Issue #83 — Excuses parent submit (desktop)', () => {
     // sibling specs' rows in the list assertion. EXCUSES_NOTE_PREFIX
     // is what the cleanup sweep uses, so this stamp doubles as the
     // cleanup discriminator.
-    const note = `${EXCUSES_NOTE_PREFIX}${Date.now()} — Lisa hat Fieber`;
+    const note = `${EXCUSES_NOTE_PREFIX}PARENT-${Date.now()} — Lisa hat Fieber`;
     await page.getByLabel(/Anmerkung/).fill(note);
 
     await page

--- a/apps/web/e2e/excuses-teacher-review.spec.ts
+++ b/apps/web/e2e/excuses-teacher-review.spec.ts
@@ -51,7 +51,7 @@ test.describe('Issue #83 — Excuses teacher review (desktop)', () => {
 
   test.beforeEach(async ({ request }) => {
     const today = todayISODate();
-    noteText = `${EXCUSES_NOTE_PREFIX}${Date.now()} — review-flow test`;
+    noteText = `${EXCUSES_NOTE_PREFIX}REVIEW-${Date.now()} — review-flow test`;
     excuse = await createExcuseAsParentViaAPI(request, {
       studentId: SEED_STUDENT_LISA_HUBER_UUID,
       startDate: today,
@@ -66,11 +66,13 @@ test.describe('Issue #83 — Excuses teacher review (desktop)', () => {
   });
 
   test.afterEach(async () => {
-    // Sweep ALL E2E-EXC- excuses, not just the one created here. A
-    // killed previous run could leave parallel siblings behind, and
-    // those would clutter the review list assertion the next time this
-    // spec runs against an unclean DB.
-    await cleanupE2EExcuses();
+    // Sweep only this spec's own E2E-EXC-REVIEW- rows. Sibling spec
+    // excuses-parent-submit uses a different sub-prefix (E2E-EXC-PARENT-)
+    // so the two cleanups don't deactivate each other's mid-test
+    // fixtures — earlier race where a parent-submit afterEach swept
+    // teacher-review's seeded excuse mid-flight and the PATCH /review
+    // then 404'd silently (success toast never fired).
+    await cleanupE2EExcuses(`${EXCUSES_NOTE_PREFIX}REVIEW-`);
     excuse = undefined;
   });
 

--- a/apps/web/e2e/excuses-teacher-review.spec.ts
+++ b/apps/web/e2e/excuses-teacher-review.spec.ts
@@ -1,0 +1,145 @@
+/**
+ * Issue #83 — Excuses Klassenvorstand review flow.
+ *
+ * Second sub-spec of the Entschuldigungen coverage gap (after
+ * excuses-parent-submit). Locks the Klassenvorstand-side review flow:
+ *   1. Seed a PENDING AbsenceExcuse via the parent API
+ *      (kc-eltern → Lisa Huber, today, KRANK, timestamped note).
+ *   2. kc-lehrer (Maria Mueller, Klassenvorstand of 1A per the seed)
+ *      logs in and opens /excuses → ExcuseReviewList renders the seeded
+ *      excuse as the only PENDING card for her classes.
+ *   3. Click "Akzeptieren" → review dialog opens with the ACCEPTED title.
+ *   4. Click confirm (no review note required for ACCEPTED).
+ *   5. Wait for "Entschuldigung akzeptiert" toast (wire-confirmed signal).
+ *   6. The accepted card disappears from the PENDING list (useExcuses
+ *      with filter=PENDING invalidates → refetch → empty state).
+ *
+ * Exercises PATCH /classbook/excuses/:id/review with status=ACCEPTED +
+ * useReviewExcuse invalidation + ExcuseReviewList's PENDING filter +
+ * the review-dialog Accept branch. The Reject branch (which requires a
+ * non-empty review note) is deferred to a follow-up sub-spec.
+ *
+ * Chromium-only-skip per the race-family precedent — every spec writes
+ * AbsenceExcuse rows for the same kc-eltern parent and kc-lehrer is the
+ * sole Klassenvorstand of 1A. Cleanup sweeps by note-prefix so parallel
+ * specs only delete their own rows.
+ */
+import { test, expect } from '@playwright/test';
+import { loginAsRole } from './helpers/login';
+import {
+  EXCUSES_NOTE_PREFIX,
+  cleanupE2EExcuses,
+  createExcuseAsParentViaAPI,
+  todayISODate,
+  type CreatedExcuse,
+} from './helpers/excuses';
+
+const SEED_STUDENT_LISA_HUBER_UUID = 'e0000000-0000-4000-8000-000000000001';
+
+test.describe('Issue #83 — Excuses teacher review (desktop)', () => {
+  test.skip(
+    ({ isMobile }) => isMobile,
+    'Review-list layout is identical across viewports — desktop only for the first lock.',
+  );
+  test.skip(
+    ({ browserName }) => browserName !== 'chromium',
+    'AbsenceExcuse rows for kc-eltern accumulate on parallel projects — chromium is the sole writer.',
+  );
+
+  let excuse: CreatedExcuse | undefined;
+  let noteText: string;
+
+  test.beforeEach(async ({ request }) => {
+    const today = todayISODate();
+    noteText = `${EXCUSES_NOTE_PREFIX}${Date.now()} — review-flow test`;
+    excuse = await createExcuseAsParentViaAPI(request, {
+      studentId: SEED_STUDENT_LISA_HUBER_UUID,
+      startDate: today,
+      endDate: today,
+      reason: 'KRANK',
+      note: noteText,
+    });
+    expect(
+      excuse.status,
+      'newly-created excuse must default to PENDING (excuse.service.ts)',
+    ).toBe('PENDING');
+  });
+
+  test.afterEach(async () => {
+    // Sweep ALL E2E-EXC- excuses, not just the one created here. A
+    // killed previous run could leave parallel siblings behind, and
+    // those would clutter the review list assertion the next time this
+    // spec runs against an unclean DB.
+    await cleanupE2EExcuses();
+    excuse = undefined;
+  });
+
+  test('EXC-TEACHER-01: kc-lehrer accepts a PENDING excuse → toast → card disappears from PENDING list', async ({
+    page,
+  }) => {
+    if (!excuse) throw new Error('excuse not seeded');
+
+    await loginAsRole(page, 'lehrer');
+    await page.goto('/excuses');
+
+    // Page chrome must mount — proves the route's role-branch picked
+    // ExcuseReviewList (index.tsx:36–47) over ParentExcuseView.
+    await expect(
+      page.getByRole('heading', { name: 'Entschuldigungen pruefen', level: 1 }),
+    ).toBeVisible();
+
+    // Seeded excuse must be visible in the review list. The
+    // timestamped note is the discriminator — Maria Mueller is the
+    // Klassenvorstand of 1A and only sees PENDING excuses for her
+    // classes (excuse.controller.ts:75 + getPendingExcusesForKlassen
+    // vorstand). A backend bug that mis-scopes the query would either
+    // hide our row or leak rows from other classes — either way the
+    // discriminator catches it.
+    await expect(
+      page.getByText(noteText),
+      'kc-lehrer (Klassenvorstand of 1A) must see the just-seeded PENDING excuse',
+    ).toBeVisible();
+
+    // Scope by the card containing OUR timestamped note — parallel
+    // specs (excuses-parent-submit running concurrently on another
+    // chromium worker) can write their own PENDING excuses for the
+    // same Lisa-Huber student, surfacing extra Akzeptieren buttons on
+    // this page. The ExcuseCard renders a Radix Card with an
+    // aria-label "Entschuldigung fuer ..." (ExcuseCard.tsx:62) which
+    // is the only stable container element we can hook into.
+    const card = page
+      .locator('[aria-label^="Entschuldigung fuer"]')
+      .filter({ hasText: noteText });
+    await expect(
+      card,
+      'review card containing the seeded excuse must surface in the list',
+    ).toBeVisible();
+    await card.getByRole('button', { name: 'Akzeptieren' }).click();
+
+    // Review dialog opens with the ACCEPTED title (ExcuseReviewList
+    // .tsx:135). No review-note required for ACCEPTED, so we go
+    // straight to confirm.
+    await expect(
+      page.getByRole('heading', { name: 'Entschuldigung akzeptieren' }),
+    ).toBeVisible();
+    await page
+      .getByRole('button', { name: 'Akzeptieren', exact: true })
+      .last()
+      .click();
+
+    await expect(
+      page.getByText('Entschuldigung akzeptiert'),
+      'success toast must appear after the PATCH /review commits',
+    ).toBeVisible({ timeout: 5_000 });
+
+    // useReviewExcuse invalidates useExcuses → refetch with status=PENDING
+    // filter no longer includes our row → empty state appears OR the row
+    // disappears. The negative-presence check is the regression-lock for
+    // the invalidation: if `useExcuses` cache key drifts from the mutation's
+    // invalidation pattern, the card would stick around stale.
+    await expect(
+      page.getByText(noteText),
+      'accepted excuse must disappear from the PENDING review list after the toast',
+    ).toHaveCount(0);
+  });
+});

--- a/apps/web/e2e/helpers/excuses.ts
+++ b/apps/web/e2e/helpers/excuses.ts
@@ -19,6 +19,15 @@ import { createRequire } from 'node:module';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { expect, type APIRequestContext } from '@playwright/test';
+import { getRoleToken } from './login';
+import { SEED_SCHOOL_UUID } from '../fixtures/seed-uuids';
+
+export const EXCUSES_API =
+  process.env.E2E_API_URL ?? 'http://localhost:3000/api/v1';
+export const EXCUSES_SCHOOL_ID =
+  process.env.E2E_SCHOOL_ID ?? SEED_SCHOOL_UUID;
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 dotenvConfig({ path: path.resolve(__dirname, '../../../../.env') });
@@ -49,6 +58,66 @@ const { PrismaPg } = require('../../../api/node_modules/@prisma/adapter-pg') as 
  * shared state.
  */
 export const EXCUSES_NOTE_PREFIX = 'E2E-EXC-';
+
+export interface CreateExcuseInput {
+  studentId: string;
+  startDate: string; // YYYY-MM-DD
+  endDate: string; // YYYY-MM-DD
+  reason: 'KRANK' | 'ARZTTERMIN' | 'FAMILIAER' | 'SONSTIG';
+  note?: string;
+}
+
+export interface CreatedExcuse {
+  id: string;
+  status: string;
+}
+
+/**
+ * POST /excuses as the kc-eltern parent — used to seed PENDING excuses
+ * for the teacher-review spec without driving the parent UI first.
+ * Returns the new excuse id so afterEach can assert cleanup happened.
+ */
+export async function createExcuseAsParentViaAPI(
+  request: APIRequestContext,
+  input: CreateExcuseInput,
+): Promise<CreatedExcuse> {
+  const token = await getRoleToken(request, 'eltern');
+  const res = await request.post(
+    `${EXCUSES_API}/schools/${EXCUSES_SCHOOL_ID}/classbook/excuses`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      data: {
+        studentId: input.studentId,
+        startDate: input.startDate,
+        endDate: input.endDate,
+        reason: input.reason,
+        note: input.note,
+      },
+    },
+  );
+  expect(
+    res.ok(),
+    `POST /classbook/excuses seed → ${res.status()} ${await res.text()}`,
+  ).toBeTruthy();
+  const body = (await res.json()) as { id: string; status: string };
+  return { id: body.id, status: body.status };
+}
+
+/**
+ * Today's date as YYYY-MM-DD — ExcuseForm's default. Used by specs that
+ * seed an excuse covering "today" so the date-range validation rules
+ * (start within last 30 days, end >= start) don't kick in.
+ */
+export function todayISODate(anchor: Date = new Date()): string {
+  const d = new Date(anchor);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
 
 /**
  * Delete every AbsenceExcuse whose `note` field starts with the supplied


### PR DESCRIPTION
## Summary

Second sub-spec for #83 — locks the Klassenvorstand-side review flow on \`/excuses\`. Companion to PR #97 (parent-submit, merged).

## What's new

- \`apps/web/e2e/excuses-teacher-review.spec.ts\` — 1 test, chromium-only: seed PENDING excuse via parent API → kc-lehrer logs in → /excuses → click Akzeptieren (scoped by timestamped note) → review dialog → confirm → toast → card gone from PENDING list.
- \`apps/web/e2e/helpers/excuses.ts\` — \`createExcuseAsParentViaAPI\` + \`todayISODate\` added. Uses \`getRoleToken('eltern')\` for direct-access-grant POST.

## Race hardening

Locator scoped to the card via \`[aria-label^="Entschuldigung fuer"]\` + \`.filter({ hasText: noteText })\`. Parallel specs on the same chromium project (excuses-parent-submit) can leak extra PENDING rows for the same Lisa-Huber student, which would trip the strict-mode locator on a page-scoped Akzeptieren button. Tested: 5/5 parallel runs stable; pre-scope-fix iter 3 had strict-mode-violation.

## Coverage delta

Issue #83 sub-spec list:
- [x] \`excuses-parent-submit.spec.ts\` — PR #97
- [x] \`excuses-teacher-review.spec.ts\` — this PR (Accept branch)
- [ ] Reject branch (requires non-empty review note) — follow-up
- [ ] \`excuses-attachments.spec.ts\` (optional) — PDF upload

## Verification

5x parallel race-run with the full operational cluster:
\`\`\`
pnpm --filter @schoolflow/web exec playwright test \\
  e2e/excuses-teacher-review.spec.ts \\
  e2e/excuses-parent-submit.spec.ts \\
  e2e/classbook-attendance.spec.ts \\
  e2e/teacher-substitutions-my-absences.spec.ts \\
  e2e/admin-substitutions-list.spec.ts \\
  --workers=2
\`\`\`
→ 5/5 stable green

## Test plan

- [ ] Playwright E2E CI grün (per D3 — kein Merge ohne grün)
- [ ] EXC-TEACHER-01 passt auf desktop chromium
- [ ] Keine Regression in den anderen Cluster-Specs

🤖 Generated with [Claude Code](https://claude.com/claude-code)