### PR TITLE
chore(e2e): #112 phase 4 — drop chromium-only-skip from 4 read-only timetable view specs

### DIFF
--- a/apps/web/e2e/timetable-eltern-view.spec.ts
+++ b/apps/web/e2e/timetable-eltern-view.spec.ts
@@ -63,10 +63,11 @@ test.describe('Issue #86 — Timetable Eltern view (desktop)', () => {
     ({ isMobile }) => isMobile,
     'Perspective routing is identical across viewports — desktop only for the first lock.',
   );
-  test.skip(
-    ({ browserName }) => browserName !== 'chromium',
-    'Mutates active TimetableRun on shared seed school — chromium is the sole writer.',
-  );
+  // Phase 4 of #112: chromium-only-skip removed. The active-TimetableRun
+  // race is now closed by the Postgres advisory lock in seedTimetableRun()
+  // (commit 9991e74). Parallel firefox + chromium workers seeding for the
+  // same seed school serialize at the lock; this spec is read-only after
+  // the lock is held, so cross-project parallelism is safe.
 
   let fixture: TimetableRunFixture | undefined;
 

--- a/apps/web/e2e/timetable-lehrer-view.spec.ts
+++ b/apps/web/e2e/timetable-lehrer-view.spec.ts
@@ -71,10 +71,11 @@ test.describe('Issue #86 — Timetable Lehrer view (desktop)', () => {
     ({ isMobile }) => isMobile,
     'Perspective routing is identical across viewports — desktop only for the first lock.',
   );
-  test.skip(
-    ({ browserName }) => browserName !== 'chromium',
-    'Mutates active TimetableRun on shared seed school — chromium is the sole writer.',
-  );
+  // Phase 4 of #112: chromium-only-skip removed. The active-TimetableRun
+  // race is now closed by the Postgres advisory lock in seedTimetableRun()
+  // (commit 9991e74). Parallel firefox + chromium workers seeding for the
+  // same seed school serialize at the lock; this spec is read-only after
+  // the lock is held, so cross-project parallelism is safe.
 
   let fixture: TimetableRunFixture | undefined;
 

--- a/apps/web/e2e/timetable-schueler-view.spec.ts
+++ b/apps/web/e2e/timetable-schueler-view.spec.ts
@@ -60,10 +60,11 @@ test.describe('Issue #86 — Timetable Schüler view (desktop)', () => {
     ({ isMobile }) => isMobile,
     'Perspective routing is identical across viewports — desktop only for the first lock.',
   );
-  test.skip(
-    ({ browserName }) => browserName !== 'chromium',
-    'Mutates active TimetableRun on shared seed school — chromium is the sole writer.',
-  );
+  // Phase 4 of #112: chromium-only-skip removed. The active-TimetableRun
+  // race is now closed by the Postgres advisory lock in seedTimetableRun()
+  // (commit 9991e74). Parallel firefox + chromium workers seeding for the
+  // same seed school serialize at the lock; this spec is read-only after
+  // the lock is held, so cross-project parallelism is safe.
 
   let fixture: TimetableRunFixture | undefined;
 

--- a/apps/web/e2e/timetable-week-navigation.spec.ts
+++ b/apps/web/e2e/timetable-week-navigation.spec.ts
@@ -84,10 +84,11 @@ test.describe('Issue #86 — Timetable week navigation (desktop)', () => {
     ({ isMobile }) => isMobile,
     'Mobile forces day view (TimetablePage:118 — effectiveViewMode = isMobile ? "day" : viewMode), so the Tag/Woche toggle is hidden on base/sm. Mobile coverage of the day-selector tabs belongs to its own spec.',
   );
-  test.skip(
-    ({ browserName }) => browserName !== 'chromium',
-    'Mutates active TimetableRun on shared seed school — chromium is the sole writer.',
-  );
+  // Phase 4 of #112: chromium-only-skip removed. The active-TimetableRun
+  // race is now closed by the Postgres advisory lock in seedTimetableRun()
+  // (commit 9991e74). Parallel firefox + chromium workers seeding for the
+  // same seed school serialize at the lock; this spec is read-only after
+  // the lock is held, so cross-project parallelism is safe.
 
   let fixture: TimetableRunFixture | undefined;
 


### PR DESCRIPTION
## Summary

Phase 4 von **#112 (E2E-Tests deterministisch machen)**. Erste Welle der chromium-only-skip Removal, jetzt wo Phase 2 (PR #115, commit 9991e74) den per-schoolId Postgres advisory lock installiert hat.

## Logik

Phase 2's advisory lock serialisiert ALLE parallelen seedTimetableRun-Caller — **unabhängig vom Browser-Project**. Das schließt die active-TimetableRun-Race zwischen chromium und firefox (oder anderen Projects) deterministisch. Der chromium-only-skip war eine Defense-in-Depth gegen diese Race — jetzt überflüssig für Specs deren EINZIGE Race-Surface die active-Run-Flag war.

## Migrierte Specs

| Spec | Race-Surface | Skip entfernt? |
|---|---|---|
| `timetable-lehrer-view.spec.ts` | active-TimetableRun (Phase-2-Lock) | ✅ |
| `timetable-schueler-view.spec.ts` | active-TimetableRun | ✅ |
| `timetable-eltern-view.spec.ts` | active-TimetableRun | ✅ |
| `timetable-week-navigation.spec.ts` | active-TimetableRun | ✅ |

Alle 4 sind PURE READ-ONLY (navigieren `/timetable`, asserten URL params + gerenderte Cells; keine zusätzlichen DB mutations beyond der Fixture).

## NICHT migriert in dieser PR

Specs mit zusätzlichen Race-Surfaces über die active-Run-Flag hinaus — bleiben temporär chromium-only:
- `classbook-*` (mutieren ClassBookEntry, AttendanceRecord, etc.)
- `timetable-cell-badges` (mutiert Homework + Exam rows)
- `timetable-generation-flow` (long-running solver mutation)
- `admin-timetable-edit-dnd`, `admin-timetable-history` (mutieren TimetableLessonEdit / lesson moves)
- `settings-ical-*` (CalendarToken singleton — braucht Phase 2.5 lock)
- `time-grid.spec.ts` (TimeGrid PUT-replace-all — braucht eigenen advisory lock)
- `messaging-*`, `excuses-*`, etc.

## Verifikation

- 16 Tests pass auf `desktop` + `desktop-firefox` parallel (37.5s)
- Mobile-only-skip via `({isMobile}) => isMobile` BLEIBT — das ist Browser-Surface-Isolation, keine Race-Defense

## Test plan

- [x] 16 tests pass auf desktop + desktop-firefox parallel
- [x] Advisory lock serialisiert seed sections korrekt (sichtbar an den ~2s firefox-Tests die nach den chromium-Tests starten)
- [ ] CI green vor Merge (D3)

Refs #112.

🤖 Generated with [Claude Code](https://claude.com/claude-code)