### PR TITLE
fix(classbook): wire classId + invalidate exam-collision cache — 3 prod bugs (#82)

### DIFF
--- a/apps/api/src/modules/classbook/attendance.service.ts
+++ b/apps/api/src/modules/classbook/attendance.service.ts
@@ -112,6 +112,12 @@ export class AttendanceService {
       updatedAt: entry.updatedAt.toISOString(),
       subjectName: classSubject.subject.name,
       className: classSubject.schoolClass.name,
+      // classId is required by ExamDialog to satisfy CreateExamDto.classId
+      // (@IsNotEmpty) — without it the Pruefung-eintragen flow on
+      // /classbook/$lessonId silently 422s. Surfacing it on the
+      // by-timetable-lesson response is the cheapest fix; the frontend
+      // route already passes the entry verbatim into the dialog props.
+      classId: classSubject.classId,
       teacherName: teacher ? `${teacher.person.firstName} ${teacher.person.lastName}` : undefined,
     };
   }

--- a/apps/web/e2e/classbook-exams.spec.ts
+++ b/apps/web/e2e/classbook-exams.spec.ts
@@ -1,0 +1,197 @@
+/**
+ * Issue #82 — Classbook Exam create + collision override flow.
+ *
+ * Second sub-spec of the Hausaufgaben/Klausuren coverage gap (after
+ * PR #99 classbook-homework). Locks the headline regression-risk
+ * surface called out in the issue body: the ExamCollisionWarning
+ * banner + the "Trotzdem eintragen" override path.
+ *
+ * Flow:
+ *   1. Open /classbook/$lessonId?tab=aufgaben → "Pruefungen" sub-tab.
+ *   2. Empty state visible ("Keine Pruefungen geplant").
+ *   3. Click "Pruefung eintragen" → ExamDialog opens.
+ *   4. Fill timestamped title #1 + a future date → submit. Dialog
+ *      closes, exam #1 row visible in the list.
+ *   5. Click "Pruefung eintragen" again → fill title #2 + the SAME
+ *      date → backend collision-check fires → ExamCollisionWarning
+ *      renders with the "Trotzdem eintragen" override button.
+ *   6. Submit is BLOCKED until override is clicked (canSubmit gate at
+ *      ExamDialog.tsx:73). Click "Trotzdem eintragen" → submit → exam
+ *      #2 row also visible.
+ *
+ * Exercises POST /exams + GET /exams/collision-check + the
+ * ExamDialog's forceCreate gate + the ExamCollisionWarning render.
+ *
+ * Chromium-only-skip per the race-family precedent — every spec on
+ * this surface writes Exam rows on the same seed class. Cleanup
+ * sweeps by title-prefix so parallel specs only delete their own.
+ */
+import { test, expect } from '@playwright/test';
+import { loginAsAdmin } from './helpers/login';
+import { CLASSBOOK_SCHOOL_ID } from './helpers/classbook';
+import {
+  EXAMS_TITLE_PREFIX,
+  cleanupE2EExams,
+  isoDaysFromNow,
+} from './helpers/exams';
+import {
+  cleanupTimetableRun,
+  seedTimetableRun,
+  type TimetableRunFixture,
+} from './fixtures/timetable-run';
+
+test.describe('Issue #82 — Classbook Exam create + collision (desktop)', () => {
+  test.skip(
+    ({ isMobile }) => isMobile,
+    'Dialog + collision-warning layout is identical across viewports — desktop only for the first lock.',
+  );
+  test.skip(
+    ({ browserName }) => browserName !== 'chromium',
+    'Mutates Exam rows on the shared seed class — chromium is the sole writer.',
+  );
+
+  let fixture: TimetableRunFixture | undefined;
+
+  test.beforeEach(async ({ page }) => {
+    fixture = await seedTimetableRun(CLASSBOOK_SCHOOL_ID);
+    await loginAsAdmin(page);
+  });
+
+  test.afterEach(async ({ request }) => {
+    // Sweep ALL E2E-EX- rows. No FK to TimetableRun, so
+    // cleanupTimetableRun does NOT cascade to Exam rows; they
+    // accumulate across specs without this explicit sweep.
+    await cleanupE2EExams(request);
+    if (fixture) {
+      await cleanupTimetableRun(fixture);
+      fixture = undefined;
+    }
+  });
+
+  test('CB-EX-01: create exam, then second exam same day → collision warning → override → both visible', async ({
+    page,
+    request,
+  }) => {
+    if (!fixture) throw new Error('fixture not seeded');
+
+    // API-side baseline so the empty-state check below is honest.
+    await cleanupE2EExams(request);
+
+    await page.goto(`/classbook/${fixture.lessonId}?tab=aufgaben`);
+
+    // Switch to the Pruefungen sub-tab. The HomeworkExamList Tabs
+    // default to hausaufgaben; we drive the click explicitly so a
+    // future default-change doesn't silently shift coverage.
+    await page.getByRole('tab', { name: 'Pruefungen' }).click();
+    await expect(
+      page.getByText('Keine Pruefungen geplant', { exact: true }),
+      'fresh class must render the Pruefungen empty state',
+    ).toBeVisible();
+
+    // -- Exam 1: simple create, no collision yet -----------------------
+    await page
+      .getByRole('button', { name: 'Pruefung eintragen' })
+      .click();
+
+    await expect(
+      page.getByRole('heading', { name: 'Pruefung eintragen', level: 2 }),
+    ).toBeVisible();
+
+    const ts = Date.now();
+    const title1 = `${EXAMS_TITLE_PREFIX}${ts}-A — Mathe Schularbeit`;
+    const sharedDate = isoDaysFromNow(2);
+
+    await page.getByLabel('Titel *').fill(title1);
+    await page.getByLabel('Datum *').fill(sharedDate);
+
+    // No collision yet — ExamCollisionWarning must NOT render here.
+    // The negative-presence check guards against a backend mis-scope
+    // that flags ANY existing exam as a collision (would have flagged
+    // a parallel spec's row).
+    await expect(
+      page.getByRole('alert').filter({ hasText: 'Achtung: Am' }),
+      'no collision is expected for the FIRST exam on this date — the alert must not render',
+    ).toHaveCount(0);
+
+    await page
+      .getByRole('button', { name: 'Pruefung eintragen' })
+      .last()
+      .click();
+    await expect(
+      page.getByRole('heading', { name: 'Pruefung eintragen', level: 2 }),
+      'dialog must close after exam #1 commits',
+    ).toHaveCount(0);
+
+    await expect(
+      page.getByText(title1),
+      'exam #1 must surface in the Pruefungen list after create',
+    ).toBeVisible();
+
+    // -- Exam 2: SAME date → collision → override → submit -------------
+    await page
+      .getByRole('button', { name: 'Pruefung eintragen' })
+      .click();
+    await expect(
+      page.getByRole('heading', { name: 'Pruefung eintragen', level: 2 }),
+    ).toBeVisible();
+
+    const title2 = `${EXAMS_TITLE_PREFIX}${ts}-B — Mathe Wiederholung`;
+    await page.getByLabel('Titel *').fill(title2);
+    await page.getByLabel('Datum *').fill(sharedDate);
+
+    // Collision warning must render — the existing exam #1 collides
+    // because (classId, date) matches. The banner shows the existing
+    // exam's title verbatim (ExamCollisionWarning.tsx:43).
+    const warning = page
+      .getByRole('alert')
+      .filter({ hasText: 'Achtung: Am' });
+    await expect(
+      warning,
+      'collision warning must surface when a second exam is scheduled on the same date for the same class',
+    ).toBeVisible();
+    await expect(
+      warning,
+      'warning must name the existing exam (title #1) so the user knows what collides',
+    ).toContainText(title1);
+
+    // Submit is gated at the form level — canSubmit goes false while
+    // collision is unresolved (ExamDialog.tsx:73). The disabled attribute
+    // is the regression-lock for the gate; without the override path the
+    // user cannot submit by accident.
+    const submitBtn = page
+      .getByRole('button', { name: 'Pruefung eintragen' })
+      .last();
+    await expect(
+      submitBtn,
+      'submit must be disabled while collision is unresolved (forceCreate=false)',
+    ).toBeDisabled();
+
+    // Click the inline "Trotzdem eintragen" override. The warning
+    // sub-button has the same label substring as the dialog's submit;
+    // we scope to the alert region to avoid the strict-mode trap.
+    await warning
+      .getByRole('button', { name: 'Trotzdem eintragen' })
+      .click();
+
+    // Override flips forceCreate=true → submit re-enables.
+    await expect(
+      submitBtn,
+      'submit must re-enable after the override flips forceCreate=true',
+    ).toBeEnabled();
+    await submitBtn.click();
+    await expect(
+      page.getByRole('heading', { name: 'Pruefung eintragen', level: 2 }),
+      'dialog must close after collision override + submit',
+    ).toHaveCount(0);
+
+    // Both exams visible in the list.
+    await expect(
+      page.getByText(title1),
+      'exam #1 must still be in the list',
+    ).toBeVisible();
+    await expect(
+      page.getByText(title2),
+      'overridden exam #2 must also surface in the list',
+    ).toBeVisible();
+  });
+});

--- a/apps/web/e2e/helpers/exams.ts
+++ b/apps/web/e2e/helpers/exams.ts
@@ -1,0 +1,83 @@
+/**
+ * Exams E2E helpers — #82.
+ *
+ * The exams API ships full CRUD (POST/GET/DELETE), so cleanup goes
+ * through the REST endpoint. Companion helper to `helpers/homework.ts`
+ * — kept separate so the two PRs landing in #82 don't conflict on
+ * helper-file edits while in flight (PR #99 ships homework.ts; this
+ * branch ships exams.ts).
+ */
+import { type APIRequestContext } from '@playwright/test';
+import { getAdminToken } from './login';
+import { SEED_SCHOOL_UUID } from '../fixtures/seed-uuids';
+
+export const EXAMS_API =
+  process.env.E2E_API_URL ?? 'http://localhost:3000/api/v1';
+export const EXAMS_SCHOOL_ID =
+  process.env.E2E_SCHOOL_ID ?? SEED_SCHOOL_UUID;
+
+/**
+ * Prefix every E2E-generated exam title with this string so the
+ * cleanup sweep can find them. Two parallel specs CAN safely use the
+ * same prefix — DELETE is idempotent and per-row.
+ */
+export const EXAMS_TITLE_PREFIX = 'E2E-EX-';
+
+/** Seed class IDs the cleanup sweep iterates over — the exams API's
+ *  GET endpoint returns [] without a class/classSubject filter
+ *  (exam.controller.ts findAll), so we have to scope each sweep call.
+ *  Update this list if a future spec writes Exam rows under a
+ *  different class.
+ */
+export const EXAMS_SWEEP_CLASS_IDS = [
+  'seed-class-1a',
+  'seed-class-1b',
+];
+
+/**
+ * Sweep all Exam rows on the seed school whose title starts with the
+ * supplied prefix. Iterates over EXAMS_SWEEP_CLASS_IDS because the GET
+ * endpoint requires a classId or classSubjectId filter (returns [] with
+ * no filter — see exam.controller.ts findAll). Best-effort: 404 per row
+ * is fine (parallel sweep may have already deleted it).
+ */
+export async function cleanupE2EExams(
+  request: APIRequestContext,
+  prefix: string = EXAMS_TITLE_PREFIX,
+): Promise<void> {
+  const token = await getAdminToken(request);
+  const toDelete: Array<{ id: string; title: string }> = [];
+  for (const classId of EXAMS_SWEEP_CLASS_IDS) {
+    const listRes = await request.get(
+      `${EXAMS_API}/schools/${EXAMS_SCHOOL_ID}/exams?classId=${encodeURIComponent(classId)}`,
+      { headers: { Authorization: `Bearer ${token}` } },
+    );
+    if (!listRes.ok()) continue;
+    const list = (await listRes.json()) as Array<{ id: string; title: string }>;
+    toDelete.push(...list.filter((ex) => ex.title.startsWith(prefix)));
+  }
+  await Promise.all(
+    toDelete.map((ex) =>
+      request
+        .delete(`${EXAMS_API}/schools/${EXAMS_SCHOOL_ID}/exams/${ex.id}`, {
+          headers: { Authorization: `Bearer ${token}` },
+        })
+        .catch(() => undefined),
+    ),
+  );
+}
+
+/**
+ * YYYY-MM-DD for `daysFromNow` from today. The ExamDialog requires
+ * `date >= today` (ExamDialog.tsx:69). Default `daysFromNow=2` so
+ * back-to-back tests don't both pick "tomorrow" and trip an unrelated
+ * homework spec's tomorrow-due-date.
+ */
+export function isoDaysFromNow(daysFromNow: number = 2): string {
+  const d = new Date();
+  d.setDate(d.getDate() + daysFromNow);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}

--- a/apps/web/src/hooks/useExams.ts
+++ b/apps/web/src/hooks/useExams.ts
@@ -87,6 +87,12 @@ export function useCreateExam(schoolId: string) {
     },
     onSuccess: (_data) => {
       queryClient.invalidateQueries({ queryKey: examKeys.all(schoolId) });
+      // Collision-check uses its own key family (`exam-collision`) and is
+      // NOT covered by examKeys.all — without this explicit invalidation
+      // the next ExamDialog open on the same (class, date) reads the
+      // cached pre-create `hasCollision: false` for the full staleTime
+      // window, so the override-flow warning never renders.
+      queryClient.invalidateQueries({ queryKey: ['exam-collision', schoolId] });
       toast.success('Pruefung eingetragen');
     },
     onError: (error: Error) => {

--- a/apps/web/src/routes/_authenticated/classbook/$lessonId.tsx
+++ b/apps/web/src/routes/_authenticated/classbook/$lessonId.tsx
@@ -178,6 +178,7 @@ function ClassBookLessonPage() {
             )}
             <HomeworkExamList
               schoolId={schoolId}
+              classId={entry.classId}
               classSubjectId={entry.classSubjectId}
               role={primaryRole}
             />
@@ -198,6 +199,7 @@ function ClassBookLessonPage() {
         open={examDialogOpen}
         mode="create"
         schoolId={schoolId}
+        classId={entry.classId}
         classSubjectId={entry.classSubjectId}
         onClose={() => setExamDialogOpen(false)}
       />

--- a/packages/shared/src/types/classbook.ts
+++ b/packages/shared/src/types/classbook.ts
@@ -20,6 +20,7 @@ export interface ClassBookEntryDto {
   // Joined fields (populated by by-timetable-lesson endpoint and other joined queries)
   subjectName?: string;
   className?: string;
+  classId?: string;
   teacherName?: string;
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
## Summary

Second sub-spec for #82 (Klausuren) + bundled fix for **3 production bugs** the spec uncovered. Per CLAUDE.md "Bug-Fix Regression-Schutz via E2E — hard rule" the fixes ship with the spec that catches them.

## Bugs uncovered

While writing the collision-override E2E I found that **the Pruefung-eintragen flow on /classbook/\$lessonId has never worked**:

1. **ExamDialog gets undefined classId** → form sends \`classId=''\` → backend \`@IsNotEmpty\` rejects with 422. Silent — no error toast surfaces. The "Pruefung eintragen" button has been dead since shipped.
2. **HomeworkExamList gets undefined classId** → \`useExams\` runs without filter → \`exam.controller.findAll\` returns \`[]\` when no class filter is provided → the Pruefungen tab has always been empty regardless of stored data.
3. **\`useCreateExam\` doesn't invalidate the \`exam-collision\` cache** → after creating exam #1, opening the dialog for exam #2 on the same (class, date) reads stale \`hasCollision: false\` for 10s → D-03 collision warning silently disabled.

## Fix

- \`attendance.service.getOrCreateEntryByTimetableLesson\` joins \`classSubject.classId\` into the response.
- \`ClassBookEntryDto\` adds optional \`classId\` field.
- \`/classbook/\$lessonId\` route forwards \`entry.classId\` to both \`ExamDialog\` and \`HomeworkExamList\`.
- \`useCreateExam\` invalidates the \`exam-collision\` key family on success.

## E2E coverage

\`apps/web/e2e/classbook-exams.spec.ts\` — 1 chromium-only test:
1. Open ?tab=aufgaben → Pruefungen sub-tab → empty state.
2. Create exam #1 (timestamped title) — dialog closes, row visible.
3. Open dialog for exam #2, SAME date → ExamCollisionWarning renders, names exam #1.
4. Assert submit is disabled (forceCreate gate).
5. Click "Trotzdem eintragen" → submit re-enables.
6. Submit → dialog closes, both exams in list.

Helper: \`apps/web/e2e/helpers/exams.ts\` — sweep-by-title-prefix cleanup via REST DELETE. \`GET /exams\` returns \`[]\` without a class filter, so sweep iterates \`EXAMS_SWEEP_CLASS_IDS\`.

## Coverage delta

Issue #82 sub-spec list:
- [x] \`classbook-homework.spec.ts\` — PR #99
- [x] \`classbook-exams.spec.ts\` — this PR (create + collision-override)
- [ ] \`timetable-cell-badges.spec.ts\`

## Verification

\`\`\`
pnpm --filter @schoolflow/web exec playwright test \\
  e2e/classbook-exams.spec.ts \\
  e2e/classbook-attendance.spec.ts \\
  e2e/classbook-lesson-content.spec.ts \\
  e2e/classbook-student-notes.spec.ts \\
  e2e/timetable-non-admin-views.spec.ts \\
  --workers=2
\`\`\`
→ 5/5 stable green

API + web TypeScript: both clean.

## Test plan

- [ ] Playwright E2E CI grün (per D3 — kein Merge ohne grün)
- [ ] CB-EX-01 passt auf desktop chromium
- [ ] Keine Regression im classbook + timetable cluster
- [ ] Pruefung-eintragen Button funktioniert in der UI (manual sanity-check after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)