### PR TITLE
chore(e2e): Classbook Homework create flow (#82)

### DIFF
--- a/apps/web/e2e/classbook-homework.spec.ts
+++ b/apps/web/e2e/classbook-homework.spec.ts
@@ -1,0 +1,140 @@
+/**
+ * Issue #82 — Classbook Homework create flow.
+ *
+ * First sub-spec of the Hausaufgaben/Klausuren coverage gap. Locks the
+ * create-flow on the "Aufgaben" tab of /classbook/$lessonId:
+ *   1. Open the lesson with ?tab=aufgaben → "Hausaufgaben" tab shows the
+ *      empty state for a fresh ClassSubject.
+ *   2. Click "Hausaufgabe erstellen" → HomeworkDialog opens.
+ *   3. Fill a timestamped title (`E2E-HW-...`), optional description,
+ *      tomorrow's due date, submit.
+ *   4. Dialog closes → useCreateHomework invalidates useHomework →
+ *      refetch surfaces the new row in the list.
+ *
+ * Exercises POST /homework + the HomeworkDialog form + the
+ * HomeworkExamList Hausaufgaben-tab render. Edit + delete + the Exam
+ * surface (which has the ExamCollisionWarning regression risk per the
+ * issue body) are deferred to follow-up sub-specs.
+ *
+ * Chromium-only-skip per the race-family precedent — every spec on
+ * this surface writes Homework rows on the shared seed ClassSubject.
+ * Cleanup sweeps by title-prefix so parallel specs only delete their
+ * own rows.
+ */
+import { test, expect } from '@playwright/test';
+import { loginAsAdmin } from './helpers/login';
+import { CLASSBOOK_SCHOOL_ID } from './helpers/classbook';
+import {
+  HOMEWORK_TITLE_PREFIX,
+  cleanupE2EHomework,
+  isoDaysFromNow,
+} from './helpers/homework';
+import {
+  cleanupTimetableRun,
+  seedTimetableRun,
+  type TimetableRunFixture,
+} from './fixtures/timetable-run';
+
+test.describe('Issue #82 — Classbook Homework create (desktop)', () => {
+  test.skip(
+    ({ isMobile }) => isMobile,
+    'Dialog layout is identical across viewports — desktop only for the first lock.',
+  );
+  test.skip(
+    ({ browserName }) => browserName !== 'chromium',
+    'Mutates Homework rows on the shared seed ClassSubject — chromium is the sole writer.',
+  );
+
+  let fixture: TimetableRunFixture | undefined;
+
+  test.beforeEach(async ({ page }) => {
+    fixture = await seedTimetableRun(CLASSBOOK_SCHOOL_ID);
+    await loginAsAdmin(page);
+  });
+
+  test.afterEach(async ({ request }) => {
+    // Sweep ALL E2E-HW- rows on this school. The Homework FK to
+    // ClassBookEntry is `onDelete: SetNull` (schema.prisma:1425) and
+    // there's no FK to TimetableRun, so cleanupTimetableRun() does NOT
+    // cascade to Homework rows; they accumulate across specs without
+    // this explicit sweep.
+    await cleanupE2EHomework(request);
+    if (fixture) {
+      await cleanupTimetableRun(fixture);
+      fixture = undefined;
+    }
+  });
+
+  test('CB-HW-01: create homework via dialog → row visible in Hausaufgaben tab', async ({
+    page,
+    request,
+  }) => {
+    if (!fixture) throw new Error('fixture not seeded');
+
+    // Make sure no leftover homework from a killed prior run pollutes
+    // the assertions below — the empty-state and the row-visibility
+    // checks both depend on a known starting state.
+    await cleanupE2EHomework(request);
+
+    await page.goto(`/classbook/${fixture.lessonId}?tab=aufgaben`);
+
+    // The empty state is rendered when homework.length === 0
+    // (HomeworkExamList.tsx:61). A polluted DB or a wrong tab default
+    // would fail this loudly.
+    await expect(
+      page.getByText('Keine Hausaufgaben', { exact: true }),
+      'fresh ClassSubject must render the Hausaufgaben empty state',
+    ).toBeVisible();
+
+    // Open the dialog. The action-bar button has the same label as the
+    // dialog's submit, so we disambiguate by clicking the only one
+    // present BEFORE the dialog mounts (the submit appears later).
+    await page
+      .getByRole('button', { name: 'Hausaufgabe erstellen' })
+      .click();
+
+    // Dialog title is the cross-cutting mount signal — without it the
+    // form fields below would either not exist or be from a different
+    // dialog. (HomeworkDialog.tsx:90)
+    await expect(
+      page.getByRole('heading', { name: 'Hausaufgabe erstellen', level: 2 }),
+    ).toBeVisible();
+
+    // Timestamped title doubles as the cleanup discriminator (the
+    // prefix-sweep in afterEach hooks on HOMEWORK_TITLE_PREFIX).
+    const title = `${HOMEWORK_TITLE_PREFIX}${Date.now()} — Mathe Kapitel 3`;
+    await page.getByLabel('Titel *').fill(title);
+    await page
+      .getByLabel('Beschreibung')
+      .fill('Aufgaben 12–18 auf Seite 47');
+    await page.getByLabel('Faellig am *').fill(isoDaysFromNow(1));
+
+    // Submit. After the mutation onSuccess, the dialog closes (the
+    // `onSuccess: () => onClose()` chain at HomeworkDialog.tsx:70).
+    // We then wait for the dialog to disappear before asserting on
+    // the list — otherwise the dialog could still mask the list row.
+    await page
+      .getByRole('button', { name: 'Hausaufgabe erstellen' })
+      .last()
+      .click();
+
+    await expect(
+      page.getByRole('heading', { name: 'Hausaufgabe erstellen', level: 2 }),
+      'dialog must close after a successful create',
+    ).toHaveCount(0);
+
+    // Refetched list row carries the timestamped title verbatim.
+    // HomeworkExamList renders the title as the row heading
+    // (HomeworkExamList.tsx:159). The negative-presence check on the
+    // empty state guards against the row being rendered ALONGSIDE the
+    // empty state (which would mean the conditional render broke).
+    await expect(
+      page.getByText(title),
+      'newly-created homework must surface in the Hausaufgaben tab',
+    ).toBeVisible();
+    await expect(
+      page.getByText('Keine Hausaufgaben', { exact: true }),
+      'empty state must be gone once the list has at least one row',
+    ).toHaveCount(0);
+  });
+});

--- a/apps/web/e2e/helpers/homework.ts
+++ b/apps/web/e2e/helpers/homework.ts
@@ -1,0 +1,68 @@
+/**
+ * Homework / Exams E2E helpers — #82.
+ *
+ * The homework API ships full CRUD (POST/GET/DELETE) so cleanup goes
+ * through the REST endpoint — no Prisma-direct bridge needed (the
+ * excuses helper has the Prisma bridge for that gap).
+ */
+import { type APIRequestContext } from '@playwright/test';
+import { getAdminToken } from './login';
+import { SEED_SCHOOL_UUID } from '../fixtures/seed-uuids';
+
+export const HOMEWORK_API =
+  process.env.E2E_API_URL ?? 'http://localhost:3000/api/v1';
+export const HOMEWORK_SCHOOL_ID =
+  process.env.E2E_SCHOOL_ID ?? SEED_SCHOOL_UUID;
+
+/**
+ * Prefix every E2E-generated homework title with this string so the
+ * cleanup sweep can find them. Two parallel specs CAN safely use the
+ * same prefix — DELETE is idempotent and per-row.
+ */
+export const HOMEWORK_TITLE_PREFIX = 'E2E-HW-';
+
+/**
+ * Sweep all Homework rows on the seed school whose title starts with
+ * the supplied prefix. Best-effort: 404 per row is fine (parallel sweep
+ * may have already deleted it).
+ */
+export async function cleanupE2EHomework(
+  request: APIRequestContext,
+  prefix: string = HOMEWORK_TITLE_PREFIX,
+): Promise<void> {
+  const token = await getAdminToken(request);
+  // GET /homework returns all homework for the school (filtered server-side
+  // by RBAC; admin gets the full list).
+  const listRes = await request.get(
+    `${HOMEWORK_API}/schools/${HOMEWORK_SCHOOL_ID}/homework`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+  if (!listRes.ok()) return;
+  const list = (await listRes.json()) as Array<{ id: string; title: string }>;
+  await Promise.all(
+    list
+      .filter((hw) => hw.title.startsWith(prefix))
+      .map((hw) =>
+        request
+          .delete(
+            `${HOMEWORK_API}/schools/${HOMEWORK_SCHOOL_ID}/homework/${hw.id}`,
+            { headers: { Authorization: `Bearer ${token}` } },
+          )
+          .catch(() => undefined),
+      ),
+  );
+}
+
+/**
+ * YYYY-MM-DD for `daysFromNow` from today. HomeworkDialog requires
+ * `dueDate >= today` (HomeworkDialog.tsx:54) — default `daysFromNow=1`
+ * gives the form a tomorrow due-date which always passes.
+ */
+export function isoDaysFromNow(daysFromNow: number = 1): string {
+  const d = new Date();
+  d.setDate(d.getDate() + daysFromNow);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}


### PR DESCRIPTION
## Summary

First sub-spec for #82 (Hausaufgaben + Klausuren) — locks the create-flow on the "Aufgaben" tab of \`/classbook/\$lessonId\`. Independent surface from PR #98 (#83 teacher-review).

## What's new

- \`apps/web/e2e/classbook-homework.spec.ts\` — 1 test, chromium-only: open aufgaben-tab → "Keine Hausaufgaben" empty state → click "Hausaufgabe erstellen" → fill title/description/dueDate → submit → dialog closes → row visible in list.
- \`apps/web/e2e/helpers/homework.ts\` — sweep-by-title-prefix cleanup (Homework has full CRUD; no Prisma bridge needed) + \`isoDaysFromNow\` for the form's \`dueDate >= today\` validation.

## Coverage delta

Issue #82 sub-spec list:
- [x] \`classbook-homework.spec.ts\` — this PR (create flow)
- [ ] \`classbook-exams.spec.ts\` — Klausur dialog + ExamCollisionWarning
- [ ] \`timetable-cell-badges.spec.ts\` — badges clickable in timetable cells

## Verification

5x parallel race-run with the full classbook + adjacent cluster:
\`\`\`
pnpm --filter @schoolflow/web exec playwright test \\
  e2e/classbook-homework.spec.ts \\
  e2e/classbook-attendance.spec.ts \\
  e2e/classbook-lesson-content.spec.ts \\
  e2e/classbook-student-notes.spec.ts \\
  e2e/timetable-non-admin-views.spec.ts \\
  e2e/admin-substitutions-list.spec.ts \\
  --workers=2
\`\`\`
→ 5/5 stable green

## Test plan

- [ ] Playwright E2E CI grün (per D3 — kein Merge ohne grün)
- [ ] CB-HW-01 passt auf desktop chromium
- [ ] Keine Regression im classbook + adjacent cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)