### PR TITLE
chore(e2e): Messaging DIRECT 1:1 recipient flow (#84)

### DIFF
--- a/apps/web/e2e/helpers/messaging.ts
+++ b/apps/web/e2e/helpers/messaging.ts
@@ -4,15 +4,23 @@
  * Phase 7 Conversation REST API:
  *   - POST /schools/:schoolId/conversations          — create + scope-expand
  *   - GET  /schools/:schoolId/conversations           — list for current user
- *   - DELETE /schools/:schoolId/conversations/:id     — admin-only cleanup
+ *   - DELETE /schools/:schoolId/conversations/:id     — admin/schulleitung only
  *
  * Per-spec cleanup follows the established prefix-isolation pattern
  * (`helpers/students.ts`, `helpers/teachers.ts`): every E2E-created
- * conversation carries `E2E-MSG-…` in its subject so afterEach can sweep
- * by listing + filtering + deleting.
+ * conversation carries `E2E-MSG-…` in its subject (broadcast) or body
+ * (DIRECT — DIRECT has no subject in the data model) so afterEach can
+ * sweep by listing + filtering + deleting.
+ *
+ * Listing is actor-scoped: `GET /conversations` only returns rows where
+ * the caller is a `conversationMembers` row. Admin sees the broadcasts
+ * they created, but DIRECT lehrer↔eltern rows require listing AS lehrer
+ * (or eltern). Deletion is always done with the admin token because the
+ * DELETE endpoint requires the `manage:communication` permission, which
+ * lehrer/eltern do not have.
  */
 import { expect, type APIRequestContext } from '@playwright/test';
-import { getAdminToken } from './login';
+import { getAdminToken, getRoleToken, type Role } from './login';
 import { SEED_SCHOOL_UUID } from '../fixtures/seed-uuids';
 
 export const MESSAGING_API =
@@ -28,6 +36,17 @@ export interface CreateBroadcastInput {
   body: string;
   scopeId: string;
   scope?: 'CLASS' | 'YEAR_GROUP' | 'SCHOOL';
+}
+
+export interface CreateDirectInput {
+  /** Keycloak userId of the recipient — resolve via `getSeedUserId(request, role)`. */
+  recipientId: string;
+  body: string;
+  /**
+   * Role to POST as. Defaults to 'lehrer' because that's the canonical
+   * sender for the lehrer→eltern flow specified in #84.
+   */
+  actorRole?: Role;
 }
 
 export interface CreatedConversation {
@@ -72,32 +91,95 @@ export async function createBroadcastConversation(
 }
 
 /**
- * Best-effort cleanup: list conversations the admin can see, filter by
- * subject prefix, and delete each. Swallows per-row errors so a parallel
+ * Create a DIRECT 1:1 conversation as `actorRole` (default 'lehrer'), to
+ * the given recipient keycloakUserId, with `body` as the first message.
+ *
+ * DIRECT is find-or-create: if an existing conversation between the
+ * actor and recipient exists (e.g. left over from a prior run that
+ * cleanup didn't sweep), the backend re-uses it AND appends `body` as a
+ * new message. Either way, the latest message body matches `body` and
+ * surfaces in the recipient's list — so the spec assertion is stable
+ * regardless of leftover state.
+ */
+export async function createDirectConversation(
+  request: APIRequestContext,
+  input: CreateDirectInput,
+): Promise<CreatedConversation> {
+  const role = input.actorRole ?? 'lehrer';
+  const token = await getRoleToken(request, role);
+  const res = await request.post(
+    `${MESSAGING_API}/schools/${MESSAGING_SCHOOL_ID}/conversations`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      data: {
+        scope: 'DIRECT',
+        recipientId: input.recipientId,
+        body: input.body,
+      },
+    },
+  );
+  expect(
+    res.ok(),
+    `POST /conversations DIRECT (as ${role} → ${input.recipientId}) → ${res.status()}`,
+  ).toBeTruthy();
+  const body = (await res.json()) as { id: string; subject: string | null };
+  return { id: body.id, subject: body.subject };
+}
+
+/**
+ * Best-effort cleanup: list conversations visible to the listing actor,
+ * keep rows whose subject OR last-message body starts with `prefix`, and
+ * delete each via the admin token. Swallows per-row errors so a parallel
  * spec deleting the same row mid-flight doesn't crash this sweep — same
  * pattern as `cleanupE2EParents`.
+ *
+ * `listAs` defaults to 'admin'. Broadcast specs (where admin created the
+ * conversation and is therefore a member) can leave the default. DIRECT
+ * specs must pass the actor that participated in the conversation
+ * (lehrer or eltern) — admin is NOT a member of DIRECT rows, so a
+ * default-admin list would return zero DIRECT hits and the row would
+ * leak.
+ *
+ * Bugfix note: the previous version typed the GET response as
+ * `{ data?: ConversationDto[] }` and read `body.data ?? []`, but the
+ * endpoint returns a bare `ConversationDto[]`. The sweep silently
+ * no-op'd for the entire lifetime of PR #91, leaving every E2E-MSG-
+ * broadcast in the DB. Fixed here as part of the DIRECT extension
+ * because the new spec hits the same code path.
  */
 export async function cleanupE2EConversations(
   request: APIRequestContext,
   prefix: string = MESSAGING_PREFIX,
+  listAs: Role = 'admin',
 ): Promise<void> {
-  const token = await getAdminToken(request);
+  const listToken = await getRoleToken(request, listAs);
+  const adminToken =
+    listAs === 'admin' ? listToken : await getAdminToken(request);
   const listRes = await request.get(
     `${MESSAGING_API}/schools/${MESSAGING_SCHOOL_ID}/conversations?limit=200`,
-    { headers: { Authorization: `Bearer ${token}` } },
+    { headers: { Authorization: `Bearer ${listToken}` } },
   );
   if (!listRes.ok()) return;
-  const body = (await listRes.json()) as {
-    data?: Array<{ id: string; subject?: string | null }>;
-  };
-  const list = body.data ?? [];
+  const list = (await listRes.json()) as Array<{
+    id: string;
+    scope: string;
+    subject?: string | null;
+    lastMessage?: { body?: string | null } | null;
+  }>;
   await Promise.all(
     list
-      .filter((c) => (c.subject ?? '').startsWith(prefix))
+      .filter((c) => {
+        const subj = c.subject ?? '';
+        const body = c.lastMessage?.body ?? '';
+        return subj.startsWith(prefix) || body.startsWith(prefix);
+      })
       .map((c) =>
         request.delete(
           `${MESSAGING_API}/schools/${MESSAGING_SCHOOL_ID}/conversations/${c.id}`,
-          { headers: { Authorization: `Bearer ${token}` } },
+          { headers: { Authorization: `Bearer ${adminToken}` } },
         ),
       ),
   );

--- a/apps/web/e2e/messaging-direct-1on1.spec.ts
+++ b/apps/web/e2e/messaging-direct-1on1.spec.ts
@@ -1,0 +1,122 @@
+/**
+ * Issue #84 — Messaging DIRECT 1:1 (lehrer → eltern, recipient visibility).
+ *
+ * Slice 2/n of the Messaging coverage gap. Locks the recipient-side flow
+ * for DIRECT 1:1 conversations: a message that the lehrer sends to a
+ * single parent must surface in that parent's /messages list, and
+ * clicking it must show the actual message body in ConversationView.
+ *
+ * Why DIRECT next (after MSG-LIST-01 broadcast): the DIRECT path takes a
+ * different branch in ConversationService.create() — `createDirect` with
+ * its `directPairKey` find-or-create + 2-member transactional create.
+ * The previous broadcast spec exercised the CLASS scope-expansion
+ * branch; this one closes the DIRECT branch on the same load-bearing
+ * stack (backend create → useConversations list → ConversationView
+ * render). DIRECT also has no subject, so the recipient sees the row
+ * titled by the sender's name with the body in the preview — a
+ * different UI rendering path (`title = conversation.subject ?? senderName`
+ * in `ConversationListItem.tsx:34`).
+ *
+ * Compose-via-UI is intentionally NOT exercised here: the current
+ * `ComposeDialog.tsx` wires its footer "Senden" button only to
+ * `handleBroadcastSend`, so the Direktnachricht tab cannot actually
+ * post through the UI today. Driving setup via the API mirrors the
+ * MSG-LIST-01 pattern (seed-via-API, assert-via-UI), keeps the spec
+ * focused on the recipient-visibility contract, and avoids couplng to
+ * the unrelated dialog wiring gap.
+ *
+ * Chromium-only-skip per the race-family precedent — DIRECT rows
+ * between the shared seed (lehrer-user, eltern-user) pair are
+ * find-or-create, so two parallel browser projects would step on the
+ * same `directPairKey` row mid-flight.
+ */
+import { test, expect } from '@playwright/test';
+import { loginAsRole } from './helpers/login';
+import { getSeedUserId } from './helpers/users';
+import {
+  MESSAGING_PREFIX,
+  cleanupE2EConversations,
+  createDirectConversation,
+  type CreatedConversation,
+} from './helpers/messaging';
+
+test.describe('Issue #84 — Messaging DIRECT 1:1 (lehrer → eltern, desktop)', () => {
+  test.skip(
+    ({ isMobile }) => isMobile,
+    'List-detail two-pane layout is desktop-only; mobile has a separate route a future slice will cover.',
+  );
+  test.skip(
+    ({ browserName }) => browserName !== 'chromium',
+    'DIRECT rows share a per-pair singleton (directPairKey) on the seed users; parallel browser projects collide mid-flight.',
+  );
+
+  let created: CreatedConversation | null = null;
+
+  test.afterEach(async ({ request }) => {
+    // Sweep DIRECT rows whose latest message body carries the E2E-MSG-
+    // prefix. Listing AS lehrer is required because admin is not a
+    // member of DIRECT conversations and so cannot see them via the
+    // member-scoped GET. Deletion still goes through the admin token
+    // inside the helper (DELETE requires manage:communication).
+    await cleanupE2EConversations(request, MESSAGING_PREFIX, 'lehrer');
+    created = null;
+  });
+
+  test('MSG-DIRECT-01: lehrer-sent DIRECT message appears in eltern-user list and opens with body', async ({
+    page,
+    request,
+  }) => {
+    const elternId = await getSeedUserId(request, 'eltern');
+    const ts = Date.now();
+    const body = `${MESSAGING_PREFIX}DIRECT-${ts} — Hallo, eine direkte Nachricht von Maria Mueller.`;
+
+    created = await createDirectConversation(request, {
+      actorRole: 'lehrer',
+      recipientId: elternId,
+      body,
+    });
+    expect(created.id, 'POST /conversations DIRECT must return an id').toBeTruthy();
+
+    await loginAsRole(page, 'eltern');
+    await page.goto('/messages');
+
+    // Page chrome must be visible before we assert on rows.
+    await expect(
+      page.getByRole('heading', { name: 'Nachrichten' }),
+    ).toBeVisible();
+
+    // DIRECT rows render with `title = senderName` (Maria Mueller) and
+    // body preview underneath (ConversationListItem.tsx:33-34, 73-75).
+    // Matching on the unique body prefix isolates this run's row from
+    // any pre-existing lehrer↔eltern DIRECT conversation (find-or-create
+    // semantics mean the same conversation row can carry many prior
+    // messages — only the latest is asserted).
+    const row = page.getByRole('button', { name: new RegExp(`${MESSAGING_PREFIX}DIRECT-${ts}`) });
+    await expect(
+      row,
+      'eltern-user must see the DIRECT message preview the lehrer just sent',
+    ).toBeVisible();
+
+    await row.click();
+
+    // ConversationView renders the first message via MessageBubble
+    // (MessageBubble.tsx:90). `.first()` because the unique body string
+    // appears twice on the page after the row click: once in the
+    // truncated list preview and once in the bubble itself. Assertion
+    // intent ("body is rendered in ConversationView") is preserved.
+    await expect(
+      page.getByText(body).first(),
+      'DIRECT message body must appear in ConversationView after click',
+    ).toBeVisible();
+
+    // DIRECT badge proves the row is the DIRECT path (not a stray
+    // broadcast leaking through with a colliding prefix). `.first()`
+    // because the same "Direkt" badge appears in BOTH the list row
+    // (still visible in the left column) and the conversation header
+    // after the row click.
+    await expect(
+      page.getByText('Direkt').first(),
+      'Scope badge "Direkt" must render — guards against a broadcast-row false-positive',
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

Second sub-spec of #84 Messaging coverage. Locks the recipient-side flow for DIRECT 1:1 conversations:

- Lehrer (Maria Mueller) creates a DIRECT conversation to eltern-user via API
- eltern-user opens `/messages` → row appears titled by sender name with the message body in the preview
- Click → `ConversationView` renders the message body via `MessageBubble`
- Scope badge \"Direkt\" is visible (guards against a broadcast row leaking through a colliding prefix)

Refs #84.

## Why DIRECT next

MSG-LIST-01 (PR #91) covered the `CLASS` scope-expansion branch of `ConversationService.create`. The DIRECT branch is a different code path entirely — `createDirect` with its `directPairKey` find-or-create + 2-member transactional create. It's also where the conversation has **no subject**, so the recipient sees a row titled by `senderName` with the body in the preview (`ConversationListItem.tsx:33-34`) — a different UI render path than the broadcast row this PR's predecessor exercised.

## How

- `apps/web/e2e/helpers/messaging.ts`
  - `createDirectConversation(actor, recipient, body)` — actor-aware POST (default actor 'lehrer'). Uses `getRoleToken` so the spec doesn't need to hand-roll a Keycloak password-grant.
  - `cleanupE2EConversations(prefix, listAs)` — listing role is now configurable. Admin doesn't see DIRECT rows (admin is not a `conversationMembers` row for them), so the DIRECT spec passes `listAs='lehrer'`. Deletion still goes through the admin token because DELETE requires `manage:communication`.
  - Sweep filter now matches subject prefix **OR** last-message body prefix (DIRECT has no subject in the data model).
- `apps/web/e2e/messaging-direct-1on1.spec.ts` — 1 test, chromium-only, body-prefix isolation so the find-or-create singleton between the seed lehrer↔eltern pair can carry prior messages without breaking the assertion.

## Bug caught while writing

`GET /conversations` returns a bare `ConversationDto[]` — **not** a `{data: [...]}` paginated wrapper. The previous typing in `cleanupE2EConversations` was `{ data?: ... }` and read `body.data ?? []`, which silently returned `[]` for every array response. The sweep has been a no-op for the entire lifetime of PR #91; every `E2E-MSG-` broadcast leaked into the DB. Confirmed live: three leftover rows from the May-13 CI runs that I deleted by hand before this PR. Fixed inline because the new spec touches the same code path; verified post-run DB is clean (0 leftover E2E-MSG rows visible to either admin or lehrer tokens).

## Compose-via-UI deferred

The current `ComposeDialog.tsx` wires its footer \"Senden\" button only to `handleBroadcastSend`, so the Direktnachricht tab cannot actually post through the UI today. This spec drives setup via the API (same as MSG-LIST-01) and focuses on the recipient-visibility contract. A future slice can lock the compose UI once that wiring is fixed.

## Would-fail-without-fix check

Pointed `recipientId` at the admin's keycloakUserId instead of eltern's. Spec failed red on the `getByRole('button', { name: /E2E-MSG-DIRECT-…/ })` visibility assertion (timeout 10s) — eltern is not a member, no DIRECT row appears in their list. Restored to `elternId` before commit.

## Verification

- [x] Local: `playwright test messaging-direct-1on1.spec.ts --project=desktop` green (2.5s)
- [x] Local: `playwright test messaging-direct-1on1.spec.ts messaging-conversation-list.spec.ts --project=desktop` green in parallel (2 workers, 4.1s) — proves the cleanup fix didn't break MSG-LIST-01
- [x] Would-fail check verified red on wrong recipient
- [x] DB state post-run: 0 leftover `E2E-MSG-` rows visible to either admin or lehrer tokens
- [x] `pnpm --filter @schoolflow/web build` + `tsc --noEmit` green
- [ ] Playwright E2E CI green on this branch (per D3 — kein Merge ohne grün)

🤖 Generated with [Claude Code](https://claude.com/claude-code)