### PR TITLE
chore(e2e): close #85 — complete substitutions coverage (3 new specs)

### DIFF
--- a/apps/web/e2e/admin-substitutions-create.spec.ts
+++ b/apps/web/e2e/admin-substitutions-create.spec.ts
@@ -1,0 +1,166 @@
+/**
+ * Issue #85 — Admin "Neue Abwesenheit erfassen" UI flow.
+ *
+ * Third sub-spec of the Substitutions coverage gap. Locks the admin-side
+ * UI for creating an absence end-to-end:
+ *
+ *   1. Seed an active TimetableRun with one lesson at MONDAY/period-1
+ *      for kc-lehrer (Maria Mueller).
+ *   2. Admin opens /admin/substitutions?tab=absences, clicks "Neue
+ *      Abwesenheit erfassen", picks Maria Mueller + date range +
+ *      KRANK reason, submits.
+ *   3. Toast "Abwesenheit erfasst. 1 Stunden betroffen." confirms the
+ *      backend expansion produced exactly one row, and the AbsenceList
+ *      below the form re-renders with the new row.
+ *   4. Switch to "Offene Vertretungen" tab — the auto-generated
+ *      substitution surfaces.
+ *
+ * Why this slice: SUB-ADMIN-01 (PR #92) drove the absence creation via
+ * the API helper and only locked the list-side rendering. This one
+ * exercises the actual `<AbsenceForm>` ↔ `useCreateAbsence` ↔
+ * `POST /absences` path through the UI, which is the production-user
+ * flow and the only place the date inputs, the teacher Select, and the
+ * affectedLessonCount toast are wired together.
+ *
+ * Chromium-only-skip per the race-family precedent — shared seed-school
+ * mutating specs collide on parallel browser projects (TimetableRun is
+ * the canonical race surface).
+ */
+import { test, expect } from '@playwright/test';
+import { loginAsAdmin } from './helpers/login';
+import {
+  nextMondayISODate,
+  listSubstitutionsViaAPI,
+} from './helpers/substitutions';
+import {
+  cleanupTimetableRun,
+  seedTimetableRun,
+  purgeAbsenceViaPrisma,
+  type TimetableRunFixture,
+} from './fixtures/timetable-run';
+import { SEED_SCHOOL_UUID } from './fixtures/seed-uuids';
+
+test.describe('Issue #85 — Admin Neue Abwesenheit erfassen UI flow (desktop)', () => {
+  test.skip(
+    ({ isMobile }) => isMobile,
+    'AbsenceForm is desktop-prioritised — mobile flow is a follow-up slice once the form layout is mobile-audited.',
+  );
+  test.skip(
+    ({ browserName }) => browserName !== 'chromium',
+    'Race-family: mutates the shared seed-school TimetableRun + absences.',
+  );
+
+  let fixture: TimetableRunFixture | undefined;
+  // The UI flow leaves the absence row created via POST /absences on
+  // the server. afterEach tracks it by id (resolved post-submit via the
+  // admin GET /substitutions list) so the cleanup hard-deletes it
+  // through Prisma (cascades the auto-generated PENDING substitution).
+  let absenceId: string | undefined;
+
+  test.beforeEach(async ({ page }) => {
+    fixture = await seedTimetableRun(SEED_SCHOOL_UUID);
+    await loginAsAdmin(page);
+  });
+
+  test.afterEach(async () => {
+    if (absenceId) {
+      await purgeAbsenceViaPrisma(absenceId);
+      absenceId = undefined;
+    }
+    if (fixture) {
+      await cleanupTimetableRun(fixture);
+      fixture = undefined;
+    }
+  });
+
+  test('SUB-ADMIN-CREATE-01: admin creates an absence via the UI form → toast + AbsenceList + Offene Vertretungen row', async ({
+    page,
+    request,
+  }) => {
+    if (!fixture) throw new Error('fixture not seeded');
+
+    const monday = nextMondayISODate();
+
+    await page.goto('/admin/substitutions?tab=absences');
+    await expect(
+      page.getByRole('heading', { name: 'Vertretungsplanung' }),
+    ).toBeVisible();
+
+    // Open the form. Button copy is verbatim from substitutions.tsx:142.
+    await page
+      .getByRole('button', { name: 'Neue Abwesenheit erfassen' })
+      .click();
+
+    // Teacher Select — Radix Select renders option labels as
+    // "{lastName}, {firstName}" (AbsenceForm.tsx:152). The seed
+    // teacher is Maria Mueller.
+    await page.getByRole('combobox', { name: 'Lehrer/in' }).click();
+    await page
+      .getByRole('option', { name: 'Mueller, Maria' })
+      .click();
+
+    // Date range — both inputs default to today but the fixture lesson
+    // is on MONDAY, so override to the next Monday to guarantee the
+    // expansion algorithm picks up exactly one lesson.
+    await page.fill('input#absence-date-from', monday);
+    await page.fill('input#absence-date-to', monday);
+
+    // Reason defaults to KRANK already (AbsenceForm.tsx:67) — leaving
+    // it as-is intentionally to lock the default for downstream
+    // analytics specs.
+
+    await page
+      .getByRole('button', { name: 'Abwesenheit erfassen' })
+      .click();
+
+    // Submission toast — exact text from AbsenceForm.tsx:115. "1" is
+    // load-bearing: it proves the backend treated the absence as
+    // covering exactly the one seed lesson, not zero (would-fail check
+    // below) and not many (which would mean cross-fixture leakage).
+    await expect(
+      page.getByText('Abwesenheit erfasst. 1 Stunden betroffen.'),
+    ).toBeVisible();
+
+    // AbsenceList below the form re-renders with the new row. The
+    // teacherName field is "{firstName} {lastName}" (space-separated)
+    // from teacher-absence.service.ts:268, NOT the comma form the
+    // dropdown option uses. `.first()` because parallel-spec absences
+    // for Maria Mueller on the same Monday show up alongside ours in
+    // the shared tenant — assertion intent ("the row landed in the
+    // list") is preserved.
+    await expect(
+      page
+        .locator('table')
+        .getByText(/Maria\s+Mueller/)
+        .first(),
+    ).toBeVisible();
+
+    // Resolve the absence id via the admin substitutions API so
+    // afterEach can hard-delete it. We match by (originalTeacherId,
+    // dayOfWeek=MONDAY, periodNumber=1, status=PENDING) — the only
+    // substitution our spec could have produced given the fixture.
+    const subs = await listSubstitutionsViaAPI(request);
+    const ours = subs.find(
+      (s) =>
+        s.originalTeacherId === fixture!.teacherId &&
+        s.dayOfWeek === 'MONDAY' &&
+        s.periodNumber === 1 &&
+        s.status === 'PENDING',
+    );
+    expect(
+      ours,
+      'admin substitutions list must contain the auto-generated row for our absence',
+    ).toBeTruthy();
+    absenceId = ours!.absenceId;
+
+    // Switch tabs and verify the substitution surfaces in
+    // OpenSubstitutionsPanel. This validates the end-to-end loop:
+    // UI form → POST /absences → backend expansion → useSubstitutions
+    // refetch → panel render.
+    await page.getByRole('tab', { name: 'Offene Vertretungen' }).click();
+    await expect(
+      page.getByText(/Vertretung fuer:\s*Maria Mueller/).first(),
+      'newly created absence must produce a substitution row in the open panel',
+    ).toBeVisible();
+  });
+});

--- a/apps/web/e2e/fixtures/timetable-run.ts
+++ b/apps/web/e2e/fixtures/timetable-run.ts
@@ -34,7 +34,10 @@ import { createRequire } from 'node:module';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { SEED_TEACHER_KC_LEHRER_UUID } from './seed-uuids';
+import {
+  SEED_TEACHER_2_UUID,
+  SEED_TEACHER_KC_LEHRER_UUID,
+} from './seed-uuids';
 
 // Belt-and-braces dotenv. `import 'dotenv/config'` above loads from CWD (fine
 // when the runner is invoked from the repo root). Playwright workers run with
@@ -107,6 +110,13 @@ const { PrismaClient } = require('../../../api/dist/config/database/generated/cl
     };
     timetableLesson: {
       create: (args: { data: Record<string, unknown> }) => Promise<{ id: string }>;
+      deleteMany: (args: { where: { id: string } }) => Promise<unknown>;
+    };
+    teacherAbsence: {
+      deleteMany: (args: { where: Record<string, unknown> }) => Promise<unknown>;
+    };
+    handoverNote: {
+      deleteMany: (args: { where: Record<string, unknown> }) => Promise<unknown>;
     };
     $disconnect: () => Promise<void>;
   };
@@ -394,6 +404,161 @@ export async function cleanupTimetableRun(fixture: TimetableRunFixture): Promise
     // eslint-disable-next-line no-console
     console.warn(
       `[timetable-run fixture] cleanup failed for runId=${fixture.runId}:`,
+      err,
+    );
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Second-teacher lesson extension (Issue #85, SUB-LEHRER-INCOMING)
+// ---------------------------------------------------------------------------
+
+export interface SecondTeacherLessonFixture {
+  /** Echoed back so callers can scope downstream cleanups. */
+  runId: string;
+  lessonId: string;
+  /** Anna Lehrerin (`SEED_TEACHER_2_UUID`). */
+  teacherId: string;
+  /** Display name in "{firstName} {lastName}" order. */
+  teacherFullName: string;
+  /** Always MONDAY for now — paired with `seedTimetableRun`'s MONDAY/period-1. */
+  dayOfWeek: 'MONDAY';
+  /** Always 2 — different from `seedTimetableRun`'s period-1 so kc-lehrer is free to substitute. */
+  periodNumber: 2;
+}
+
+/**
+ * Add a SECOND TimetableLesson to an existing fixture's TimetableRun,
+ * taught by Anna Lehrerin (`SEED_TEACHER_2_UUID`) at MONDAY/period-2.
+ *
+ * Why a second lesson rather than a second run: keeping a single
+ * TimetableRun avoids the "multiple active runs" tie-breaker in
+ * `TimetableService.getView` and matches the per-school singleton
+ * invariant the production code enforces.
+ *
+ * Why MONDAY/period-2: paired with the existing fixture lesson at
+ * MONDAY/period-1 (kc-lehrer). At period-2 kc-lehrer has no lesson,
+ * so when Anna is absent the assign-substitute pre-check
+ * (`substitution.service.ts:91-108` Pitfall-2 guard) finds kc-lehrer
+ * free and accepts the OFFER. At a colliding period the assign would
+ * 409.
+ *
+ * Cleanup: piggy-backs on `cleanupTimetableRun` — the lesson is
+ * cascade-deleted via runId FK when the run is dropped. No bespoke
+ * cleanup needed unless an OFFERED Substitution survived
+ * (cancelAbsenceViaAPI deletes PENDING only). The companion
+ * `purgeAbsencesViaPrisma` in `helpers/substitutions.ts` handles that.
+ */
+export async function seedSecondTeacherLesson(
+  parent: TimetableRunFixture,
+): Promise<SecondTeacherLessonFixture> {
+  const prisma = new PrismaClient({
+    adapter: new PrismaPg({ connectionString: process.env.DATABASE_URL ?? '' }),
+  });
+  try {
+    const teacher = await prisma.teacher.findFirst({
+      where: { schoolId: parent.schoolId, id: SEED_TEACHER_2_UUID },
+      include: { person: true },
+    });
+    if (!teacher) {
+      throw new Error(
+        `Teacher ${SEED_TEACHER_2_UUID} (Anna Lehrerin) not found — re-run prisma:seed`,
+      );
+    }
+    const teacherFullName = teacher.person
+      ? `${teacher.person.firstName} ${teacher.person.lastName}`
+      : teacher.id;
+
+    const lesson = await prisma.timetableLesson.create({
+      data: {
+        runId: parent.runId,
+        classSubjectId: parent.classSubjectId,
+        teacherId: teacher.id,
+        roomId: parent.roomId,
+        dayOfWeek: 'MONDAY',
+        periodNumber: 2,
+        weekType: 'BOTH',
+      },
+    });
+
+    return {
+      runId: parent.runId,
+      lessonId: lesson.id,
+      teacherId: teacher.id,
+      teacherFullName,
+      dayOfWeek: 'MONDAY',
+      periodNumber: 2,
+    };
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+/**
+ * Pre-test sweep for stale handover notes left behind by previously
+ * crashed or interrupted `substitutions-handover.spec.ts` runs.
+ *
+ * Why this is needed even though afterEach calls `cancelAbsenceViaAPI`:
+ *   - `cancelAbsenceViaAPI` only marks the absence CANCELLED and
+ *     deletes PENDING substitutions for THAT specific absenceId. If a
+ *     previous run died between save-note and afterEach (CI timeout,
+ *     ctrl-C, OOM kill), the absence stays ACTIVE and the note stays
+ *     in DB forever.
+ *   - On the next run, `/teacher/substitutions` Section 2 renders BOTH
+ *     the stale absence AND the new one, both with "Notiz bearbeiten"
+ *     buttons. `.first()` then picks the stale row and the assertion
+ *     `toHaveValue(noteContent)` reads the OLD timestamp content —
+ *     observed failure on parallel run 2026-05-17.
+ *
+ * Scoped to the `E2E-SUB-HANDOVER-` content prefix so sibling specs
+ * that write handover notes (none today, but defensive) and the
+ * production seed data are untouched. Handover notes cascade-delete
+ * their attachments via the `HandoverAttachment.handoverNoteId`
+ * onDelete: Cascade FK, so attachment rows + on-disk files are
+ * collected by `HandoverService.deleteNote` semantics — but here we
+ * skip the on-disk unlink because (a) the file path lives only in the
+ * Node API service and (b) orphan attachment files in `uploads/` are
+ * harmless test residue, mopped up by the standard
+ * `pnpm db:e2e:reset` flow.
+ */
+export async function purgeStaleE2EHandoverNotes(): Promise<void> {
+  const prisma = new PrismaClient({
+    adapter: new PrismaPg({ connectionString: process.env.DATABASE_URL ?? '' }),
+  });
+  try {
+    await prisma.handoverNote.deleteMany({
+      where: { content: { startsWith: 'E2E-SUB-HANDOVER-' } },
+    });
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn('[timetable-run fixture] purgeStaleE2EHandoverNotes failed:', err);
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+/**
+ * Hard-delete a TeacherAbsence (cascades through Substitution and
+ * HandoverNote). Use this when a spec has assigned a substitute and
+ * the substitution is OFFERED/CONFIRMED — the public `cancelAbsence`
+ * endpoint only marks the absence as CANCELLED and only deletes
+ * PENDING substitutions, leaving OFFERED rows in the DB and tripping
+ * subsequent spec runs.
+ *
+ * Idempotent: a no-op if the absence is already gone.
+ */
+export async function purgeAbsenceViaPrisma(absenceId: string): Promise<void> {
+  const prisma = new PrismaClient({
+    adapter: new PrismaPg({ connectionString: process.env.DATABASE_URL ?? '' }),
+  });
+  try {
+    await prisma.teacherAbsence.deleteMany({ where: { id: absenceId } });
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[timetable-run fixture] purgeAbsenceViaPrisma failed for absenceId=${absenceId}:`,
       err,
     );
   } finally {

--- a/apps/web/e2e/helpers/substitutions.ts
+++ b/apps/web/e2e/helpers/substitutions.ts
@@ -100,6 +100,75 @@ export async function cancelAbsenceViaAPI(
 }
 
 /**
+ * GET /substitutions as admin. Returns the raw array (PENDING +
+ * OFFERED + DECLINED — `substitution.service.ts:419`). Specs use this
+ * to locate a freshly-created PENDING substitution by `absenceId` so
+ * they can pass its `id` into `assignSubstituteViaAPI`.
+ */
+export async function listSubstitutionsViaAPI(
+  request: APIRequestContext,
+): Promise<
+  Array<{
+    id: string;
+    absenceId: string;
+    status: string;
+    substituteTeacherId: string | null;
+    originalTeacherId: string;
+    periodNumber: number;
+    dayOfWeek: string;
+  }>
+> {
+  const token = await getAdminToken(request);
+  const res = await request.get(
+    `${SUBSTITUTIONS_API}/schools/${SUBSTITUTIONS_SCHOOL_ID}/substitutions`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+  expect(
+    res.ok(),
+    `GET /substitutions → ${res.status()}`,
+  ).toBeTruthy();
+  return (await res.json()) as Array<{
+    id: string;
+    absenceId: string;
+    status: string;
+    substituteTeacherId: string | null;
+    originalTeacherId: string;
+    periodNumber: number;
+    dayOfWeek: string;
+  }>;
+}
+
+/**
+ * POST /substitutions/:id/assign as admin — PENDING/DECLINED → OFFERED
+ * (`substitution.controller.ts:60`). Re-runs the Pitfall-2 conflict
+ * guard server-side; throws on 409 so the spec fails loud if the
+ * candidate is unexpectedly unavailable. The caller is responsible
+ * for ensuring the candidate is free at the substitution's
+ * (dayOfWeek, periodNumber) slot.
+ */
+export async function assignSubstituteViaAPI(
+  request: APIRequestContext,
+  substitutionId: string,
+  candidateTeacherId: string,
+): Promise<void> {
+  const token = await getAdminToken(request);
+  const res = await request.post(
+    `${SUBSTITUTIONS_API}/schools/${SUBSTITUTIONS_SCHOOL_ID}/substitutions/${substitutionId}/assign`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      data: { candidateTeacherId },
+    },
+  );
+  expect(
+    res.ok(),
+    `POST /substitutions/${substitutionId}/assign → ${res.status()} ${await res.text()}`,
+  ).toBeTruthy();
+}
+
+/**
  * Compute the YYYY-MM-DD string for the next MONDAY at-or-after the
  * given anchor date (defaults to today). Used to align test absences
  * with the seedTimetableRun fixture's MONDAY/period-1 lesson so the

--- a/apps/web/e2e/substitutions-handover.spec.ts
+++ b/apps/web/e2e/substitutions-handover.spec.ts
@@ -1,0 +1,203 @@
+/**
+ * Issue #85 — Übergabenotiz (handover note) author flow with attachment.
+ *
+ * Fifth and final sub-spec of the Substitutions coverage gap. Locks the
+ * absent-teacher's path through the `HandoverNoteEditor` dialog:
+ *
+ *   1. Seed an active TimetableRun with kc-lehrer's lesson at
+ *      MONDAY/period-1.
+ *   2. POST an absence for kc-lehrer for next Monday → backend creates
+ *      a PENDING Substitution.
+ *   3. kc-lehrer logs in → /teacher/substitutions → Section 2 row
+ *      "Uebergabenotiz" button visible.
+ *   4. Click button → `HandoverNoteEditor` dialog opens. Fill the
+ *      content textarea, attach a 4-byte stub PDF (magic bytes only —
+ *      handover.service.ts MIME validation looks at the first 4 bytes
+ *      and nothing else), click "Uebergabenotiz speichern".
+ *   5. Toast "Uebergabenotiz gespeichert" confirms the round-trip
+ *      through POST /handover-notes/substitutions/:id + multipart
+ *      POST /handover-notes/:noteId/attachments.
+ *   6. Re-open the editor — the content persists AND the attachment
+ *      surfaces in the "Anhaenge" panel (HandoverNoteEditor.tsx:103),
+ *      both of which prove the note actually landed in the DB and is
+ *      re-readable by the author (D-15 visibility rule).
+ *
+ * Why bundle attachment + content in one test: the issue text calls
+ * out attachment explicitly ("Eltern lädt PDF hoch ... Lehrer sieht
+ * Attachment" but for substitution context), and both legs of the
+ * round-trip hit related code paths (createOrUpdateNote +
+ * saveAttachment + assertVisible). Splitting into two specs would
+ * duplicate the dialog scaffolding for marginal coverage gain.
+ *
+ * Substitute-side view (substitute teacher reads the note inline on
+ * their offer card) is NOT covered here. That requires a second
+ * keycloak-mapped teacher to log in as substitute, which the seed
+ * doesn't ship. Deferred as a follow-up (the visibility rule itself
+ * is locked by handover.service.spec.ts at unit-test level).
+ *
+ * Chromium-only-skip per the race-family precedent — shared seed-school
+ * mutating specs collide on parallel browser projects.
+ */
+import { test, expect } from '@playwright/test';
+import { loginAsRole } from './helpers/login';
+import {
+  cancelAbsenceViaAPI,
+  createAbsenceViaAPI,
+  nextMondayISODate,
+  type CreatedAbsence,
+} from './helpers/substitutions';
+import {
+  cleanupTimetableRun,
+  purgeStaleE2EHandoverNotes,
+  seedTimetableRun,
+  type TimetableRunFixture,
+} from './fixtures/timetable-run';
+import { SEED_SCHOOL_UUID } from './fixtures/seed-uuids';
+
+// Stub PDF whose first 4 bytes are the PDF magic signature
+// (handover.service.ts:38 MAGIC_BYTES['application/pdf']). Magic-byte
+// detection is the only server-side gate beyond MIME + the 5 MB
+// Fastify multipart limit, so a 13-byte buffer is sufficient to pass
+// validation. Stays in-memory via Playwright's setInputFiles buffer
+// overload — no temp files, no fs cleanup.
+const STUB_PDF = Buffer.from('%PDF-1.4 test', 'utf-8');
+
+test.describe('Issue #85 — Uebergabenotiz author flow + attachment (desktop)', () => {
+  test.skip(
+    ({ isMobile }) => isMobile,
+    'HandoverNoteEditor dialog is desktop-prioritised; mobile layout is a follow-up audit once the dialog\'s textarea height is mobile-tuned.',
+  );
+  test.skip(
+    ({ browserName }) => browserName !== 'chromium',
+    'Race-family: mutates the shared seed-school TimetableRun + absences.',
+  );
+
+  let fixture: TimetableRunFixture | undefined;
+  let absence: CreatedAbsence | undefined;
+
+  test.beforeEach(async ({ page, request }) => {
+    // Wipe leftover E2E handover notes from previously-crashed runs so
+    // Section 2's "Notiz bearbeiten" `.first()` deterministically
+    // resolves to the row OUR test will save on (see
+    // `purgeStaleE2EHandoverNotes` for the full failure mode).
+    await purgeStaleE2EHandoverNotes();
+    fixture = await seedTimetableRun(SEED_SCHOOL_UUID);
+
+    const monday = nextMondayISODate();
+    absence = await createAbsenceViaAPI(request, {
+      teacherId: fixture.teacherId, // kc-lehrer absent → kc-lehrer becomes the note author
+      dateFrom: monday,
+      dateTo: monday,
+      reason: 'KRANK',
+    });
+    expect(
+      absence.affectedLessonCount ?? 0,
+      'absence-expansion must produce one PENDING substitution row for the author to attach the note to',
+    ).toBeGreaterThan(0);
+
+    await loginAsRole(page, 'lehrer');
+  });
+
+  test.afterEach(async ({ request }) => {
+    if (absence) {
+      // Substitution is still PENDING (no admin assigned a substitute)
+      // → cancelAbsenceViaAPI's deleteMany(PENDING) sweeps it,
+      // cascading the HandoverNote + HandoverAttachment rows + the
+      // on-disk file (HandoverService.delete unlinks attachments).
+      await cancelAbsenceViaAPI(request, absence.id);
+      absence = undefined;
+    }
+    if (fixture) {
+      await cleanupTimetableRun(fixture);
+      fixture = undefined;
+    }
+  });
+
+  test('SUB-HANDOVER-01: kc-lehrer writes a handover note + PDF attachment → save → reopen shows persisted content + attachment', async ({
+    page,
+  }) => {
+    if (!fixture) throw new Error('fixture not seeded');
+
+    const ts = Date.now();
+    const noteContent = `E2E-SUB-HANDOVER-${ts} — Bitte HÜ Seite 42 fortsetzen, Klasse hat Stillarbeit gut umgesetzt.`;
+    const attachmentName = `e2e-handover-${ts}.pdf`;
+
+    await page.goto('/teacher/substitutions');
+
+    // Section-2 must be populated by our seeded absence.
+    await expect(
+      page.getByRole('heading', { name: 'Meine Abwesenheiten' }),
+    ).toBeVisible();
+
+    // No-handover-note button label is the default "Uebergabenotiz"
+    // (substitutions.tsx:111). `.first()` covers race-family parallel
+    // absences for kc-lehrer.
+    await page
+      .getByRole('button', { name: 'Uebergabenotiz' })
+      .first()
+      .click();
+
+    // Editor dialog mounts. Title verbatim from
+    // HandoverNoteEditor.tsx:86.
+    await expect(
+      page.getByRole('heading', { name: 'Uebergabenotiz verfassen' }),
+    ).toBeVisible();
+
+    // Fill content textarea (id="handover-content" — line 92).
+    await page.fill('textarea#handover-content', noteContent);
+
+    // Attach the stub PDF. The FileUploadField wraps a hidden
+    // <input type="file"> (FileUploadField.tsx:113-122) — Playwright's
+    // setInputFiles works on hidden inputs. The dialog itself is the
+    // best locator scope since the page may carry other file inputs.
+    await page
+      .locator('dialog input[type="file"], [role="dialog"] input[type="file"]')
+      .first()
+      .setInputFiles({
+        name: attachmentName,
+        mimeType: 'application/pdf',
+        buffer: STUB_PDF,
+      });
+
+    // Save — copy verbatim from HandoverNoteEditor.tsx:133.
+    await page
+      .getByRole('button', { name: 'Uebergabenotiz speichern' })
+      .click();
+
+    // Success toast — author-flow round-trip succeeded.
+    await expect(
+      page.getByText('Uebergabenotiz gespeichert'),
+    ).toBeVisible();
+
+    // Dialog closes on save (HandoverNoteEditor.tsx:73). Wait for it
+    // to leave the DOM before re-opening.
+    await expect(
+      page.getByRole('heading', { name: 'Uebergabenotiz verfassen' }),
+    ).toHaveCount(0);
+
+    // The Section-2 row's button now reads "Notiz bearbeiten"
+    // (substitutions.tsx:110 — branch when hasHandoverNote=true).
+    // This proves the SubstitutionDto.hasHandoverNote field refreshed
+    // after the mutation, and the persisted note is reachable from
+    // the list view.
+    await expect(
+      page.getByRole('button', { name: 'Notiz bearbeiten' }).first(),
+      'after save, the button must flip to "Notiz bearbeiten" — proves hasHandoverNote refresh',
+    ).toBeVisible();
+
+    // Reopen → editor pre-fills with our saved content AND lists the
+    // attachment (HandoverNoteEditor.tsx:103-111).
+    await page
+      .getByRole('button', { name: 'Notiz bearbeiten' })
+      .first()
+      .click();
+    await expect(
+      page.locator('textarea#handover-content'),
+      'content must persist across save+reopen',
+    ).toHaveValue(noteContent);
+    await expect(
+      page.getByText(attachmentName),
+      'attachment filename must appear in the dialog\'s Anhaenge panel after reopen',
+    ).toBeVisible();
+  });
+});

--- a/apps/web/e2e/teacher-substitutions-incoming.spec.ts
+++ b/apps/web/e2e/teacher-substitutions-incoming.spec.ts
@@ -1,0 +1,180 @@
+/**
+ * Issue #85 — Teacher "Offene Anfragen" Section 1 (incoming offer).
+ *
+ * Fourth sub-spec of the Substitutions coverage gap. Locks the
+ * substitute-teacher's view of an OFFERED substitution on
+ * /teacher/substitutions Section 1 — the "Du vertrittst heute…" flow
+ * the issue text calls out and PR #94 explicitly deferred.
+ *
+ *   1. Seed an active TimetableRun with kc-lehrer's lesson at
+ *      MONDAY/period-1 + Anna Lehrerin's lesson at MONDAY/period-2
+ *      (added via seedSecondTeacherLesson on the SAME run).
+ *   2. POST an absence for Anna for next Monday → backend creates a
+ *      PENDING Substitution with originalTeacher=Anna.
+ *   3. POST /substitutions/:id/assign with candidateTeacherId =
+ *      kc-lehrer.teacher.id → status flips to OFFERED.
+ *   4. kc-lehrer logs in → /teacher/substitutions →
+ *      `SubstituteOfferCard` renders the offer with
+ *      "Vertretung fuer: Anna Lehrerin", an "Angeboten" badge, and
+ *      Akzeptieren / Ablehnen CTAs.
+ *
+ * Why this slice was deferred from PR #94: the substitute-side view
+ * requires a DIFFERENT teacher's lesson to be the absence target (so
+ * kc-lehrer can be the substitute, not the absentee). The previous
+ * `seedTimetableRun` fixture only seeded kc-lehrer's lesson, so an
+ * absence against any other teacher would expand to zero rows. This
+ * PR introduces `seedSecondTeacherLesson` to plug that gap on the
+ * SAME TimetableRun (avoids the "multiple active runs" race the prod
+ * `activateRun` transaction prevents).
+ *
+ * Why MONDAY/period-2 for Anna's lesson: kc-lehrer's seed lesson is
+ * MONDAY/period-1, so kc-lehrer is FREE at period-2 — the Pitfall-2
+ * conflict guard in `substitution.service.ts:91-108` accepts the
+ * assign. A colliding slot would 409.
+ *
+ * Chromium-only-skip per the race-family precedent — shared seed-school
+ * mutating specs collide on parallel browser projects.
+ */
+import { test, expect } from '@playwright/test';
+import { loginAsRole } from './helpers/login';
+import {
+  assignSubstituteViaAPI,
+  createAbsenceViaAPI,
+  listSubstitutionsViaAPI,
+  nextMondayISODate,
+  type CreatedAbsence,
+} from './helpers/substitutions';
+import {
+  cleanupTimetableRun,
+  purgeAbsenceViaPrisma,
+  seedSecondTeacherLesson,
+  seedTimetableRun,
+  type SecondTeacherLessonFixture,
+  type TimetableRunFixture,
+} from './fixtures/timetable-run';
+import {
+  SEED_SCHOOL_UUID,
+  SEED_TEACHER_KC_LEHRER_UUID,
+} from './fixtures/seed-uuids';
+
+test.describe('Issue #85 — Teacher Offene Anfragen Section 1 (desktop)', () => {
+  test.skip(
+    ({ isMobile }) => isMobile,
+    'Section-1 rendering is desktop-only for the first lock; mobile is a follow-up if the SubstituteOfferCard layout drifts.',
+  );
+  test.skip(
+    ({ browserName }) => browserName !== 'chromium',
+    'Race-family: mutates the shared seed-school TimetableRun + assigns kc-lehrer as substitute.',
+  );
+
+  let fixture: TimetableRunFixture | undefined;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  let second: SecondTeacherLessonFixture | undefined;
+  let absence: CreatedAbsence | undefined;
+  // OFFERED substitutions are NOT cleaned up by `cancelAbsenceViaAPI`
+  // (the API cancel-handler only deletes PENDING rows — see
+  // teacher-absence.service.ts:253). Track the absence id so afterEach
+  // hard-deletes via Prisma + cascade.
+  let absenceIdForCleanup: string | undefined;
+
+  test.beforeEach(async ({ request }) => {
+    fixture = await seedTimetableRun(SEED_SCHOOL_UUID);
+    second = await seedSecondTeacherLesson(fixture);
+
+    const monday = nextMondayISODate();
+    absence = await createAbsenceViaAPI(request, {
+      teacherId: second.teacherId, // Anna — NOT kc-lehrer
+      dateFrom: monday,
+      dateTo: monday,
+      reason: 'KRANK',
+    });
+    absenceIdForCleanup = absence.id;
+    expect(
+      absence.affectedLessonCount ?? 0,
+      'absence-expansion must produce one substitution row for Anna\'s MONDAY/period-2 lesson',
+    ).toBeGreaterThan(0);
+
+    // Resolve the PENDING substitution id, then assign kc-lehrer as the
+    // candidate substitute. Both happen as admin (the candidate has no
+    // permission to assign themselves).
+    const subs = await listSubstitutionsViaAPI(request);
+    const pending = subs.find(
+      (s) =>
+        s.originalTeacherId === second!.teacherId &&
+        s.dayOfWeek === 'MONDAY' &&
+        s.periodNumber === 2 &&
+        s.status === 'PENDING',
+    );
+    expect(
+      pending,
+      'admin substitutions list must contain the PENDING row for Anna\'s absence',
+    ).toBeTruthy();
+    await assignSubstituteViaAPI(
+      request,
+      pending!.id,
+      SEED_TEACHER_KC_LEHRER_UUID,
+    );
+  });
+
+  test.afterEach(async () => {
+    if (absenceIdForCleanup) {
+      await purgeAbsenceViaPrisma(absenceIdForCleanup);
+      absenceIdForCleanup = undefined;
+      absence = undefined;
+    }
+    if (fixture) {
+      await cleanupTimetableRun(fixture);
+      fixture = undefined;
+      second = undefined;
+    }
+  });
+
+  test('SUB-LEHRER-INCOMING-01: kc-lehrer sees Anna\'s absence as an OFFERED substitution in Section 1 with Accept/Decline CTAs', async ({
+    page,
+  }) => {
+    if (!fixture) throw new Error('fixture not seeded');
+
+    await loginAsRole(page, 'lehrer');
+    await page.goto('/teacher/substitutions');
+
+    // Section-1 page heading mounts.
+    await expect(
+      page.getByRole('heading', { name: 'Meine Vertretungen' }),
+    ).toBeVisible();
+
+    // Section-1 empty-state copy must NOT appear — our OFFERED row
+    // should populate the section. (substitutions.tsx:48 — "Keine
+    // offenen Vertretungsanfragen.")
+    await expect(
+      page.getByText('Keine offenen Vertretungsanfragen.'),
+      'Section-1 empty state must not appear when an OFFERED substitution exists for the logged-in teacher',
+    ).toHaveCount(0);
+
+    // SubstituteOfferCard renders "Vertretung fuer: <strong>{name}</strong>"
+    // (SubstituteOfferCard.tsx:117). Anna Lehrerin is the original
+    // teacher of the absence we created above. `.first()` covers the
+    // race-family case where another spec leaks an OFFERED row to
+    // kc-lehrer with the same originalTeacher.
+    await expect(
+      page.getByText(/Vertretung fuer:\s*Anna Lehrerin/).first(),
+      'card must show the absent teacher\'s name as the offer subject',
+    ).toBeVisible();
+
+    // "Angeboten" badge on the card proves the row's status flipped to
+    // OFFERED (SubstituteOfferCard.tsx:121).
+    await expect(
+      page.getByText('Angeboten').first(),
+      'OFFERED badge must render — guards against the row leaking as PENDING/CONFIRMED',
+    ).toBeVisible();
+
+    // Both CTAs render and are reachable from the card. (Accept opens
+    // a confirm dialog; we only verify presence here — the
+    // accept/decline mutation is a separate slice.)
+    await expect(
+      page.getByRole('button', { name: 'Akzeptieren' }).first(),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: 'Ablehnen' }).first(),
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

Ships the three remaining sub-specs of #85, taking the issue from 2/5 to 5/5. **Closes #85.**

| Slice | Test file | Status before | Status now |
|---|---|---|---|
| Admin Offene Vertretungen | `admin-substitutions-list.spec.ts` | ✅ PR #92 | ✅ |
| Teacher Meine Abwesenheiten | `teacher-substitutions-my-absences.spec.ts` | ✅ PR #94 | ✅ |
| **Admin Neue Abwesenheit erfassen (UI)** | `admin-substitutions-create.spec.ts` | ❌ | ✅ new |
| **Teacher Offene Anfragen (incoming offer)** | `teacher-substitutions-incoming.spec.ts` | ❌ (deferred PR #94) | ✅ new |
| **Übergabenotiz + Attachment (author flow)** | `substitutions-handover.spec.ts` | ❌ | ✅ new |

Closes #85.

## What's new

### SUB-ADMIN-CREATE-01 — admin UI absence form
Drives `Neue Abwesenheit erfassen` end-to-end through `AbsenceForm`:
teacher Select → date range → KRANK reason → submit. Asserts the
toast (`Abwesenheit erfasst. 1 Stunden betroffen.`), the AbsenceList
row, and the substitution row that surfaces on the Offene Vertretungen
tab. Locks the full UI → `useCreateAbsence` → POST /absences →
expansion → useSubstitutions refetch loop.

### SUB-LEHRER-INCOMING-01 — substitute-side OFFERED card
Seeds an absence for Anna Lehrerin at MONDAY/period-2 (on the same
TimetableRun as kc-lehrer's existing MONDAY/period-1 lesson), assigns
kc-lehrer as the candidate via `POST /substitutions/:id/assign` →
status flips PENDING → OFFERED → kc-lehrer logs in and sees the
`SubstituteOfferCard` with `Vertretung fuer: Anna Lehrerin`, Angeboten
badge, Akzeptieren / Ablehnen CTAs. **Closes the slice PR #94
explicitly deferred** ("requires a second teacher's lesson; out of
scope for this slice").

### SUB-HANDOVER-01 — author writes note + attachment, persists on reopen
kc-lehrer absent → opens `HandoverNoteEditor` → fills content
textarea + attaches a 13-byte stub PDF (first 4 bytes are `%PDF` to
pass `handover.service.ts:38` MAGIC_BYTES) → save → toast
`Uebergabenotiz gespeichert` → reopen proves both content AND
attachment filename round-tripped. The substitute-side view (a second
keycloak teacher seeing the note inline on their offer card) is
deferred — that needs a second seeded keycloak-mapped teacher; the
visibility rule itself stays locked at unit-test level in
`handover.service.spec.ts`.

## Fixture + helper additions

`apps/web/e2e/fixtures/timetable-run.ts`
- `seedSecondTeacherLesson(fixture)` — adds Anna Lehrerin at
  MONDAY/period-2 on the SAME TimetableRun. Why MONDAY/period-2: avoids
  the "multiple active runs" race AND keeps kc-lehrer free to substitute
  (Pitfall-2 conflict guard would 409 otherwise).
- `purgeAbsenceViaPrisma(id)` — hard-delete (cascades through
  Substitution + HandoverNote). The public `cancelAbsence` endpoint
  only marks the absence CANCELLED and only deletes PENDING
  substitutions; OFFERED rows leak across runs without this.
- `purgeStaleE2EHandoverNotes()` — pre-test sweep of leftover
  `E2E-SUB-HANDOVER-*` content from previously-crashed runs. **Race
  fix discovered on first parallel run**: without this, Section 2's
  `getByRole('button', { name: 'Notiz bearbeiten' }).first()`
  non-deterministically picks a stale row and the
  `toHaveValue(noteContent)` assertion reads the OLD timestamp.

`apps/web/e2e/helpers/substitutions.ts`
- `listSubstitutionsViaAPI(request)` — admin GET that returns the
  array used to resolve the freshly-created PENDING substitution id.
- `assignSubstituteViaAPI(request, subId, candidateId)` — admin POST
  `/assign` (PENDING → OFFERED).

## Would-fail-without-fix proofs

| Spec | Mutation | Result |
|---|---|---|
| SUB-ADMIN-CREATE-01 | Toast text "1 Stunden" → "99 Stunden" | Red ✓ |
| SUB-LEHRER-INCOMING-01 | candidateTeacherId → Peter Sportlich (not kc-lehrer) | Red ✓ |
| SUB-HANDOVER-01 | `toHaveValue(noteContent)` → wrong literal | Red ✓ |

All restored before commit.

## Stability

- 5 #85 specs `--workers=2`: 3x in a row green (8.3s / 7.7s / 7.8s).
- 5 #85 specs + 4 timetable-mutating siblings (timetable-non-admin-views,
  timetable-generation-flow, admin-timetable-edit-dnd,
  admin-timetable-edit-perspective): 13 passed + 1 pre-existing skip
  (REGRESSION-DND-COLLISION).
- DB post-run: 0 stale `E2E-SUB-HANDOVER-` notes, 0 PENDING/OFFERED
  substitutions, 0 ACTIVE absences.

## Test plan

- [x] Local: 3x parallel run of 5 #85 specs green
- [x] Local: 9-spec cross-cluster run green (13 passed + 1 pre-skip)
- [x] Would-fail-without-fix verified red on all 3 new specs
- [x] `tsc --noEmit` + `pnpm --filter @schoolflow/web build` green
- [x] DB clean post-run
- [ ] Playwright E2E CI green on this branch (per D3 — kein Merge ohne grün)

🤖 Generated with [Claude Code](https://claude.com/claude-code)