### PR TITLE
chore(e2e): close #87 — Timetable-History + Absence-Statistics admin coverage

### DIFF
--- a/apps/web/e2e/admin-timetable-history.spec.ts
+++ b/apps/web/e2e/admin-timetable-history.spec.ts
@@ -1,0 +1,207 @@
+/**
+ * Issue #87 — Admin Aenderungsverlauf (Timetable Edit History) coverage.
+ *
+ * Surface: /admin/timetable-history (apps/web/src/routes/_authenticated/
+ * admin/timetable-history.tsx, 104 LoC). Renders the EditHistoryPanel for
+ * the active TimetableRun. Today only `roles-smoke.spec.ts` proves the
+ * page rendert ohne Crash — there is no assertion that an actual edit
+ * shows up with the right action badge + description + revert
+ * confirmation copy.
+ *
+ * Test-Strategie:
+ *
+ *   TT-HIST-RENDER: seed a TimetableRun + TimetableLesson + one
+ *   TimetableLessonEdit row of action "move" (MONDAY/1 → TUESDAY/2),
+ *   admin selects class 1A perspective on /timetable so the
+ *   useTimetableStore has a perspective set, then navigates to
+ *   /admin/timetable-history. The page must render:
+ *     - heading "Aenderungsverlauf" + card title "Manuelle Aenderungen…"
+ *     - the seeded edit row with badge "Verschoben", description
+ *       "MONDAY 1. Std. -> TUESDAY 2. Std." (per EditHistoryPanel.tsx:100)
+ *     - the "Rueckgaengig" button
+ *
+ *   TT-HIST-REVERT-DIALOG: clicking "Rueckgaengig" must open the
+ *   confirmation dialog with title "Aenderung rueckgaengig machen" and
+ *   the destructive-copy paragraph that references "spaeter vorgenommenen
+ *   Aenderungen gehen verloren". "Abbrechen" closes the dialog without
+ *   touching the edit row (cleanup must still find it).
+ *
+ * Why we don't actually revert: revert mutates the underlying
+ * TimetableLesson back to the previousState (timetable-edit.service.ts:
+ * revertToEdit), which would race the seedTimetableRun() lesson
+ * coordinates with sibling specs. The confirmation-dialog open is the
+ * regression we want to lock — the actual mutation path is covered by
+ * the dnd / edit-perspective specs.
+ *
+ * Why Prisma-direct seeding: TimetableLessonEdit is an audit-log row
+ * with no API for direct creation (only PATCH /move plants edit rows as
+ * a side-effect, and driving a real move via UI would mutate the lesson
+ * grid — much wider blast radius). The `seedTimetableEdit()` helper
+ * uses the same `createRequire(Prisma client)` bridge as
+ * `seedTimetableRun()`. See fixtures/timetable-run.ts:seedTimetableEdit
+ * for the rationale.
+ *
+ * Race-Family-Achtung: chromium-only-skip + per-test seeding (same
+ * precedent as the #86 non-admin-view specs). The TimetableLessonEdit
+ * FK has no onDelete: Cascade on `run_id`, so cleanup MUST drop the
+ * edit row before the run row — `cleanupTimetableEdit` first, then
+ * `cleanupTimetableRun`. Reversed order leaks edit rows that subsequent
+ * runs see as ghost history.
+ */
+import { test, expect } from '@playwright/test';
+import { loginAsRole } from './helpers/login';
+import {
+  cleanupTimetableEdit,
+  cleanupTimetableRun,
+  seedTimetableEdit,
+  seedTimetableRun,
+  type TimetableEditFixture,
+  type TimetableRunFixture,
+} from './fixtures/timetable-run';
+import { SEED_SCHOOL_UUID } from './fixtures/seed-uuids';
+
+test.describe('Issue #87 — Admin timetable-history (desktop)', () => {
+  test.skip(
+    ({ isMobile }) => isMobile,
+    'Aenderungsverlauf is an admin-desktop surface. Mobile coverage of the EditHistoryPanel would belong to its own *.mobile.spec.ts.',
+  );
+  test.skip(
+    ({ browserName }) => browserName !== 'chromium',
+    'Mutates active TimetableRun on shared seed school — chromium is the sole writer (race-family precedent).',
+  );
+
+  let run: TimetableRunFixture | undefined;
+  let edit: TimetableEditFixture | undefined;
+
+  test.beforeEach(async () => {
+    run = await seedTimetableRun(SEED_SCHOOL_UUID);
+    edit = await seedTimetableEdit(run.runId, run.lessonId);
+  });
+
+  test.afterEach(async () => {
+    // CRITICAL ORDER: TimetableLessonEdit.run_id has NO onDelete: Cascade
+    // (schema.prisma:799–808). Dropping the run first would leave the
+    // edit row dangling — Postgres allows it (no FK constraint), but the
+    // ghost row pollutes subsequent test fixtures' history-length
+    // assertions. Drop the edit FIRST, then the run.
+    if (edit) {
+      await cleanupTimetableEdit(edit);
+      edit = undefined;
+    }
+    if (run) {
+      await cleanupTimetableRun(run);
+      run = undefined;
+    }
+  });
+
+  test('TT-HIST-RENDER: seeded "Verschoben" edit row + description show up on /admin/timetable-history', async ({
+    page,
+  }) => {
+    await loginAsRole(page, 'admin');
+
+    // ── Step 1: prime the timetable store with a perspective ────────────
+    // /admin/timetable-history reads `perspective` + `perspectiveId` from
+    // the zustand timetable-store and is empty-state until they are set.
+    // Admin auto-perspective is not auto-set; we mimic the same flow the
+    // admin-timetable-edit-perspective spec uses to drive the
+    // PerspectiveSelector to class 1A.
+    await page.goto('/timetable');
+    const perspectiveTrigger = page.getByRole('combobox').first();
+    await expect(perspectiveTrigger).toBeVisible();
+    await perspectiveTrigger.click();
+    await page.getByRole('option', { name: '1A', exact: true }).click();
+    await expect(
+      page.getByRole('grid', { name: 'Stundenplan' }),
+      'Class 1A perspective must mount the timetable grid before navigating to /admin/timetable-history (otherwise the page has no runId to fetch edit-history for)',
+    ).toBeVisible({ timeout: 15_000 });
+
+    // ── Step 2: navigate to the Aenderungsverlauf page via SPA router ──
+    // CRITICAL: `page.goto('/admin/timetable-history')` triggers a full
+    // page reload which destroys the in-memory zustand timetable-store
+    // (perspective + perspectiveId), and the page lands in the
+    // "Kein Stundenplan vorhanden" empty-state because `useTimetableView`
+    // is disabled when perspectiveId is null. Clicking the sidebar link
+    // routes via TanStack Router's history-API navigation — the store
+    // survives, the view query runs with our seeded perspective, and
+    // the page renders the EditHistoryPanel. Observed 2026-05-18:
+    // page.goto produced the empty-state regardless of how /timetable
+    // primed the store.
+    await page.getByRole('link', { name: 'Aenderungsverlauf' }).click();
+
+    await expect(
+      page.getByRole('heading', { name: 'Aenderungsverlauf' }),
+    ).toBeVisible();
+    await expect(
+      page.getByText('Manuelle Aenderungen am Stundenplan'),
+    ).toBeVisible();
+
+    // ── Step 3: assert the seeded edit row content ──────────────────────
+    // Badge label "Verschoben" comes from ACTION_LABELS['move'] in
+    // EditHistoryPanel.tsx:23.
+    await expect(
+      page.getByText('Verschoben', { exact: true }),
+      'Badge label for action "move" must read "Verschoben" (ACTION_LABELS.move in EditHistoryPanel.tsx:23)',
+    ).toBeVisible();
+
+    // Description is built from previousState/newState in
+    // EditHistoryPanel.tsx:100 — "MONDAY 1. Std. -> TUESDAY 2. Std."
+    // The strings are emitted verbatim from the JSON columns; matching
+    // the literal text catches any future change that would silently
+    // re-format the diff string.
+    await expect(
+      page.getByText('MONDAY 1. Std. -> TUESDAY 2. Std.', { exact: true }),
+      'Move description must read "${prevDay} ${prevPeriod}. Std. -> ${newDay} ${newPeriod}. Std." (EditHistoryPanel.tsx:101)',
+    ).toBeVisible();
+
+    // Revert button must be present on the row.
+    await expect(
+      page.getByRole('button', { name: 'Rueckgaengig' }),
+    ).toBeVisible();
+  });
+
+  test('TT-HIST-REVERT-DIALOG: "Rueckgaengig" opens the confirmation dialog with destructive copy and Abbrechen closes it', async ({
+    page,
+  }) => {
+    await loginAsRole(page, 'admin');
+    await page.goto('/timetable');
+    const perspectiveTrigger = page.getByRole('combobox').first();
+    await expect(perspectiveTrigger).toBeVisible();
+    await perspectiveTrigger.click();
+    await page.getByRole('option', { name: '1A', exact: true }).click();
+    await expect(page.getByRole('grid', { name: 'Stundenplan' })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // SPA-link navigation, NOT page.goto: see TT-HIST-RENDER for the
+    // zustand-store-survival rationale.
+    await page.getByRole('link', { name: 'Aenderungsverlauf' }).click();
+
+    // Wait for the edit row to mount before clicking — the Rueckgaengig
+    // button is one-per-row.
+    await expect(page.getByText('Verschoben', { exact: true })).toBeVisible();
+    await page.getByRole('button', { name: 'Rueckgaengig' }).click();
+
+    // Dialog must surface with the EditHistoryPanel.tsx:150 title + the
+    // destructive-copy paragraph (UI-SPEC: "Alle spaeter vorgenommenen
+    // Aenderungen gehen verloren.").
+    await expect(
+      page.getByRole('dialog'),
+      'Clicking "Rueckgaengig" must open the confirmation Radix Dialog',
+    ).toBeVisible();
+    await expect(
+      page.getByText('Aenderung rueckgaengig machen', { exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByText(/spaeter vorgenommenen Aenderungen gehen verloren/),
+      'Destructive-copy paragraph must reference the data-loss consequence (UI-SPEC destructive copy guard)',
+    ).toBeVisible();
+
+    // "Abbrechen" closes the dialog without firing the revert mutation —
+    // the edit row therefore stays in the DB and cleanupTimetableEdit
+    // can still find it in afterEach.
+    await page.getByRole('button', { name: 'Abbrechen' }).click();
+    await expect(page.getByRole('dialog')).toHaveCount(0);
+    // Sanity: the row is still there.
+    await expect(page.getByText('Verschoben', { exact: true })).toBeVisible();
+  });
+});

--- a/apps/web/e2e/fixtures/absence-stats.ts
+++ b/apps/web/e2e/fixtures/absence-stats.ts
@@ -1,0 +1,279 @@
+/**
+ * Fixture for the absence-statistics E2E spec — Issue #87.
+ *
+ * Seeds one ClassBookEntry on a deterministic date with three
+ * AttendanceRecord rows that exercise each of the four
+ * `AttendanceStatus` values that the statistics aggregator surfaces
+ * differently:
+ *
+ *   - Lisa Huber   → PRESENT                  → 0.0%  Fehlquote
+ *   - Felix Bauer  → ABSENT                   → 100.0% Fehlquote (unentschuldigt)
+ *   - Sophie Wagner→ LATE, lateMinutes=20     → counted as 1 Verspaetet +
+ *                                                 1 Verspaetet>15Min,
+ *                                                 100.0% Fehlquote
+ *                                                 (D-04 Schulunterrichtsgesetz)
+ *
+ * Why Prisma-direct: the backend has POST/PATCH endpoints for
+ * AttendanceRecord but the path to create a ClassBookEntry from scratch
+ * requires resolving a TimetableLesson first (`/classbook/by-timetable-
+ * lesson/:id` upserts the entry). Driving that through the live API
+ * would require seeding a TimetableLesson with a matching date, then
+ * resolving the entry, then POSTing attendance per student — three
+ * round-trips on every test setup. Direct insert is deterministic and
+ * self-contained, and the data shape required by `statistics.service.ts`
+ * is just (classSubjectId, date, periodNumber, weekType, teacherId,
+ * schoolId) for the entry plus (classBookEntryId, studentId, status,
+ * lateMinutes) for each record.
+ *
+ * Date isolation: the fixture writes to a single calendar date that the
+ * spec then pins via the date-range filter inputs on /statistics/absence.
+ * This way the test asserts on exactly its own three rows even if other
+ * specs leave attendance noise in class 1A on different dates.
+ *
+ * Module-loading pattern: same `createRequire` + dotenv belt-and-braces
+ * bridge that fixtures/timetable-run.ts uses to load the API's
+ * SWC-emitted CJS Prisma client into the ESM Playwright runner.
+ */
+import 'dotenv/config';
+import { config as dotenvConfig } from 'dotenv';
+import { createRequire } from 'node:module';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+dotenvConfig({ path: path.resolve(__dirname, '../../../../.env') });
+
+const require = createRequire(import.meta.url);
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { PrismaClient } = require('../../../api/dist/config/database/generated/client.js') as {
+  PrismaClient: new (opts?: { adapter?: unknown }) => {
+    classSubject: {
+      findFirst: (args: {
+        where: Record<string, unknown>;
+        orderBy?: Record<string, unknown>;
+        select?: Record<string, unknown>;
+      }) => Promise<{ id: string; subjectId: string } | null>;
+    };
+    student: {
+      findMany: (args: {
+        where: Record<string, unknown>;
+        include?: Record<string, unknown>;
+        orderBy?: Record<string, unknown>;
+      }) => Promise<
+        Array<{
+          id: string;
+          person?: { firstName: string; lastName: string } | null;
+        }>
+      >;
+    };
+    classBookEntry: {
+      create: (args: { data: Record<string, unknown> }) => Promise<{ id: string }>;
+      deleteMany: (args: { where: { id: string } }) => Promise<unknown>;
+    };
+    attendanceRecord: {
+      create: (args: { data: Record<string, unknown> }) => Promise<{ id: string }>;
+    };
+    $disconnect: () => Promise<void>;
+  };
+};
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { PrismaPg } = require('../../../api/node_modules/@prisma/adapter-pg') as {
+  PrismaPg: new (opts: { connectionString: string }) => unknown;
+};
+
+import { SEED_TEACHER_KC_LEHRER_UUID } from './seed-uuids';
+
+/**
+ * Fixed date used by both the fixture and the spec. Must lie inside
+ * an Austrian school semester so the page's default date-range
+ * doesn't filter our entry out before the spec overrides the inputs.
+ *
+ * 2026-03-15 (Sunday, semester 2 = Feb-Jun 2026). Sunday is fine for
+ * the data model — `ClassBookEntry.dayOfWeek` is a separate enum
+ * from the calendar date and the statistics aggregator does not
+ * cross-check the two. Picking a Sunday keeps us safely outside any
+ * date that a "today"-anchored spec might compute.
+ */
+export const STATS_FIXTURE_DATE = '2026-03-15';
+
+/** Spec sets this period on the fixture to avoid colliding with the
+ *  period=1 used by the seedTimetableRun() singleton lesson. */
+export const STATS_FIXTURE_PERIOD = 5;
+
+export interface AbsenceStatsFixture {
+  /** The ClassBookEntry row id — used by cleanup to scope the delete. */
+  entryId: string;
+  /** classSubjectId the entry was bound to (echoed back for assertions). */
+  classSubjectId: string;
+  /** Resolved student person IDs for the three seeded attendance rows. */
+  students: {
+    lisaId: string;
+    felixId: string;
+    sophieId: string;
+  };
+}
+
+const SEED_CLASS_1A_ID = 'seed-class-1a';
+
+const STUDENT_NAMES = {
+  lisa: { firstName: 'Lisa', lastName: 'Huber' },
+  felix: { firstName: 'Felix', lastName: 'Bauer' },
+  sophie: { firstName: 'Sophie', lastName: 'Wagner' },
+} as const;
+
+type PrismaClientShape = InstanceType<typeof PrismaClient>;
+
+/**
+ * Resolves student row IDs by firstName+lastName for class 1A. The
+ * statistics service joins Student → Person and renders
+ * `${firstName} ${lastName}` — we match by the same key.
+ */
+async function findThreeSeedStudents(
+  prisma: PrismaClientShape,
+): Promise<AbsenceStatsFixture['students']> {
+  const students = await prisma.student.findMany({
+    where: { classId: SEED_CLASS_1A_ID, isArchived: false },
+    include: { person: true },
+  });
+
+  function findId(target: { firstName: string; lastName: string }): string {
+    const hit = students.find(
+      (s) =>
+        s.person?.firstName === target.firstName &&
+        s.person?.lastName === target.lastName,
+    );
+    if (!hit) {
+      throw new Error(
+        `[absence-stats fixture] seed student ${target.firstName} ${target.lastName} not found in class 1A — re-run prisma:seed`,
+      );
+    }
+    return hit.id;
+  }
+
+  return {
+    lisaId: findId(STUDENT_NAMES.lisa),
+    felixId: findId(STUDENT_NAMES.felix),
+    sophieId: findId(STUDENT_NAMES.sophie),
+  };
+}
+
+/**
+ * Seeds one ClassBookEntry on STATS_FIXTURE_DATE/STATS_FIXTURE_PERIOD
+ * for the first ClassSubject of class 1A, plus three AttendanceRecord
+ * rows (one per Huber/Bauer/Wagner). Returns the fixture handle so
+ * `cleanupAbsenceStats()` can hard-delete the entry (cascade removes
+ * the attendance records via the AttendanceRecord.classBookEntry FK
+ * with onDelete: Cascade, schema.prisma:961).
+ *
+ * Uniqueness: ClassBookEntry has @@unique([classSubjectId, date,
+ * periodNumber, weekType]). Pinning periodNumber = STATS_FIXTURE_PERIOD
+ * (5) keeps us clear of the period=1 lesson seedTimetableRun() plants
+ * and of any other classbook-related fixture using period=1 or 2.
+ */
+export async function seedAbsenceStats(
+  schoolId: string,
+): Promise<AbsenceStatsFixture> {
+  const prisma = new PrismaClient({
+    adapter: new PrismaPg({ connectionString: process.env.DATABASE_URL ?? '' }),
+  });
+  try {
+    const classSubject = await prisma.classSubject.findFirst({
+      where: { classId: SEED_CLASS_1A_ID },
+      orderBy: { id: 'asc' },
+      select: { id: true, subjectId: true },
+    });
+    if (!classSubject) {
+      throw new Error(
+        '[absence-stats fixture] seed-class-1a has no ClassSubject — re-run `pnpm --filter @schoolflow/api prisma:seed`',
+      );
+    }
+
+    const students = await findThreeSeedStudents(prisma);
+
+    const entry = await prisma.classBookEntry.create({
+      data: {
+        classSubjectId: classSubject.id,
+        dayOfWeek: 'FRIDAY',
+        periodNumber: STATS_FIXTURE_PERIOD,
+        weekType: 'BOTH',
+        // Store exactly at UTC midnight so it matches the API's date-filter
+        // bounds. The statistics service parses `startDate`/`endDate` query
+        // params with `new Date('2026-03-15')` (statistics.service.ts:53)
+        // which the JS spec resolves to midnight UTC for an
+        // ISO-date-only string. A non-midnight value would silently fall
+        // OUT of `gte/lte` when the spec sets startDate == endDate ==
+        // fixture date (observed 2026-05-18: storing 12:00:00 produced
+        // an empty result set despite the entry existing).
+        date: new Date(`${STATS_FIXTURE_DATE}T00:00:00Z`),
+        teacherId: SEED_TEACHER_KC_LEHRER_UUID,
+        schoolId,
+        thema: null,
+        lehrstoff: null,
+        hausaufgabe: null,
+      },
+    });
+
+    await prisma.attendanceRecord.create({
+      data: {
+        classBookEntryId: entry.id,
+        studentId: students.lisaId,
+        status: 'PRESENT',
+        recordedBy: SEED_TEACHER_KC_LEHRER_UUID,
+      },
+    });
+    await prisma.attendanceRecord.create({
+      data: {
+        classBookEntryId: entry.id,
+        studentId: students.felixId,
+        status: 'ABSENT',
+        recordedBy: SEED_TEACHER_KC_LEHRER_UUID,
+      },
+    });
+    await prisma.attendanceRecord.create({
+      data: {
+        classBookEntryId: entry.id,
+        studentId: students.sophieId,
+        status: 'LATE',
+        lateMinutes: 20,
+        recordedBy: SEED_TEACHER_KC_LEHRER_UUID,
+      },
+    });
+
+    return {
+      entryId: entry.id,
+      classSubjectId: classSubject.id,
+      students,
+    };
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+/**
+ * Hard-delete the ClassBookEntry. AttendanceRecord rows cascade via
+ * AttendanceRecord.classBookEntry { onDelete: Cascade } (schema.prisma:961).
+ *
+ * Best-effort: swallows errors so a half-applied fixture from a
+ * previously killed test can't block the next setup.
+ */
+export async function cleanupAbsenceStats(
+  fixture: AbsenceStatsFixture,
+): Promise<void> {
+  const prisma = new PrismaClient({
+    adapter: new PrismaPg({ connectionString: process.env.DATABASE_URL ?? '' }),
+  });
+  try {
+    await prisma.classBookEntry.deleteMany({ where: { id: fixture.entryId } });
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[absence-stats fixture] cleanupAbsenceStats failed for entryId=${fixture.entryId}:`,
+      err,
+    );
+  } finally {
+    await prisma.$disconnect();
+  }
+}

--- a/apps/web/e2e/fixtures/timetable-run.ts
+++ b/apps/web/e2e/fixtures/timetable-run.ts
@@ -112,6 +112,10 @@ const { PrismaClient } = require('../../../api/dist/config/database/generated/cl
       create: (args: { data: Record<string, unknown> }) => Promise<{ id: string }>;
       deleteMany: (args: { where: { id: string } }) => Promise<unknown>;
     };
+    timetableLessonEdit: {
+      create: (args: { data: Record<string, unknown> }) => Promise<{ id: string; createdAt: Date }>;
+      deleteMany: (args: { where: { id: string } }) => Promise<unknown>;
+    };
     teacherAbsence: {
       deleteMany: (args: { where: Record<string, unknown> }) => Promise<unknown>;
     };
@@ -559,6 +563,96 @@ export async function purgeAbsenceViaPrisma(absenceId: string): Promise<void> {
     // eslint-disable-next-line no-console
     console.warn(
       `[timetable-run fixture] purgeAbsenceViaPrisma failed for absenceId=${absenceId}:`,
+      err,
+    );
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+export interface TimetableEditFixture {
+  /** TimetableLessonEdit row id — used by cleanup to scope the delete. */
+  editId: string;
+  /** ISO-string of `created_at` so the spec can render the same Berlin-local
+   *  "dd.MM.yyyy HH:mm" string the EditHistoryPanel produces via date-fns. */
+  createdAtISO: string;
+}
+
+/**
+ * Seed a single TimetableLessonEdit row of type "move" against an existing
+ * TimetableRun + TimetableLesson (use seedTimetableRun() first). The
+ * EditHistoryPanel renders the row as:
+ *
+ *   "${prevDay} ${prevPeriod}. Std. -> ${newDay} ${newPeriod}. Std."
+ *
+ * (see apps/web/src/components/timetable/EditHistoryPanel.tsx:100). The
+ * action badge label is "Verschoben" for `editAction = 'move'` per
+ * ACTION_LABELS in the same file.
+ *
+ * Why Prisma-direct: the backend exposes a PATCH lesson-move endpoint
+ * (timetable.controller.ts:184), but driving an actual move via API would
+ * require correct CSRF/auth headers AND would mutate the real lesson grid
+ * — a wider blast radius than a single edit-history row needs. The
+ * `TimetableLessonEdit` row is a pure audit-log entry with no FK
+ * cascades back to the lesson it references, so a direct insert is
+ * deterministic and self-contained.
+ *
+ * Fields:
+ * - lessonId / runId — passed in from a seedTimetableRun() fixture
+ * - editedBy — UUID-shaped string; the page doesn't require a real
+ *   User row (no FK) and only renders `editedByName` if present in the
+ *   DTO, which the backend leaves undefined.
+ * - previousState / newState — minimal {dayOfWeek, periodNumber} so the
+ *   description renderer at EditHistoryPanel.tsx:101 has something to
+ *   format. The spec asserts on the resulting "MONDAY 1. Std. -> TUESDAY 2. Std."
+ *   string.
+ */
+export async function seedTimetableEdit(
+  runId: string,
+  lessonId: string,
+): Promise<TimetableEditFixture> {
+  const prisma = new PrismaClient({
+    adapter: new PrismaPg({ connectionString: process.env.DATABASE_URL ?? '' }),
+  });
+  try {
+    const edit = await prisma.timetableLessonEdit.create({
+      data: {
+        runId,
+        lessonId,
+        editedBy: '00000000-0000-4000-8000-00000000e2e1',
+        editAction: 'move',
+        previousState: { dayOfWeek: 'MONDAY', periodNumber: 1 },
+        newState: { dayOfWeek: 'TUESDAY', periodNumber: 2 },
+      },
+    });
+    return {
+      editId: edit.id,
+      createdAtISO: edit.createdAt.toISOString(),
+    };
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+/**
+ * Hard-delete a single TimetableLessonEdit row. The TimetableRun cleanup
+ * does NOT cascade to TimetableLessonEdit (the FK on `run_id` has no
+ * onDelete: Cascade in schema.prisma:799), so specs MUST clean up their
+ * own edit rows or they accumulate on the seed school's runs and skew
+ * subsequent specs' history-length assertions.
+ */
+export async function cleanupTimetableEdit(
+  fixture: TimetableEditFixture,
+): Promise<void> {
+  const prisma = new PrismaClient({
+    adapter: new PrismaPg({ connectionString: process.env.DATABASE_URL ?? '' }),
+  });
+  try {
+    await prisma.timetableLessonEdit.deleteMany({ where: { id: fixture.editId } });
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[timetable-run fixture] cleanupTimetableEdit failed for editId=${fixture.editId}:`,
       err,
     );
   } finally {

--- a/apps/web/e2e/statistics-absence.spec.ts
+++ b/apps/web/e2e/statistics-absence.spec.ts
@@ -1,0 +1,167 @@
+/**
+ * Issue #87 — Absence-Statistics (Abwesenheitsstatistik) coverage.
+ *
+ * Surface: /statistics/absence (apps/web/src/routes/_authenticated/
+ * statistics/absence.tsx, 50 LoC) → renders AbsenceStatisticsPanel.
+ * Today only `roles-smoke.spec.ts` proves the page renders ohne crash;
+ * there is no assertion that the per-student aggregation MATCHES the
+ * underlying attendance data — exactly the kind of silent drift that
+ * the statistics service's status-→-counter switch (statistics.service.
+ * ts:144) and the D-04 Schulunterrichtsgesetz rule "Verspaetet >15 Min
+ * zaehlt als abwesend" could quietly break.
+ *
+ * Test-Strategie — single end-to-end aggregation lock:
+ *
+ *   STATS-AGG-3STUDENTS: seed exactly ONE ClassBookEntry on a fixed
+ *   date (STATS_FIXTURE_DATE = 2026-03-15) with three AttendanceRecords:
+ *     - Lisa Huber    → PRESENT
+ *     - Felix Bauer   → ABSENT
+ *     - Sophie Wagner → LATE, lateMinutes=20 (counts as 1 Verspaetet
+ *                          AND 1 Verspaetet>15Min per D-04)
+ *
+ *   Admin opens /statistics/absence, the page auto-selects class 1A
+ *   (the first class by yearLevel+name asc), the spec sets BOTH date
+ *   inputs to the fixture date so the API filter narrows to our entry
+ *   only, and the spec then asserts the three Fehlquote values:
+ *     - Felix Bauer  → 100.0%
+ *     - Lisa Huber   →   0.0%
+ *     - Sophie Wagner→ 100.0% (the >15min late + the absent share the
+ *                              "counts as absent" semantics in absenceRate)
+ *
+ * Why a fixed date instead of "today": the page's default date range
+ * is the current Austrian school semester (statistics.service.ts:15
+ * getSemesterDateRange), which spans ~5 months. Without a fixed date
+ * input override, any leftover attendance noise from other classbook
+ * specs in the same semester would pollute the counts and make the
+ * assertions race-prone. The spec pins BOTH date inputs to
+ * STATS_FIXTURE_DATE so the API call passes startDate=endDate=
+ * 2026-03-15 and the backend filter `gte/lte` returns only the
+ * fixture's entry. The fixture also uses a unique periodNumber (5,
+ * not the period=1 that seedTimetableRun() uses) so the
+ * ClassBookEntry.@@unique constraint can't collide with the
+ * classbook-related fixtures.
+ *
+ * Why Prisma-direct fixture: the path to create a ClassBookEntry via
+ * API is `GET /classbook/by-timetable-lesson/:id` which upserts an
+ * entry from a TimetableLesson — but it pins the entry's date to
+ * the lesson's date (today) and the period to the lesson's period.
+ * That doesn't give us deterministic control over the (classSubjectId,
+ * date, period, weekType) tuple the statistics service aggregates on,
+ * and would require seeding additional TimetableLessons for each
+ * spec iteration. Direct Prisma insert hits the same uniqueness
+ * constraint without the extra round-trips.
+ *
+ * Race-Family-Achtung: chromium-only-skip + per-test seed/cleanup.
+ * The fixture deletes the ClassBookEntry in afterEach, which cascades
+ * to the AttendanceRecord rows via `AttendanceRecord.classBookEntry`
+ * onDelete: Cascade (schema.prisma:961).
+ */
+import { test, expect } from '@playwright/test';
+import { loginAsRole } from './helpers/login';
+import {
+  cleanupAbsenceStats,
+  seedAbsenceStats,
+  STATS_FIXTURE_DATE,
+  type AbsenceStatsFixture,
+} from './fixtures/absence-stats';
+import { SEED_SCHOOL_UUID } from './fixtures/seed-uuids';
+
+test.describe('Issue #87 — Absence-Statistics (desktop)', () => {
+  test.skip(
+    ({ isMobile }) => isMobile,
+    'Statistics table is wider than mobile viewport (horizontal scroll required) — mobile coverage would belong to its own *.mobile.spec.ts that asserts the sticky-name-column behaviour.',
+  );
+  test.skip(
+    ({ browserName }) => browserName !== 'chromium',
+    'Mutates ClassBookEntry + AttendanceRecord rows on the shared seed class 1A — chromium is the sole writer (race-family precedent).',
+  );
+
+  let fixture: AbsenceStatsFixture | undefined;
+
+  test.beforeEach(async () => {
+    fixture = await seedAbsenceStats(SEED_SCHOOL_UUID);
+  });
+
+  test.afterEach(async () => {
+    if (!fixture) return;
+    await cleanupAbsenceStats(fixture);
+    fixture = undefined;
+  });
+
+  test('STATS-AGG-3STUDENTS: aggregated Fehlquote per student matches the seeded PRESENT/ABSENT/LATE>15 attendance', async ({
+    page,
+  }) => {
+    await loginAsRole(page, 'admin');
+    await page.goto('/statistics/absence');
+
+    await expect(
+      page.getByRole('heading', { name: 'Abwesenheitsstatistik' }),
+    ).toBeVisible();
+
+    // The Zeitraum is two raw `<input type="date">` elements; the page
+    // doesn't label them individually (one shared "Zeitraum" label).
+    // Pin both to the fixture date to isolate from semester-wide noise.
+    const dateInputs = page.locator('input[type="date"]');
+    await expect(dateInputs).toHaveCount(2);
+    await dateInputs.nth(0).fill(STATS_FIXTURE_DATE);
+    await dateInputs.nth(1).fill(STATS_FIXTURE_DATE);
+
+    // Wait for the table to render with the seeded data.
+    // The page auto-selects classes[0] on mount (1A by yearLevel+name asc),
+    // so by the time we land here the API request for statistics has
+    // already been kicked off for 1A. The date-input changes invalidate
+    // the query and trigger a refetch.
+    const table = page.locator('table');
+    await expect(table).toBeVisible();
+
+    // Each student row is keyed by studentId; we assert content by name.
+    // Sort order is lastName-asc per statistics.service.ts:188, so the
+    // visible order is Bauer → Huber → Wagner.
+    const felixRow = page.locator('tr', { hasText: 'Felix Bauer' });
+    const lisaRow = page.locator('tr', { hasText: 'Lisa Huber' });
+    const sophieRow = page.locator('tr', { hasText: 'Sophie Wagner' });
+
+    await expect(felixRow).toBeVisible();
+    await expect(lisaRow).toBeVisible();
+    await expect(sophieRow).toBeVisible();
+
+    // ── Felix Bauer: ABSENT → 100.0% Fehlquote ────────────────────────
+    // formatPercentage = `${value.toFixed(1)}%` ⇒ JS .toFixed uses dot,
+    // not the German comma decimal separator (AbsenceStatisticsPanel.
+    // tsx:49). The literal "100.0%" string therefore matches exactly.
+    await expect(
+      felixRow.getByText('100.0%', { exact: true }),
+      'Felix Bauer is ABSENT for 1 of 1 lesson → Fehlquote 100.0% (absentUnexcused / totalLessons * 100, statistics.service.ts:170)',
+    ).toBeVisible();
+
+    // ── Lisa Huber: PRESENT → 0.0% Fehlquote ──────────────────────────
+    await expect(
+      lisaRow.getByText('0.0%', { exact: true }),
+      'Lisa Huber is PRESENT for 1 of 1 lesson → Fehlquote 0.0%',
+    ).toBeVisible();
+
+    // ── Sophie Wagner: LATE 20min → 100.0% Fehlquote ──────────────────
+    // D-04 Schulunterrichtsgesetz: lateMinutes > 15 counts in
+    // lateOver15MinCount AND in absenceRate.
+    // statistics.service.ts:171 puts (absentUnexcused + absentExcused +
+    // lateOver15Min) / totalLessons into absenceRate → (0 + 0 + 1) / 1 =
+    // 100.0%.
+    await expect(
+      sophieRow.getByText('100.0%', { exact: true }),
+      'Sophie Wagner is LATE with lateMinutes=20 → lateOver15MinCount=1 → Fehlquote 100.0% (D-04 Schulunterrichtsgesetz rule)',
+    ).toBeVisible();
+
+    // ── D-04 deeper lock: Sophie's "Verspaetet >15 Min." column = 1 ──
+    // The lateOver15MinCount cell is the column that the D-04 rule
+    // most directly drives, and AbsenceStatisticsPanel.tsx:262 applies
+    // the orange highlight when the value > 0. A future refactor that
+    // collapsed lateOver15MinCount into a generic "late" counter
+    // would break the rule silently — this assertion catches it.
+    const sophieCells = sophieRow.locator('td');
+    // Columns (AbsenceStatisticsPanel.tsx:108):
+    //   0 studentName, 1 totalLessons, 2 presentCount, 3 absentUnexcused,
+    //   4 absentExcused, 5 lateCount, 6 lateOver15MinCount, 7 absenceRate
+    await expect(sophieCells.nth(5)).toHaveText('1');
+    await expect(sophieCells.nth(6)).toHaveText('1');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #87 — die beiden Admin-Surfaces `/admin/timetable-history` (104 LoC) und `/statistics/absence` (50 LoC) waren bisher nur durch `roles-smoke.spec.ts` abgedeckt (rendern ohne Crash). Diese PR liefert die beiden Specs, die das Issue auflistet, plus zwei neue Fixture-Helper.

## Was die PR macht

| Datei | Tests | Was es lockt |
|---|---|---|
| `admin-timetable-history.spec.ts` | 2 | TT-HIST-RENDER — seed `TimetableLessonEdit` (action=`move`) erscheint mit Badge `Verschoben` + Description `MONDAY 1. Std. -> TUESDAY 2. Std.` + `Rueckgaengig` Button. TT-HIST-REVERT-DIALOG — Klick auf `Rueckgaengig` öffnet Confirmation-Dialog mit destruktiver Copy, `Abbrechen` schließt ohne Mutation. |
| `statistics-absence.spec.ts` | 1 | STATS-AGG-3STUDENTS — Lisa PRESENT / Felix ABSENT / Sophie LATE-20min → Fehlquote 0.0% / 100.0% / 100.0% + Sophie's `Verspaetet >15 Min.` Spalte = 1 (D-04 Schulunterrichtsgesetz-Regel). |
| `fixtures/timetable-run.ts` | (extended) | `seedTimetableEdit` / `cleanupTimetableEdit` Helper für die Edit-Audit-Row. |
| `fixtures/absence-stats.ts` | (new) | `seedAbsenceStats` / `cleanupAbsenceStats` Helper für ClassBookEntry + 3 AttendanceRecord-Rows. |

## Bug-Klassen, die diese Specs fangen

- **EditHistoryPanel re-formatting drift** — wenn jemand `${prevDay} ${prevPeriod}. Std. -> ${newDay} ${newPeriod}. Std.` umbaut (z.B. auf Deutsch-Tagesnamen `Montag` oder relative Strings), fällt der exact-text-match.
- **Destructive-copy regression** — wenn die Confirmation-Copy ("spaeter vorgenommenen Aenderungen gehen verloren") gekürzt wird, fällt die Regex-Assertion.
- **D-04 Schulunterrichtsgesetz-Verlust** — wenn statistics.service.ts:144 das `LATE > 15min counts as absent` switch-case verliert (z.B. durch eine Refactor-PR, die `lateOver15MinCount` in einen generischen `late` counter kollabiert), schlägt die Sophie-Assertion zu.
- **Date-filter offset bug** — fix dokumentiert: das Backend nutzt `new Date('YYYY-MM-DD')` als `gte/lte` ohne end-of-day Erweiterung. Fixture stored at UTC midnight, sonst landet die Row außerhalb der `gte/lte` Bounds.

## SPA-link-vs-page.goto Lesson learned

Während der Implementation: `/admin/timetable-history` braucht den Zustand `perspective + perspectiveId` aus dem zustand timetable-store. `page.goto()` reloadet die Seite und löscht den In-Memory-Store → empty-state. Lösung: nach Setzen der Perspective auf `/timetable` via SPA-Link (`getByRole('link', { name: 'Aenderungsverlauf' }).click()`) navigieren, NICHT `page.goto`. Im Spec-Body dokumentiert für künftige Leser.

## Test plan

- [x] All 3 tests pass on `--project=desktop` (6.4s)
- [x] Specs skip cleanly on `--project=desktop-firefox` (race-family precedent: shared per-school TimetableRun + ClassBookEntry mutation → chromium is the sole writer)
- [x] Specs not picked up by mobile projects (no `.mobile.spec.ts` suffix)
- [x] Fixtures clean up: TimetableLessonEdit deleted BEFORE TimetableRun (FK has no cascade); ClassBookEntry delete cascades to AttendanceRecord
- [ ] CI green before merge (D3 directive)

Closes #87.

🤖 Generated with [Claude Code](https://claude.com/claude-code)