### PR TITLE
chore(e2e): Classbook Grade-Matrix create flow (#81)

### DIFF
--- a/apps/web/e2e/classbook-grades.spec.ts
+++ b/apps/web/e2e/classbook-grades.spec.ts
@@ -1,0 +1,146 @@
+/**
+ * Issue #81 — Classbook Grade-Matrix create flow.
+ *
+ * Fourth sub-spec for the Klassenbuch surface (after #89 attendance +
+ * #95 inhalt + #96 notizen). Locks the "Noten" tab's create-flow on
+ * /classbook/$lessonId:
+ *   1. Open the lesson with ?tab=noten → "Noch keine Noten erfasst"
+ *      empty state for a fresh ClassSubject.
+ *   2. Click "Note hinzufuegen" → GradeEntryDialog opens.
+ *   3. Pick first student, leave default category MITARBEIT, click
+ *      grade value "2" via GradeValuePicker (aria-label="Note 2").
+ *   4. Submit → "Note gespeichert" toast.
+ *   5. Dialog closes, GradeMatrix renders the student row with the
+ *      grade column AND a weighted average. The average for one
+ *      MITARBEIT-2 should display as "2.0".
+ *
+ * Exercises POST /classbook/grades + the GradeEntryDialog form +
+ * GradeMatrix render + the grade-average util (one grade ⇒ avg =
+ * that grade's value). Edit + delete + category-filter + weight
+ * adjustment are deferred to follow-up sub-specs.
+ *
+ * Chromium-only-skip per the race-family precedent — every spec on
+ * this surface writes Grade rows under the same seed ClassSubject.
+ */
+import { test, expect } from '@playwright/test';
+import { loginAsAdmin } from './helpers/login';
+import { CLASSBOOK_SCHOOL_ID } from './helpers/classbook';
+import { cleanupGradesForClassSubject } from './helpers/grades';
+import {
+  cleanupTimetableRun,
+  seedTimetableRun,
+  type TimetableRunFixture,
+} from './fixtures/timetable-run';
+
+test.describe('Issue #81 — Classbook Grade-Matrix (desktop)', () => {
+  test.skip(
+    ({ isMobile }) => isMobile,
+    'GradeMatrix layout is identical across viewports — desktop only for the first lock.',
+  );
+  test.skip(
+    ({ browserName }) => browserName !== 'chromium',
+    'Mutates Grade rows on the shared seed ClassSubject — chromium is the sole writer.',
+  );
+
+  let fixture: TimetableRunFixture | undefined;
+
+  test.beforeEach(async ({ page }) => {
+    fixture = await seedTimetableRun(CLASSBOOK_SCHOOL_ID);
+    await loginAsAdmin(page);
+  });
+
+  test.afterEach(async ({ request }) => {
+    if (!fixture) return;
+    // Sweep every grade on this classSubject. The Grade FK to
+    // ClassSubject is a hard reference (no cascade-from-TimetableRun),
+    // so cleanupTimetableRun does NOT cascade to Grade rows; they
+    // would otherwise survive into the next test's GradeMatrix and
+    // turn the empty-state check below into a strict-mode flake.
+    await cleanupGradesForClassSubject(request, fixture.classSubjectId);
+    await cleanupTimetableRun(fixture);
+    fixture = undefined;
+  });
+
+  test('CB-GRADE-01: create grade via dialog → toast → student row + average visible', async ({
+    page,
+    request,
+  }) => {
+    if (!fixture) throw new Error('fixture not seeded');
+
+    // API-side baseline so the empty-state assertion is honest.
+    await cleanupGradesForClassSubject(request, fixture.classSubjectId);
+
+    await page.goto(`/classbook/${fixture.lessonId}?tab=noten`);
+
+    // Empty state on a freshly-cleared classSubject (GradeMatrix.tsx:206).
+    await expect(
+      page.getByRole('heading', { name: 'Noch keine Noten erfasst' }),
+      'fresh ClassSubject must render the GradeMatrix empty state',
+    ).toBeVisible();
+
+    await page.getByRole('button', { name: 'Note hinzufuegen' }).first().click();
+
+    // Dialog mount: GradeEntryDialog.tsx:125 "Neue Note erfassen".
+    await expect(
+      page.getByRole('heading', { name: 'Neue Note erfassen', level: 2 }),
+    ).toBeVisible();
+
+    // Pick first student. The select is populated from the matrix's
+    // studentList → all class-1A members. The actual student doesn't
+    // matter for the create-flow lock; deterministic first pick keeps
+    // the assertion stable.
+    await page.getByRole('combobox', { name: 'Schueler/in' }).click();
+    const firstStudentOption = page.getByRole('option').first();
+    await expect(firstStudentOption).toBeVisible();
+    const pickedStudentName = (await firstStudentOption.textContent())?.trim() ?? '';
+    expect(
+      pickedStudentName.length,
+      'first student option must surface a non-empty name',
+    ).toBeGreaterThan(0);
+    await firstStudentOption.click();
+
+    // Default category MITARBEIT (GradeEntryDialog.tsx:62) — no extra
+    // click needed. Default date is today (initialized in dialog), so
+    // both gate inputs are satisfied; the picker is the last input.
+    await page.getByRole('radio', { name: 'Note 2', exact: true }).click();
+
+    // Submit. The dialog's submit button is labelled "Note hinzufuegen"
+    // in CREATE mode (line 212), same as the action-bar button — scope
+    // to the dialog so we don't accidentally hit the action-bar one.
+    await page
+      .getByRole('dialog')
+      .getByRole('button', { name: 'Note hinzufuegen' })
+      .click();
+
+    await expect(
+      page.getByText('Note gespeichert'),
+      'success toast must appear after the POST commits',
+    ).toBeVisible({ timeout: 5_000 });
+
+    // Dialog auto-closes onSave (GradeEntryDialog.tsx:113).
+    await expect(
+      page.getByRole('heading', { name: 'Neue Note erfassen', level: 2 }),
+      'dialog must close after a successful create',
+    ).toHaveCount(0);
+
+    // After invalidation, GradeMatrix re-renders with the new column +
+    // a row for the picked student. The empty state is gone.
+    await expect(
+      page.getByRole('heading', { name: 'Noch keine Noten erfasst' }),
+      'empty state must be gone once the matrix has at least one grade',
+    ).toHaveCount(0);
+    await expect(
+      page.getByText(pickedStudentName).first(),
+      'picked student row must surface in the GradeMatrix',
+    ).toBeVisible();
+
+    // Weighted average for ONE MITARBEIT grade of value 2.0 must
+    // resolve to "2.0" (one decimal, GradeMatrix.tsx:81). This is the
+    // regression-lock for grade-average.util — a bug that miscalculates
+    // averages or applies wrong default weights would surface here.
+    await expect(
+      page.getByText('2.0').first(),
+      'weighted average must display "2.0" for one MITARBEIT-2 grade',
+    ).toBeVisible();
+  });
+});

--- a/apps/web/e2e/helpers/grades.ts
+++ b/apps/web/e2e/helpers/grades.ts
@@ -1,0 +1,55 @@
+/**
+ * Grades E2E helpers — #81.
+ *
+ * The grade API ships full CRUD plus a matrix endpoint:
+ *   - POST   /classbook/grades                          — admin creates entry
+ *   - GET    /classbook/grades/matrix/:classSubjectId   — student rows + weighted avg
+ *   - PATCH  /classbook/grades/:gradeId                 — update
+ *   - DELETE /classbook/grades/:gradeId                 — delete (returns 204)
+ *
+ * No description-prefix filter is needed for cleanup — the sweep is
+ * scoped to one classSubjectId, which a single test owns end-to-end
+ * via the seedTimetableRun fixture.
+ */
+import { type APIRequestContext } from '@playwright/test';
+import { getAdminToken } from './login';
+import { SEED_SCHOOL_UUID } from '../fixtures/seed-uuids';
+
+export const GRADES_API =
+  process.env.E2E_API_URL ?? 'http://localhost:3000/api/v1';
+export const GRADES_SCHOOL_ID =
+  process.env.E2E_SCHOOL_ID ?? SEED_SCHOOL_UUID;
+
+/**
+ * Delete every Grade entry on a given classSubject. The grade-matrix
+ * endpoint surfaces grades nested under each student row, so we collect
+ * the ids from there and DELETE each in parallel. Best-effort — 404 per
+ * row is fine (parallel sweep may have already removed it).
+ */
+export async function cleanupGradesForClassSubject(
+  request: APIRequestContext,
+  classSubjectId: string,
+): Promise<void> {
+  const token = await getAdminToken(request);
+  const matrixRes = await request.get(
+    `${GRADES_API}/schools/${GRADES_SCHOOL_ID}/classbook/grades/matrix/${classSubjectId}`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+  if (!matrixRes.ok()) return;
+  const matrix = (await matrixRes.json()) as {
+    rows?: Array<{ grades: Array<{ id: string }> }>;
+  };
+  const gradeIds = (matrix.rows ?? []).flatMap((row) =>
+    row.grades.map((g) => g.id),
+  );
+  await Promise.all(
+    gradeIds.map((gradeId) =>
+      request
+        .delete(
+          `${GRADES_API}/schools/${GRADES_SCHOOL_ID}/classbook/grades/${gradeId}`,
+          { headers: { Authorization: `Bearer ${token}` } },
+        )
+        .catch(() => undefined),
+    ),
+  );
+}


### PR DESCRIPTION
## Summary

Fourth sub-spec for #81 (Klassenbuch) — locks the **Noten** tab create-flow on \`/classbook/\$lessonId\`. Completes the 4 mandatory sub-specs of #81; the 5th "optional, schwierig in CI" realtime sub-spec is deferred to a separate follow-up so #81 can close after this merges.

## What's new

- \`apps/web/e2e/classbook-grades.spec.ts\` — 1 chromium-only test: open noten-tab → "Noch keine Noten erfasst" → click "Note hinzufuegen" → pick student → grade "2" (MITARBEIT) → submit → toast → student row + average "2.0" visible.
- \`apps/web/e2e/helpers/grades.ts:cleanupGradesForClassSubject\` — sweep all Grade rows on a classSubjectId via matrix-GET + DELETE. No description-prefix needed; one test owns its classSubject via fixture.

## Coverage delta — #81 closeable after this

Issue #81 sub-spec list:
- [x] \`classbook-attendance.spec.ts\` — #89
- [x] \`classbook-lesson-content.spec.ts\` — PR #95
- [x] \`classbook-student-notes.spec.ts\` — PR #96
- [x] \`classbook-grades.spec.ts\` — this PR
- [ ] \`classbook-realtime.spec.ts\` — **deferred** to follow-up (optional, schwierig in CI per the issue body; needs 2-tab Socket.IO + 2 distinct teacher logins which the seed doesn't provide — kc-lehrer is the only Keycloak-mapped lehrer)

## Verification

5x parallel race-run with the full classbook cluster:
\`\`\`
pnpm --filter @schoolflow/web exec playwright test \\
  e2e/classbook-grades.spec.ts \\
  e2e/classbook-attendance.spec.ts \\
  e2e/classbook-lesson-content.spec.ts \\
  e2e/classbook-student-notes.spec.ts \\
  e2e/classbook-homework.spec.ts \\
  --workers=2
\`\`\`
→ 5/5 stable green

## Test plan

- [ ] Playwright E2E CI grün (per D3 — kein Merge ohne grün)
- [ ] CB-GRADE-01 passt auf desktop chromium
- [ ] Keine Regression im classbook cluster
- [ ] After merge: open separate follow-up issue for realtime + close #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)