### PR TITLE
fix(exams): GET /exams returns school-wide rows + badge spec closes #82

### DIFF
--- a/apps/api/src/modules/homework/exam.controller.ts
+++ b/apps/api/src/modules/homework/exam.controller.ts
@@ -68,6 +68,7 @@ export class ExamController {
   @ApiQuery({ name: 'classSubjectId', required: false, description: 'Filter by class subject' })
   @ApiResponse({ status: 200, description: 'List of exams' })
   async findAll(
+    @Param('schoolId') schoolId: string,
     @Query('classId') classId?: string,
     @Query('classSubjectId') classSubjectId?: string,
   ) {
@@ -77,8 +78,11 @@ export class ExamController {
     if (classSubjectId) {
       return this.examService.findByClassSubject(classSubjectId);
     }
-    // Without filters, return empty -- callers should provide a filter
-    return [];
+    // No filter → return every exam on the school. Mirrors GET /homework's
+    // no-filter branch (homework.controller.ts findAll). The /timetable
+    // cell-badge aggregation depends on this — without it ExamBadge is
+    // silently disabled school-wide on the timetable surface.
+    return this.examService.findBySchool(schoolId);
   }
 
   /**

--- a/apps/api/src/modules/homework/exam.service.ts
+++ b/apps/api/src/modules/homework/exam.service.ts
@@ -117,6 +117,23 @@ export class ExamService {
     return rows.map((r: any) => this.toDto(r));
   }
 
+  /**
+   * Return every Exam row on a school, ordered by date asc. Mirrors
+   * `HomeworkService.findBySchool` so the /timetable cell-badge
+   * aggregation (which calls `useExams(schoolId)` with no class filter)
+   * receives a non-empty result. Prior behaviour returned `[]` for the
+   * no-filter branch, which silently disabled ExamBadge across the
+   * entire timetable surface.
+   */
+  async findBySchool(schoolId: string): Promise<ExamDto[]> {
+    const rows = await this.prisma.exam.findMany({
+      where: { schoolId },
+      orderBy: { date: 'asc' },
+      include: CLASS_SUBJECT_INCLUDE,
+    });
+    return rows.map((r: any) => this.toDto(r));
+  }
+
   async findByClassSubject(classSubjectId: string): Promise<ExamDto[]> {
     const rows = await this.prisma.exam.findMany({
       where: { classSubjectId },

--- a/apps/web/e2e/classbook-exams.spec.ts
+++ b/apps/web/e2e/classbook-exams.spec.ts
@@ -61,7 +61,7 @@ test.describe('Issue #82 — Classbook Exam create + collision (desktop)', () =>
     // Sweep ALL E2E-EX- rows. No FK to TimetableRun, so
     // cleanupTimetableRun does NOT cascade to Exam rows; they
     // accumulate across specs without this explicit sweep.
-    await cleanupE2EExams(request);
+    await cleanupE2EExams(request, `${EXAMS_TITLE_PREFIX}CREATE-`);
     if (fixture) {
       await cleanupTimetableRun(fixture);
       fixture = undefined;
@@ -75,7 +75,7 @@ test.describe('Issue #82 — Classbook Exam create + collision (desktop)', () =>
     if (!fixture) throw new Error('fixture not seeded');
 
     // API-side baseline so the empty-state check below is honest.
-    await cleanupE2EExams(request);
+    await cleanupE2EExams(request, `${EXAMS_TITLE_PREFIX}CREATE-`);
 
     await page.goto(`/classbook/${fixture.lessonId}?tab=aufgaben`);
 
@@ -98,7 +98,7 @@ test.describe('Issue #82 — Classbook Exam create + collision (desktop)', () =>
     ).toBeVisible();
 
     const ts = Date.now();
-    const title1 = `${EXAMS_TITLE_PREFIX}${ts}-A — Mathe Schularbeit`;
+    const title1 = `${EXAMS_TITLE_PREFIX}CREATE-${ts}-A — Mathe Schularbeit`;
     const sharedDate = isoDaysFromNow(2);
 
     await page.getByLabel('Titel *').fill(title1);
@@ -135,7 +135,7 @@ test.describe('Issue #82 — Classbook Exam create + collision (desktop)', () =>
       page.getByRole('heading', { name: 'Pruefung eintragen', level: 2 }),
     ).toBeVisible();
 
-    const title2 = `${EXAMS_TITLE_PREFIX}${ts}-B — Mathe Wiederholung`;
+    const title2 = `${EXAMS_TITLE_PREFIX}CREATE-${ts}-B — Mathe Wiederholung`;
     await page.getByLabel('Titel *').fill(title2);
     await page.getByLabel('Datum *').fill(sharedDate);
 

--- a/apps/web/e2e/classbook-homework.spec.ts
+++ b/apps/web/e2e/classbook-homework.spec.ts
@@ -58,7 +58,7 @@ test.describe('Issue #82 — Classbook Homework create (desktop)', () => {
     // there's no FK to TimetableRun, so cleanupTimetableRun() does NOT
     // cascade to Homework rows; they accumulate across specs without
     // this explicit sweep.
-    await cleanupE2EHomework(request);
+    await cleanupE2EHomework(request, `${HOMEWORK_TITLE_PREFIX}CREATE-`);
     if (fixture) {
       await cleanupTimetableRun(fixture);
       fixture = undefined;
@@ -74,7 +74,7 @@ test.describe('Issue #82 — Classbook Homework create (desktop)', () => {
     // Make sure no leftover homework from a killed prior run pollutes
     // the assertions below — the empty-state and the row-visibility
     // checks both depend on a known starting state.
-    await cleanupE2EHomework(request);
+    await cleanupE2EHomework(request, `${HOMEWORK_TITLE_PREFIX}CREATE-`);
 
     await page.goto(`/classbook/${fixture.lessonId}?tab=aufgaben`);
 
@@ -102,7 +102,7 @@ test.describe('Issue #82 — Classbook Homework create (desktop)', () => {
 
     // Timestamped title doubles as the cleanup discriminator (the
     // prefix-sweep in afterEach hooks on HOMEWORK_TITLE_PREFIX).
-    const title = `${HOMEWORK_TITLE_PREFIX}${Date.now()} — Mathe Kapitel 3`;
+    const title = `${HOMEWORK_TITLE_PREFIX}CREATE-${Date.now()} — Mathe Kapitel 3`;
     await page.getByLabel('Titel *').fill(title);
     await page
       .getByLabel('Beschreibung')

--- a/apps/web/e2e/helpers/exams.ts
+++ b/apps/web/e2e/helpers/exams.ts
@@ -7,7 +7,7 @@
  * helper-file edits while in flight (PR #99 ships homework.ts; this
  * branch ships exams.ts).
  */
-import { type APIRequestContext } from '@playwright/test';
+import { expect, type APIRequestContext } from '@playwright/test';
 import { getAdminToken } from './login';
 import { SEED_SCHOOL_UUID } from '../fixtures/seed-uuids';
 
@@ -65,6 +65,48 @@ export async function cleanupE2EExams(
         .catch(() => undefined),
     ),
   );
+}
+
+export interface CreateExamInput {
+  title: string;
+  date: string; // YYYY-MM-DD
+  classSubjectId: string;
+  classId: string;
+  duration?: number;
+  description?: string;
+}
+
+export interface CreatedExam {
+  id: string;
+}
+
+/**
+ * Seed an Exam row via the REST endpoint (admin auth). Returns the new
+ * exam id. Used by specs that need the cell-badge surface state without
+ * driving the ExamDialog UI.
+ */
+export async function createExamViaAPI(
+  request: APIRequestContext,
+  input: CreateExamInput,
+): Promise<CreatedExam> {
+  const token = await getAdminToken(request);
+  const res = await request.post(
+    `${EXAMS_API}/schools/${EXAMS_SCHOOL_ID}/exams`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      data: input,
+    },
+  );
+  expect(
+    res.ok(),
+    `POST /exams seed → ${res.status()} ${await res.text()}`,
+  ).toBeTruthy();
+  // POST /exams returns `{ exam: {...}, collision?: {...} }` per exam.service
+  const body = (await res.json()) as { exam: { id: string } };
+  return { id: body.exam.id };
 }
 
 /**

--- a/apps/web/e2e/helpers/homework.ts
+++ b/apps/web/e2e/helpers/homework.ts
@@ -5,7 +5,7 @@
  * through the REST endpoint — no Prisma-direct bridge needed (the
  * excuses helper has the Prisma bridge for that gap).
  */
-import { type APIRequestContext } from '@playwright/test';
+import { expect, type APIRequestContext } from '@playwright/test';
 import { getAdminToken } from './login';
 import { SEED_SCHOOL_UUID } from '../fixtures/seed-uuids';
 
@@ -51,6 +51,44 @@ export async function cleanupE2EHomework(
           .catch(() => undefined),
       ),
   );
+}
+
+export interface CreateHomeworkInput {
+  title: string;
+  description?: string;
+  dueDate: string; // YYYY-MM-DD
+  classSubjectId: string;
+}
+
+export interface CreatedHomework {
+  id: string;
+}
+
+/**
+ * Seed a Homework row via the REST endpoint (admin auth). Returns the
+ * new homework id. Used by specs that need the cell-badge surface
+ * state without driving the HomeworkDialog UI.
+ */
+export async function createHomeworkViaAPI(
+  request: APIRequestContext,
+  input: CreateHomeworkInput,
+): Promise<CreatedHomework> {
+  const token = await getAdminToken(request);
+  const res = await request.post(
+    `${HOMEWORK_API}/schools/${HOMEWORK_SCHOOL_ID}/homework`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      data: input,
+    },
+  );
+  expect(
+    res.ok(),
+    `POST /homework seed → ${res.status()} ${await res.text()}`,
+  ).toBeTruthy();
+  return (await res.json()) as CreatedHomework;
 }
 
 /**

--- a/apps/web/e2e/timetable-cell-badges.spec.ts
+++ b/apps/web/e2e/timetable-cell-badges.spec.ts
@@ -1,0 +1,152 @@
+/**
+ * Issue #82 — Timetable cell badges (Homework + Exam) regression-lock.
+ *
+ * Third sub-spec of the Hausaufgaben/Klausuren coverage gap (closes #82
+ * alongside #99 + #100). Locks the cross-surface render contract that
+ * homework and exam badges land on the right timetable cell when the
+ * Lehrer opens /timetable:
+ *
+ *   1. Seed a TimetableRun fixture (MONDAY/period-1 lesson for class 1A,
+ *      teacher = kc-lehrer Maria Mueller).
+ *   2. Seed ONE Homework and ONE Exam against the fixture's
+ *      classSubjectId via API.
+ *   3. kc-lehrer logs in → /timetable defaults to perspective=teacher
+ *      for her own teacherId.
+ *   4. The seeded cell renders TimetableCellBadges with both icons —
+ *      aria-label="Hausaufgabe: <title>" and "Pruefung: <title>"
+ *      identify them deterministically.
+ *   5. Click each badge → Popover opens with the seeded title visible.
+ *
+ * Exercises the renderCellWithBadges path in /timetable/index.tsx, the
+ * useHomework + useExams aggregation, and the badge Popover trigger.
+ * Bug-class guard: if HomeworkBadge stops accepting its homework prop
+ * or the badge container drops aria-label, this spec turns red loudly.
+ *
+ * Chromium-only-skip per the race-family precedent — every spec on
+ * this surface writes Homework / Exam rows on the shared seed class.
+ */
+import { test, expect } from '@playwright/test';
+import { loginAsRole } from './helpers/login';
+import {
+  HOMEWORK_TITLE_PREFIX,
+  cleanupE2EHomework,
+  createHomeworkViaAPI,
+  isoDaysFromNow as homeworkDateInDays,
+} from './helpers/homework';
+import {
+  EXAMS_TITLE_PREFIX,
+  cleanupE2EExams,
+  createExamViaAPI,
+  isoDaysFromNow as examDateInDays,
+} from './helpers/exams';
+import {
+  cleanupTimetableRun,
+  seedTimetableRun,
+  type TimetableRunFixture,
+} from './fixtures/timetable-run';
+import { SEED_SCHOOL_UUID } from './fixtures/seed-uuids';
+
+const SEED_CLASS_1A_ID = 'seed-class-1a';
+
+test.describe('Issue #82 — Timetable cell badges (desktop)', () => {
+  test.skip(
+    ({ isMobile }) => isMobile,
+    'Cell-badge contract is identical across viewports — desktop only for the first lock.',
+  );
+  test.skip(
+    ({ browserName }) => browserName !== 'chromium',
+    'Mutates Homework + Exam rows on the shared seed class — chromium is the sole writer.',
+  );
+
+  let fixture: TimetableRunFixture | undefined;
+  let homeworkTitle: string;
+  let examTitle: string;
+
+  test.beforeEach(async ({ page, request }) => {
+    fixture = await seedTimetableRun(SEED_SCHOOL_UUID);
+
+    const ts = Date.now();
+    homeworkTitle = `${HOMEWORK_TITLE_PREFIX}BADGE-${ts} — Kapitel 5 lesen`;
+    examTitle = `${EXAMS_TITLE_PREFIX}BADGE-${ts} — Schularbeit 1`;
+
+    await createHomeworkViaAPI(request, {
+      title: homeworkTitle,
+      description: 'Aufgaben 1–12 auf Seite 47',
+      dueDate: homeworkDateInDays(2),
+      classSubjectId: fixture.classSubjectId,
+    });
+    await createExamViaAPI(request, {
+      title: examTitle,
+      date: examDateInDays(7),
+      classSubjectId: fixture.classSubjectId,
+      classId: SEED_CLASS_1A_ID,
+    });
+
+    await loginAsRole(page, 'lehrer');
+  });
+
+  test.afterEach(async ({ request }) => {
+    // Sweep by BADGE- sub-prefix so parallel specs (classbook-homework,
+    // classbook-exams) only delete their own rows. Pattern lifted from
+    // the recent excuses cross-spec cleanup-race fix.
+    await cleanupE2EHomework(request, `${HOMEWORK_TITLE_PREFIX}BADGE-`);
+    await cleanupE2EExams(request, `${EXAMS_TITLE_PREFIX}BADGE-`);
+    if (fixture) {
+      await cleanupTimetableRun(fixture);
+      fixture = undefined;
+    }
+  });
+
+  test('CB-BADGE-01: Lehrer sees Homework + Exam badges on the seeded cell, popovers open with seeded content', async ({
+    page,
+  }) => {
+    if (!fixture) throw new Error('fixture not seeded');
+
+    await page.goto('/timetable');
+
+    // Wait for the grid to mount. The kc-lehrer perspective lands on
+    // perspective=teacher (Issue #86 lock); the seeded lesson should
+    // surface as a single TimetableCell in the MONDAY/period-1 slot.
+    await expect(
+      page.getByRole('heading', { name: 'Stundenplan' }),
+    ).toBeVisible();
+
+    // HomeworkBadge ships with aria-label="Hausaufgabe: <title>"
+    // (HomeworkBadge.tsx:43). The aria-label including the seeded
+    // title is the deterministic discriminator — multiple badges from
+    // sibling specs would surface their own labels but never with
+    // OUR timestamp.
+    const homeworkBadge = page.getByRole('button', {
+      name: `Hausaufgabe: ${homeworkTitle}`,
+    });
+    await expect(
+      homeworkBadge,
+      'HomeworkBadge must render on the seeded cell carrying the seeded title in its aria-label',
+    ).toBeVisible();
+
+    const examBadge = page.getByRole('button', {
+      name: `Pruefung: ${examTitle}`,
+    });
+    await expect(
+      examBadge,
+      'ExamBadge must render on the seeded cell carrying the seeded title in its aria-label',
+    ).toBeVisible();
+
+    // Click homework badge → Radix Popover opens with the seeded title.
+    await homeworkBadge.click();
+    await expect(
+      page.getByRole('dialog').getByText(homeworkTitle),
+      'homework popover must surface the seeded title verbatim',
+    ).toBeVisible();
+    // Close popover before triggering the next one — Radix renders one
+    // PopoverContent at a time but explicit Escape avoids any focus-trap
+    // ambiguity if a future Radix version stacks them.
+    await page.keyboard.press('Escape');
+
+    await examBadge.click();
+    await expect(
+      page.getByRole('dialog').getByText(examTitle),
+      'exam popover must surface the seeded title verbatim',
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #82's last sub-spec (\`timetable-cell-badges\`) and bundles the **4th production bug** the test uncovered. Same pattern as PR #100 — writing the E2E surfaced the bug, fix ships in the same PR per CLAUDE.md.

## Bug 4 (the others were in PR #100)

\`GET /schools/:schoolId/exams\` returned \`[]\` when called without a class filter, instead of the school-wide list. The \`/timetable\` cell-badge aggregation calls \`useExams(schoolId)\` with NO filter, so **ExamBadge has been silently disabled across the entire timetable surface** for every Lehrer/Schueler/Eltern view since shipping.

## Fix

- \`ExamService.findBySchool(schoolId)\` — new method mirroring \`HomeworkService.findBySchool\`.
- \`ExamController.findAll\` — no-filter branch now calls \`findBySchool\` instead of returning \`[]\`.

## E2E coverage

\`apps/web/e2e/timetable-cell-badges.spec.ts\` — 1 chromium-only test:
1. Seed TimetableRun fixture (class 1A, MONDAY/period-1, kc-lehrer).
2. Seed one Homework + one Exam via API against the fixture's classSubject.
3. kc-lehrer opens \`/timetable\` → cell renders both badges with \`aria-label="Hausaufgabe: <title>"\` / \`"Pruefung: <title>"\`.
4. Click each → Radix Popover surfaces the seeded title.

Helpers extended: \`createHomeworkViaAPI\` + \`createExamViaAPI\` for direct seed.

## Cross-spec cleanup race fix

\`classbook-homework\` + \`classbook-exams\` + this new badge spec all write \`E2E-HW-\` / \`E2E-EX-\` rows on the shared seed class. Their \`afterEach\` sweeps now use sub-prefixes (\`E2E-HW-CREATE-\` for the dialog specs, \`E2E-HW-BADGE-\` for this one) so a parallel afterEach can't stomp a mid-test sibling's seed. Same pattern as the earlier excuses sub-prefix split.

## Coverage delta

Issue #82 sub-spec list — **complete after this PR**:
- [x] \`classbook-homework.spec.ts\` — PR #99
- [x] \`classbook-exams.spec.ts\` — PR #100
- [x] \`timetable-cell-badges.spec.ts\` — this PR

## Verification

\`\`\`
pnpm --filter @schoolflow/web exec playwright test \\
  e2e/timetable-cell-badges.spec.ts \\
  e2e/classbook-homework.spec.ts \\
  e2e/classbook-exams.spec.ts \\
  e2e/timetable-non-admin-views.spec.ts \\
  e2e/timetable-generation-flow.spec.ts \\
  --workers=2 --repeat-each=2
\`\`\`
→ all stable; no test failures across 6 iterations.

## Test plan

- [ ] Playwright E2E CI grün (per D3 — kein Merge ohne grün)
- [ ] CB-BADGE-01 passt auf desktop chromium
- [ ] Keine Regression in classbook-homework + classbook-exams
- [ ] Manual sanity: open /timetable as Lehrer with an existing exam — badge visible (4 bug-class guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)