### PR TITLE
fix(calendar): close #88 — iCal CalendarController double-prefix + E2E regression-lock

### DIFF
--- a/apps/api/src/modules/calendar/calendar.controller.ts
+++ b/apps/api/src/modules/calendar/calendar.controller.ts
@@ -32,7 +32,7 @@ export class CalendarController {
   // ---------------------------------------------------------------------------
 
   @Public()
-  @Get('api/v1/calendar/:token.ics')
+  @Get('calendar/:token.ics')
   @ApiOperation({ summary: 'Get iCal feed by subscription token' })
   @ApiParam({ name: 'token', description: 'Calendar subscription token' })
   async getIcs(
@@ -59,7 +59,7 @@ export class CalendarController {
   // JWT-protected token management
   // ---------------------------------------------------------------------------
 
-  @Post('api/v1/schools/:schoolId/calendar/token')
+  @Post('schools/:schoolId/calendar/token')
   @ApiBearerAuth()
   @CheckPermissions({ action: 'create', subject: 'calendar-token' })
   @ApiOperation({ summary: 'Create a calendar subscription token' })
@@ -70,7 +70,7 @@ export class CalendarController {
     return this.calendarService.generateToken(user.id, schoolId);
   }
 
-  @Get('api/v1/schools/:schoolId/calendar/token')
+  @Get('schools/:schoolId/calendar/token')
   @ApiBearerAuth()
   @CheckPermissions({ action: 'read', subject: 'calendar-token' })
   @ApiOperation({ summary: 'Get current calendar subscription token' })
@@ -92,7 +92,7 @@ export class CalendarController {
     };
   }
 
-  @Delete('api/v1/schools/:schoolId/calendar/token')
+  @Delete('schools/:schoolId/calendar/token')
   @ApiBearerAuth()
   @CheckPermissions({ action: 'delete', subject: 'calendar-token' })
   @ApiOperation({ summary: 'Revoke current token and generate a new one' })

--- a/apps/web/e2e/helpers/calendar-tokens.ts
+++ b/apps/web/e2e/helpers/calendar-tokens.ts
@@ -1,0 +1,181 @@
+/**
+ * Calendar-Token E2E helpers — Issue #88.
+ *
+ * Three responsibilities:
+ *  1. Map test-persona role names → SchoolFlow Person UUIDs (fixed
+ *     seed constants from `fixtures/seed-uuids.ts`). The CalendarToken
+ *     row uses `userId = Person.keycloakUserId`, but the Keycloak
+ *     user UUIDs are GENERATED at realm-import time and differ across
+ *     environments. We resolve them at runtime via the Person table
+ *     (Person.keycloakUserId column) so the helper is portable
+ *     across dev / CI / fresh-import scenarios.
+ *  2. A Prisma-direct purge of `calendar_tokens` rows for the test
+ *     personas. The CalendarToken table allows MULTIPLE rows per
+ *     (userId, schoolId) — there is no @@unique constraint on that
+ *     tuple, only on `token` (calendar.service.ts:32 does an
+ *     unconditional INSERT and the schema declares only a unique
+ *     index on `token`). A leftover token from a prior failed test
+ *     therefore both (a) prevents the empty-state assertion AND (b)
+ *     leaks into the next spec's "URL must differ" assertion (the
+ *     newly-generated URL is fine but the GET returns the OLDEST
+ *     row via findFirst). Specs MUST purge in beforeEach AND
+ *     afterEach to be deterministic.
+ *  3. An `apiBaseFromE2eEnv()` helper that resolves the bare API
+ *     host (e.g. http://localhost:3000) from the existing
+ *     `E2E_API_URL` convention (which points to .../api/v1 by
+ *     default). Specs that fetch the public ICS endpoint need just
+ *     the host because `calendarUrl` already includes the
+ *     /api/v1/calendar/<token>.ics suffix.
+ *
+ * Why Prisma-direct cleanup (not API DELETE): the API DELETE
+ * endpoint is `revokeAndRegenerate` — it deletes AND immediately
+ * creates a new token (calendar.controller.ts:99). That's not
+ * cleanup, that's churn. The Prisma-direct deleteMany leaves the
+ * user in the "no token yet" state which is what beforeEach
+ * needs.
+ */
+import 'dotenv/config';
+import { config as dotenvConfig } from 'dotenv';
+import { createRequire } from 'node:module';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  SEED_PERSON_KC_ADMIN_UUID,
+  SEED_PERSON_KC_ELTERN_UUID,
+  SEED_PERSON_KC_LEHRER_UUID,
+  SEED_PERSON_KC_SCHUELER_UUID,
+  SEED_PERSON_KC_SCHULLEITUNG_UUID,
+} from '../fixtures/seed-uuids';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+dotenvConfig({ path: path.resolve(__dirname, '../../../../.env') });
+
+const require = createRequire(import.meta.url);
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { PrismaClient } = require('../../../api/dist/config/database/generated/client.js') as {
+  PrismaClient: new (opts?: { adapter?: unknown }) => {
+    person: {
+      findMany: (args: {
+        where: Record<string, unknown>;
+        select: Record<string, unknown>;
+      }) => Promise<Array<{ id: string; keycloakUserId: string | null }>>;
+    };
+    calendarToken: {
+      deleteMany: (args: { where: Record<string, unknown> }) => Promise<{ count: number }>;
+    };
+    $disconnect: () => Promise<void>;
+  };
+};
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { PrismaPg } = require('../../../api/node_modules/@prisma/adapter-pg') as {
+  PrismaPg: new (opts: { connectionString: string }) => unknown;
+};
+
+/**
+ * Role → Person UUID lookup. The Person row links a SchoolFlow domain
+ * record to a Keycloak user via `keycloakUserId`. We start from the
+ * fixed Person UUIDs (defined in apps/api/prisma/seed.ts) because the
+ * Keycloak user UUIDs are NON-fixed: they're generated at realm-import
+ * time and differ across environments (observed locally: lehrer-user =
+ * `230711d2-...`, not the `00000000-0000-0000-0000-000000000002` that
+ * docker/keycloak/realm-export.json declares).
+ */
+const PERSON_UUID_BY_ROLE = {
+  admin: SEED_PERSON_KC_ADMIN_UUID,
+  lehrer: SEED_PERSON_KC_LEHRER_UUID,
+  eltern: SEED_PERSON_KC_ELTERN_UUID,
+  schueler: SEED_PERSON_KC_SCHUELER_UUID,
+  schulleitung: SEED_PERSON_KC_SCHULLEITUNG_UUID,
+} as const;
+
+export type CalendarTestRole = keyof typeof PERSON_UUID_BY_ROLE;
+
+/**
+ * Resolve the bare API host (e.g. http://localhost:3000) for use by
+ * `request.get('<host>/api/v1/calendar/<token>.ics')`. The existing
+ * convention is `E2E_API_URL = http://localhost:3000/api/v1` —
+ * strip the trailing `/api/v1` to get the host.
+ *
+ * The public ICS endpoint is mounted at `/api/v1/calendar/:token.ics`
+ * (calendar.controller.ts after the #88 fix) and `calendarUrl` in
+ * the React settings component is the relative path
+ * `/api/v1/calendar/...ics` (calendar.controller.ts:87).
+ * Prepending the host produces the absolute URL the iCal
+ * subscription client would use.
+ */
+export function apiBaseFromE2eEnv(): string {
+  const apiUrl = process.env.E2E_API_URL ?? 'http://localhost:3000/api/v1';
+  return apiUrl.replace(/\/api\/v1\/?$/, '');
+}
+
+/**
+ * Resolve Keycloak user UUIDs from the Person table for the given
+ * roles. Returns only the userIds that have a non-null
+ * keycloakUserId — defensive against a seed run that skipped
+ * Keycloak linking (e.g. when Keycloak was unreachable and seed
+ * fell back to default UUIDs).
+ */
+async function resolveKeycloakUserIds(
+  roles: ReadonlyArray<CalendarTestRole>,
+): Promise<string[]> {
+  const personIds = roles.map((r) => PERSON_UUID_BY_ROLE[r]);
+  const prisma = new PrismaClient({
+    adapter: new PrismaPg({ connectionString: process.env.DATABASE_URL ?? '' }),
+  });
+  try {
+    const rows = await prisma.person.findMany({
+      where: { id: { in: personIds } },
+      select: { id: true, keycloakUserId: true },
+    });
+    return rows
+      .map((p) => p.keycloakUserId)
+      .filter((id): id is string => id != null && id.length > 0);
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+/**
+ * Hard-delete every CalendarToken row for the given roles on the
+ * seed school. Used in beforeEach and afterEach so each spec starts
+ * with a deterministic empty-state and leaves no residue.
+ *
+ * Implementation note: the helper resolves keycloakUserId via the
+ * Person table at call time rather than hard-coding UUIDs, because
+ * Keycloak generates fresh user UUIDs per realm-import and the
+ * realm-export.json IDs do NOT survive a re-import. Hard-coding
+ * would silently no-op against a re-imported realm.
+ */
+export async function purgeCalendarTokensForRoles(
+  schoolId: string,
+  roles: ReadonlyArray<CalendarTestRole>,
+): Promise<void> {
+  const userIds = await resolveKeycloakUserIds(roles);
+  if (userIds.length === 0) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[calendar-tokens helper] no Keycloak userId resolved for roles=${roles.join(',')} — nothing to purge`,
+    );
+    return;
+  }
+  const prisma = new PrismaClient({
+    adapter: new PrismaPg({ connectionString: process.env.DATABASE_URL ?? '' }),
+  });
+  try {
+    await prisma.calendarToken.deleteMany({
+      where: { schoolId, userId: { in: userIds } },
+    });
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[calendar-tokens helper] purgeCalendarTokensForRoles failed for roles=${roles.join(',')}:`,
+      err,
+    );
+  } finally {
+    await prisma.$disconnect();
+  }
+}

--- a/apps/web/e2e/settings-ical-generate.spec.ts
+++ b/apps/web/e2e/settings-ical-generate.spec.ts
@@ -1,0 +1,169 @@
+/**
+ * Issue #88 — iCal calendar-token generate flow (Settings).
+ *
+ * Surface: /settings → ICalSettings card (apps/web/src/components/
+ * calendar/ICalSettings.tsx). Today only `roles-smoke.spec.ts`
+ * proves the page rendert ohne Crash — there is no end-to-end
+ * regression-lock that the generated token URL actually serves a
+ * valid iCal feed.
+ *
+ * Test-Strategie — full POST → URL → public-GET round-trip:
+ *
+ *   ICAL-GEN-LEHRER:
+ *     1. Purge any stale token row for lehrer-user on the seed
+ *        school (defensive — a previous failed run could leave
+ *        one and the page would land in "Token exists" state,
+ *        not "Noch kein Kalender-Abonnement").
+ *     2. Lehrer logs in, navigates to /settings.
+ *     3. Page shows the empty-state copy + the "Kalender-URL erstellen"
+ *        CTA. Click it.
+ *     4. Success toast "Kalender-URL erstellt" surfaces.
+ *     5. The monospace URL element renders with the
+ *        `/api/v1/calendar/<uuid>.ics` path (a UUID — token is
+ *        `crypto.randomUUID()`, calendar.service.ts:30).
+ *     6. Issue an UNAUTHENTICATED GET on the absolute version of
+ *        that URL. The public ICS endpoint is @Public()
+ *        (calendar.controller.ts:34) and serves the iCal even
+ *        without a JWT — exactly what an iCal subscription client
+ *        (Apple Kalender / Google Calendar / Outlook) sends.
+ *     7. Assert: 200 OK, Content-Type contains "text/calendar",
+ *        body starts with BEGIN:VCALENDAR and ends with
+ *        END:VCALENDAR.
+ *
+ * Bug-class this catches: any future commit that breaks the
+ * full token-URL-roundtrip — e.g. renaming the controller
+ * `@Public()` decorator, changing the URL shape, dropping the
+ * UUID format, or serving the wrong Content-Type. These are
+ * exactly the kind of silent regressions the iCal subscription
+ * surface needs locked, because the user-visible failure mode is
+ * "my calendar app silently stops syncing" — no toast, no error,
+ * no log line on the user's side.
+ *
+ * Race-Family-Achtung: chromium-only-skip + purgeCalendarTokensFor
+ * in both beforeEach and afterEach. CalendarToken is per-(userId,
+ * schoolId) — multiple workers running this spec for the same
+ * lehrer would race the @@unique constraint on the `token` column
+ * and the unconditional INSERT (calendar.service.ts:32 has no
+ * upsert), so chromium is the sole writer.
+ */
+import { test, expect } from '@playwright/test';
+import { loginAsRole } from './helpers/login';
+import {
+  apiBaseFromE2eEnv,
+  purgeCalendarTokensForRoles,
+} from './helpers/calendar-tokens';
+import { SEED_SCHOOL_UUID } from './fixtures/seed-uuids';
+
+const ROLE = 'lehrer' as const;
+
+test.describe('Issue #88 — iCal generate (desktop)', () => {
+  test.skip(
+    ({ isMobile }) => isMobile,
+    'iCal subscription is a desktop-anchored workflow (URL is copied into a desktop calendar app). Mobile coverage belongs to its own *.mobile.spec.ts that asserts the "URL kopieren" button surfaces below the URL field on base/sm.',
+  );
+  test.skip(
+    ({ browserName }) => browserName !== 'chromium',
+    'Mutates the singleton CalendarToken row for lehrer-user on the seed school — chromium is the sole writer (race-family precedent).',
+  );
+
+  test.beforeEach(async () => {
+    await purgeCalendarTokensForRoles(SEED_SCHOOL_UUID, [ROLE]);
+  });
+
+  test.afterEach(async () => {
+    await purgeCalendarTokensForRoles(SEED_SCHOOL_UUID, [ROLE]);
+  });
+
+  test('ICAL-GEN-LEHRER: "Kalender-URL erstellen" → toast + URL renders → public GET returns valid VCALENDAR', async ({
+    page,
+    request,
+  }) => {
+    await loginAsRole(page, ROLE);
+    await page.goto('/settings');
+
+    // Empty-state lock — proves the purge took effect and the page is
+    // actually rendering the "no token yet" branch (ICalSettings.tsx:78).
+    //
+    // Note: shadcn CardTitle renders as <div>, NOT <h*> (see
+    // apps/web/src/components/ui/card.tsx:32 — `React.forwardRef<HTMLDivElement>`).
+    // getByRole('heading') would not match — use getByText instead.
+    await expect(
+      page.getByText('Kalender-Abonnement', { exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByText('Noch kein Kalender-Abonnement eingerichtet.'),
+    ).toBeVisible();
+
+    const createButton = page.getByRole('button', {
+      name: 'Kalender-URL erstellen',
+    });
+    await expect(createButton).toBeVisible();
+    await createButton.click();
+
+    // Success toast surfaces from useGenerateCalendarToken.onSuccess
+    // (useCalendarToken.ts:49). Sonner renders toasts inside a region
+    // with aria-label "Notifications" — getByText scoped to status role
+    // is the cleanest locator that doesn't trip on the card body's
+    // sibling text.
+    await expect(
+      page.getByText('Kalender-URL erstellt', { exact: false }),
+    ).toBeVisible();
+
+    // After the query invalidation refetches, the page swaps to the
+    // "token exists" branch which renders the monospace URL field. The
+    // <label> for that field is "Ihre persoenliche Kalender-URL".
+    await expect(
+      page.getByText('Ihre persoenliche Kalender-URL'),
+    ).toBeVisible();
+
+    // The URL element is `<div className="font-mono ...">` with the
+    // calendarUrl text. Grab the visible relative URL — `crypto.randomUUID()`
+    // produces a v4 UUID so the format is fixed.
+    const urlElement = page
+      .locator('div.font-mono')
+      .filter({ hasText: /^\/api\/v1\/calendar\/[0-9a-f-]{36}\.ics$/i })
+      .first();
+    await expect(urlElement).toBeVisible();
+    const relativeUrl = (await urlElement.textContent())?.trim() ?? '';
+    expect(
+      relativeUrl,
+      'Generated URL must match /api/v1/calendar/<uuid>.ics shape (token is crypto.randomUUID() per calendar.service.ts:30)',
+    ).toMatch(/^\/api\/v1\/calendar\/[0-9a-f-]{36}\.ics$/i);
+
+    // ── Public ICS endpoint round-trip — no Authorization header ────────
+    // calendar.controller.ts:34 marks getIcs() @Public() so this
+    // request bypasses the JWT guard. The iCal subscription client
+    // (Apple Kalender etc.) sends this exact request shape.
+    const absoluteUrl = `${apiBaseFromE2eEnv()}${relativeUrl}`;
+    const icsResponse = await request.get(absoluteUrl, {
+      // Belt-and-braces: explicitly drop any auth header that might be
+      // sticky on the shared Playwright APIRequestContext from earlier
+      // logged-in fetches.
+      headers: {},
+    });
+
+    expect(
+      icsResponse.status(),
+      `Public ICS endpoint must return 200 OK for a freshly generated token (got status ${icsResponse.status()} for ${relativeUrl})`,
+    ).toBe(200);
+    expect(
+      icsResponse.headers()['content-type'] ?? '',
+      'Content-Type must be text/calendar (calendar.controller.ts:53)',
+    ).toContain('text/calendar');
+
+    const icsBody = await icsResponse.text();
+    expect(
+      icsBody.startsWith('BEGIN:VCALENDAR'),
+      `ICS body must start with BEGIN:VCALENDAR (got first 80 chars: ${JSON.stringify(icsBody.slice(0, 80))})`,
+    ).toBe(true);
+    expect(
+      icsBody.trim().endsWith('END:VCALENDAR'),
+      'ICS body must end with END:VCALENDAR — proves the ical-generator emitted a complete document, not a partial response',
+    ).toBe(true);
+    // PRODID line is mandatory in RFC 5545 and the service sets it to
+    // SchoolFlow explicitly (calendar.service.ts:70). This catches a
+    // future swap to a stub ical-generator that emits empty calendars.
+    expect(icsBody).toMatch(/PRODID:[^\r\n]*SchoolFlow/i);
+
+  });
+});

--- a/apps/web/e2e/settings-ical-rbac.spec.ts
+++ b/apps/web/e2e/settings-ical-rbac.spec.ts
@@ -1,0 +1,155 @@
+/**
+ * Issue #88 — iCal calendar-token per-user isolation (Settings).
+ *
+ * This is the "optional" third sub-spec in #88 ("eltern-user sieht nur
+ * eigene Tokens, kann nicht andere widerrufen"). The CalendarToken
+ * table is single-row-per-(userId, schoolId) and lookups derive the
+ * userId from the JWT subject — no list-all-tokens endpoint, no
+ * cross-user delete path. The realistic regression to lock is
+ * therefore "each user gets their OWN token, distinct from any
+ * other user's, and both URLs serve valid VCALENDAR feeds".
+ *
+ * Test-Strategie — two-context per-user isolation:
+ *
+ *   ICAL-RBAC-PER-USER:
+ *     1. Two browser contexts so lehrer and eltern auth state
+ *        don't share — same pattern as messaging-broadcast/realtime
+ *        specs.
+ *     2. Lehrer generates a token in context A. Capture URL.
+ *     3. Eltern generates a token in context B. Capture URL.
+ *     4. Assert the two URLs differ — proves the backend keyed by
+ *        the JWT subject, not by some shared key (e.g. schoolId
+ *        alone, which would mean Lehrer + Eltern share one token
+ *        = exposing Eltern's child's data to Lehrer and vice versa).
+ *     5. Each token URL fetched unauthenticated → 200 + valid ICS.
+ *        Proves the public endpoint resolves the FK back to the
+ *        right user row for both — a regression that swapped the
+ *        FK or hard-coded a single user would surface here.
+ *
+ * Bug-class this catches: any future change that breaks the
+ * per-user partitioning of CalendarToken — e.g. a schema migration
+ * that drops the `userId` column, a controller refactor that
+ * resolves the user from a path param instead of the JWT, or a
+ * findFirst that mis-orders the where clause and grabs an
+ * arbitrary token.
+ *
+ * Race-Family-Achtung: chromium-only-skip + purge BOTH personas in
+ * beforeEach/afterEach (the purge helper takes an array of roles).
+ */
+import { test, expect } from '@playwright/test';
+import { loginAsRole } from './helpers/login';
+import {
+  apiBaseFromE2eEnv,
+  purgeCalendarTokensForRoles,
+} from './helpers/calendar-tokens';
+import { SEED_SCHOOL_UUID } from './fixtures/seed-uuids';
+
+/**
+ * Use personas that are NOT shared with the sibling generate.spec
+ * (lehrer) or revoke.spec (eltern). Without this isolation, parallel
+ * workers running across the three files race on the same persona's
+ * CalendarToken row — observed 2026-05-18 as the empty-state
+ * assertion in generate.spec going red because rbac.spec had just
+ * created a lehrer token in its own beforeEach window.
+ *
+ * `schueler` and `admin` are otherwise-untouched by #88 specs.
+ * Both have calendar-token CRUD permissions per
+ * apps/api/prisma/seed.ts (lines 460-462 schueler, line 217 admin
+ * "manage all").
+ */
+const ROLES = ['schueler', 'admin'] as const;
+
+test.describe('Issue #88 — iCal RBAC / per-user isolation (desktop)', () => {
+  test.skip(
+    ({ isMobile }) => isMobile,
+    'iCal subscription is a desktop-anchored workflow.',
+  );
+  test.skip(
+    ({ browserName }) => browserName !== 'chromium',
+    'Mutates singleton CalendarToken rows for two personas on the seed school — chromium is the sole writer.',
+  );
+
+  test.beforeEach(async () => {
+    await purgeCalendarTokensForRoles(SEED_SCHOOL_UUID, ROLES);
+  });
+
+  test.afterEach(async () => {
+    await purgeCalendarTokensForRoles(SEED_SCHOOL_UUID, ROLES);
+  });
+
+  test('ICAL-RBAC-PER-USER: two different users get distinct tokens, both URLs serve valid ICS', async ({
+    browser,
+    request,
+  }) => {
+    // Two contexts so each persona has its own JWT — same pattern as
+    // messaging-broadcast.spec.ts:77 / messaging-realtime.spec.ts:91.
+    const ctxA = await browser.newContext();
+    const ctxB = await browser.newContext();
+    try {
+      const pageA = await ctxA.newPage();
+      const pageB = await ctxB.newPage();
+
+      // --- Schueler in context A --------------------------------------
+      await loginAsRole(pageA, 'schueler');
+      await pageA.goto('/settings');
+      await pageA
+        .getByRole('button', { name: 'Kalender-URL erstellen' })
+        .click();
+      await expect(
+        pageA.getByText('Ihre persoenliche Kalender-URL'),
+      ).toBeVisible();
+      const urlElementA = pageA
+        .locator('div.font-mono')
+        .filter({ hasText: /^\/api\/v1\/calendar\/[0-9a-f-]{36}\.ics$/i })
+        .first();
+      await expect(urlElementA).toBeVisible();
+      const urlA = (await urlElementA.textContent())?.trim() ?? '';
+      expect(urlA).toMatch(/^\/api\/v1\/calendar\/[0-9a-f-]{36}\.ics$/i);
+
+      // --- Admin in context B -----------------------------------------
+      await loginAsRole(pageB, 'admin');
+      await pageB.goto('/settings');
+      await pageB
+        .getByRole('button', { name: 'Kalender-URL erstellen' })
+        .click();
+      await expect(
+        pageB.getByText('Ihre persoenliche Kalender-URL'),
+      ).toBeVisible();
+      const urlElementB = pageB
+        .locator('div.font-mono')
+        .filter({ hasText: /^\/api\/v1\/calendar\/[0-9a-f-]{36}\.ics$/i })
+        .first();
+      await expect(urlElementB).toBeVisible();
+      const urlB = (await urlElementB.textContent())?.trim() ?? '';
+      expect(urlB).toMatch(/^\/api\/v1\/calendar\/[0-9a-f-]{36}\.ics$/i);
+
+      // --- The core isolation lock ------------------------------------
+      // The two UUIDs MUST differ. Same string would mean the backend
+      // either keys CalendarToken on (schoolId) alone or returns a
+      // cached row from a different user — both are silent DSGVO leaks
+      // (one user would see the other's calendar feed).
+      expect(
+        urlB,
+        `Two distinct users MUST receive different tokens; got identical URLs (${urlA}) — backend has lost per-user partitioning`,
+      ).not.toBe(urlA);
+
+      // --- Both public endpoints must serve valid ICS ----------------
+      const apiBase = apiBaseFromE2eEnv();
+      const [icsA, icsB] = await Promise.all([
+        request.get(`${apiBase}${urlA}`, { headers: {} }),
+        request.get(`${apiBase}${urlB}`, { headers: {} }),
+      ]);
+      expect(icsA.status(), 'Schueler ICS endpoint must return 200').toBe(200);
+      expect(icsB.status(), 'Admin ICS endpoint must return 200').toBe(200);
+      const bodyA = await icsA.text();
+      const bodyB = await icsB.text();
+      expect(bodyA.startsWith('BEGIN:VCALENDAR')).toBe(true);
+      expect(bodyB.startsWith('BEGIN:VCALENDAR')).toBe(true);
+      expect(bodyA.trim().endsWith('END:VCALENDAR')).toBe(true);
+      expect(bodyB.trim().endsWith('END:VCALENDAR')).toBe(true);
+    } finally {
+      await ctxA.close();
+      await ctxB.close();
+    }
+  });
+});

--- a/apps/web/e2e/settings-ical-revoke.spec.ts
+++ b/apps/web/e2e/settings-ical-revoke.spec.ts
@@ -1,0 +1,179 @@
+/**
+ * Issue #88 — iCal calendar-token revoke flow (Settings).
+ *
+ * Surface: /settings → ICalSettings card → "Token erneuern" button +
+ * confirmation Dialog → DELETE /api/v1/schools/:schoolId/calendar/token.
+ *
+ * The DELETE endpoint is misleadingly named — it actually calls
+ * `revokeAndRegenerate` (calendar.service.ts:54), which HARD-deletes
+ * the prior CalendarToken row (no `revoked_at` soft-delete column
+ * exists in the schema, despite the issue text mentioning one) and
+ * unconditionally creates a fresh one. The public ICS endpoint
+ * looks up by token PK via `findUnique({ where: { token } })`
+ * (calendar.service.ts:47), so a revoked (= deleted) token returns
+ * null and throws NotFoundException → HTTP 404.
+ *
+ * Test-Strategie — end-to-end old-vs-new URL switch:
+ *
+ *   ICAL-REVOKE-ELTERN:
+ *     1. Purge any stale token row (defensive — see generate spec).
+ *     2. Eltern logs in, navigates to /settings, generates a token.
+ *        Capture the URL as `urlOld`.
+ *     3. Verify `urlOld` returns 200 + valid VCALENDAR via the
+ *        public unauthenticated GET.
+ *     4. Click "Token erneuern" → confirmation Dialog opens with
+ *        the destructive copy "Die aktuelle Kalender-URL wird
+ *        ungueltig. Alle verbundenen Kalender-Apps muessen neu
+ *        eingerichtet werden. Fortfahren?" (ICalSettings.tsx:154).
+ *     5. Click the destructive-variant "Token erneuern" button
+ *        inside the Dialog. The page swaps to a fresh URL — capture
+ *        as `urlNew`. Assert `urlNew !== urlOld`.
+ *     6. The DSGVO-critical leg:
+ *        * `urlOld` MUST return 404 — proves the old token was
+ *          hard-deleted, not soft-revoked-but-still-honoured.
+ *        * `urlNew` MUST return 200 with valid VCALENDAR — proves
+ *          the regenerate half of `revokeAndRegenerate` worked.
+ *
+ * Why eltern: the issue lists the spec as an Eltern flow ("eltern-
+ * user sieht nur eigene Tokens, kann nicht andere widerrufen"). The
+ * core revoke behaviour is role-agnostic — same endpoint, same
+ * permissions for all three personas (apps/api/prisma/seed.ts:428
+ * grants create/read/delete calendar-token to eltern). Using
+ * eltern here keeps role coverage symmetric with the generate
+ * spec (lehrer) and the rbac spec (lehrer + eltern).
+ *
+ * Bug-class this catches: a future commit that flips
+ * `revokeAndRegenerate` to a soft-delete via a `revoked_at`
+ * column-add without updating `findByToken` to honour it. That's
+ * exactly the silent DSGVO-leak the issue text warns about: the
+ * user clicks "Token erneuern" expecting the old URL to stop
+ * working, but the public endpoint still serves their personal
+ * timetable + Klausur dates to whoever cached the old URL.
+ *
+ * Race-Family-Achtung: chromium-only-skip + purge in beforeEach/
+ * afterEach for the same singleton-row reason as the generate spec.
+ */
+import { test, expect } from '@playwright/test';
+import { loginAsRole } from './helpers/login';
+import {
+  apiBaseFromE2eEnv,
+  purgeCalendarTokensForRoles,
+} from './helpers/calendar-tokens';
+import { SEED_SCHOOL_UUID } from './fixtures/seed-uuids';
+
+const ROLE = 'eltern' as const;
+
+test.describe('Issue #88 — iCal revoke (desktop)', () => {
+  test.skip(
+    ({ isMobile }) => isMobile,
+    'iCal subscription is a desktop-anchored workflow (URL is copied into a desktop calendar app).',
+  );
+  test.skip(
+    ({ browserName }) => browserName !== 'chromium',
+    'Mutates the singleton CalendarToken row for eltern-user on the seed school — chromium is the sole writer.',
+  );
+
+  test.beforeEach(async () => {
+    await purgeCalendarTokensForRoles(SEED_SCHOOL_UUID, [ROLE]);
+  });
+
+  test.afterEach(async () => {
+    await purgeCalendarTokensForRoles(SEED_SCHOOL_UUID, [ROLE]);
+  });
+
+  test('ICAL-REVOKE-ELTERN: "Token erneuern" hard-deletes the old token (old URL → 404, new URL → 200)', async ({
+    page,
+    request,
+  }) => {
+    await loginAsRole(page, ROLE);
+    await page.goto('/settings');
+
+    // Step 1 — generate the initial token.
+    await page.getByRole('button', { name: 'Kalender-URL erstellen' }).click();
+    await expect(page.getByText('Ihre persoenliche Kalender-URL')).toBeVisible();
+
+    const urlSelector = page
+      .locator('div.font-mono')
+      .filter({ hasText: /^\/api\/v1\/calendar\/[0-9a-f-]{36}\.ics$/i })
+      .first();
+    await expect(urlSelector).toBeVisible();
+    const urlOld = (await urlSelector.textContent())?.trim() ?? '';
+    expect(urlOld).toMatch(/^\/api\/v1\/calendar\/[0-9a-f-]{36}\.ics$/i);
+
+    // Sanity — the original URL is reachable BEFORE revoke.
+    const apiBase = apiBaseFromE2eEnv();
+    const preRevokeResponse = await request.get(`${apiBase}${urlOld}`, {
+      headers: {},
+    });
+    expect(
+      preRevokeResponse.status(),
+      'Sanity: freshly generated token must be reachable on the public endpoint before we revoke it',
+    ).toBe(200);
+
+    // Step 2 — open the revoke confirmation dialog.
+    // Note: there are TWO "Token erneuern" labelled affordances on this
+    // page once the dialog opens — the card button and the destructive
+    // dialog-footer button (both literally `Token erneuern` per
+    // ICalSettings.tsx:144 + 167). Use the card button first.
+    await page.getByRole('button', { name: 'Token erneuern' }).first().click();
+
+    // Dialog content + destructive copy.
+    await expect(page.getByRole('dialog')).toBeVisible();
+    await expect(
+      page.getByText(
+        /Die aktuelle Kalender-URL wird ungueltig\. Alle verbundenen Kalender-Apps muessen neu eingerichtet werden\. Fortfahren\?/,
+      ),
+      'Destructive-copy paragraph must surface (UI-SPEC guard against silent removal of the data-loss warning)',
+    ).toBeVisible();
+
+    // Step 3 — confirm the revoke. The dialog has a destructive variant
+    // "Token erneuern" button + an "Abbrechen" button. Locate the one
+    // inside the dialog scope to avoid hitting the card button again.
+    await page
+      .getByRole('dialog')
+      .getByRole('button', { name: 'Token erneuern' })
+      .click();
+
+    // Step 4 — wait for the URL to swap. The Dialog auto-closes via
+    // useRevokeCalendarToken.onSuccess (ICalSettings.tsx:65).
+    // The mutation invalidates calendarTokenKeys.all(schoolId) and the
+    // useCalendarToken query refetches the NEW token. Poll the visible
+    // URL element until it differs from urlOld — the polled equality
+    // check guards against the race where the old URL is still
+    // visible on the first sample but flips a beat later.
+    await expect.poll(
+      async () => (await urlSelector.textContent())?.trim() ?? '',
+      {
+        message: 'The displayed URL must change after revokeAndRegenerate completes',
+        timeout: 10_000,
+      },
+    ).not.toBe(urlOld);
+
+    const urlNew = (await urlSelector.textContent())?.trim() ?? '';
+    expect(urlNew).toMatch(/^\/api\/v1\/calendar\/[0-9a-f-]{36}\.ics$/i);
+    expect(urlNew, 'New URL must differ from the old URL').not.toBe(urlOld);
+
+    // ── DSGVO-critical lock ─────────────────────────────────────────────
+    // Old URL must now return 404 (token row is gone). If the backend
+    // ever switches to soft-delete WITHOUT updating findByToken to
+    // honour `revoked_at`, this assertion goes red loudly. This is the
+    // EXACT bug class the issue text calls out:
+    //
+    //   "wenn die Generate/Revoke-Logik bricht, kann ein revoked Token
+    //    weiter funktionieren = stiller Datenleak (Stundenplan +
+    //    Klausuren in fremde Hände)"
+    const oldResponse = await request.get(`${apiBase}${urlOld}`, { headers: {} });
+    expect(
+      oldResponse.status(),
+      `Revoked token MUST return 404 — got status ${oldResponse.status()} for the old URL (silent DSGVO leak)`,
+    ).toBe(404);
+
+    // New URL must serve a valid ICS document.
+    const newResponse = await request.get(`${apiBase}${urlNew}`, { headers: {} });
+    expect(newResponse.status()).toBe(200);
+    expect(newResponse.headers()['content-type'] ?? '').toContain('text/calendar');
+    const newBody = await newResponse.text();
+    expect(newBody.startsWith('BEGIN:VCALENDAR')).toBe(true);
+    expect(newBody.trim().endsWith('END:VCALENDAR')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #88. **Bug-fix + E2E coverage in one PR** (per CLAUDE.md hard rule "Bug-Fix Regression-Schutz via E2E"). Auf der `/settings`-Page war der iCal-Subscription-Flow KOMPLETT KAPUTT: jede CalendarController-Route deklarierte ein literales `api/v1/` IM Path, und main.ts:22 setzt ZUSÄTZLICH `setGlobalPrefix('api/v1')`. Die effektiven Routen waren `/api/v1/api/v1/calendar/...`. Frontend hat den single-prefix-Pfad getroffen, 404 bekommen — die Toast-Error war so kurz sichtbar dass keine Spec sie je gefangen hätte, und der angezeigte `calendarUrl` zeigte ebenfalls auf den nicht existierenden Single-Prefix-Pfad. User, der die URL in Apple Kalender pastet → silent failure.

## Backend-Fix

`apps/api/src/modules/calendar/calendar.controller.ts` — alle 4 Routen vom literalen `api/v1/`-Prefix befreit:

```diff
- @Get('api/v1/calendar/:token.ics')
+ @Get('calendar/:token.ics')

- @Post('api/v1/schools/:schoolId/calendar/token')
+ @Post('schools/:schoolId/calendar/token')

- @Get('api/v1/schools/:schoolId/calendar/token')
+ @Get('schools/:schoolId/calendar/token')

- @Delete('api/v1/schools/:schoolId/calendar/token')
+ @Delete('schools/:schoolId/calendar/token')
```

Einer der Controller aus der `project_double_prefix_bug` Audit-Liste. SisController im gleichen Modul hat das gleiche Pattern, ist aber out-of-scope für #88.

## E2E-Regression-Lock

| Datei | Persona | Lockt |
|---|---|---|
| `settings-ical-generate.spec.ts` | lehrer | "Kalender-URL erstellen" → toast + URL → public GET 200 + valid VCALENDAR + PRODID:SchoolFlow (RFC 5545). Hätte das ursprüngliche Double-Prefix-Symptom gefangen. |
| `settings-ical-revoke.spec.ts` | eltern | Generate → "Token erneuern" → Dialog mit destruktiver Copy → **alte URL → 404, neue URL → 200**. Lockt die DSGVO-kritische Hard-Delete-Semantik (`revokeAndRegenerate`). Exakt die Bug-Klasse aus dem Issue ("revoked Token kann weiter funktionieren = stiller Datenleak"). |
| `settings-ical-rbac.spec.ts` | schueler + admin | Zwei BrowserContexts, zwei Personas, ein Token pro Persona → URLs MÜSSEN differen, beide endpoints serven valid VCALENDAR. Lockt per-user partitioning am JWT-subject. |

## Spec-Design-Notes (im Body dokumentiert)

- **Disjoint personas** (lehrer / eltern / schueler+admin) damit parallele Worker auf der singleton-CalendarToken-Row nicht racen. Es gibt KEIN `@@unique([userId, schoolId])` — nur `@@unique([token])`. Concurrent writes succeeden, aber `findFirst` liefert die ÄLTESTE Row — würde "URL must differ" Assertions in Sibling-Specs killen.
- **keycloakUserId via Person.id lookup** statt Hard-Code: die Keycloak-User-UUIDs werden bei Realm-Import GENERIERT und unterscheiden sich von der `docker/keycloak/realm-export.json` (observed: lehrer-user = `230711d2-...`, NICHT `00000000-...000002`). Hard-Coding würde silent no-op gegen re-imported realm.
- **shadcn CardTitle ist `<div>`, nicht `<h*>`** — `getByText('Kalender-Abonnement', { exact: true })`, nicht `getByRole('heading')`.

## Test plan

- [x] All 3 tests pass on `--project=desktop` (7.2s)
- [x] Specs skip cleanly on `--project=desktop-firefox` (race-family precedent — chromium ist der einzige Writer)
- [x] Curl-validiert: POST/GET/DELETE auf `/api/v1/schools/.../calendar/token` returnen 201/200/200 nach Fix (vorher: 404 auf single-prefix, 201 nur auf `/api/v1/api/v1/...`)
- [x] Backend rebuild + API restart vor lokalem Test-Lauf (memory `feedback_restart_api_after_migration.md` — Routen werden bei Boot registriert)
- [ ] CI green vor Merge (D3 Direktive)

Closes #88.

🤖 Generated with [Claude Code](https://claude.com/claude-code)