### PR TITLE
chore(e2e): #112 phase 2.5a — CalendarToken advisory lock + generic helper

### DIFF
--- a/apps/web/e2e/fixtures/timetable-run.ts
+++ b/apps/web/e2e/fixtures/timetable-run.ts
@@ -34,6 +34,7 @@ import { createRequire } from 'node:module';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { acquireAdvisoryLock, type AdvisoryLock } from '../helpers/advisory-lock';
 import {
   SEED_TEACHER_2_UUID,
   SEED_TEACHER_KC_LEHRER_UUID,
@@ -54,7 +55,6 @@ const require = createRequire(import.meta.url);
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { PrismaClient } = require('../../../api/dist/config/database/generated/client.js') as {
   PrismaClient: new (opts?: { adapter?: unknown }) => {
-    $executeRawUnsafe: (sql: string) => Promise<number>;
     classSubject: {
       findFirst: (args: {
         where: Record<string, unknown>;
@@ -190,50 +190,28 @@ export interface TimetableRunFixture {
    */
   subjectAbbreviation: string;
   /**
-   * INTERNAL — Issue #112 Phase 2. The Prisma client that holds the
-   * Postgres advisory lock acquired in `seedTimetableRun()`. The lock
-   * is session-scoped (held until `$disconnect()`), so we KEEP THIS
-   * CONNECTION OPEN across the entire test lifecycle (beforeEach +
-   * test body + afterEach) and let `cleanupTimetableRun()` close it.
+   * INTERNAL — Issue #112 Phase 2 (refactored in #117). The advisory-lock
+   * handle covering the active-TimetableRun-singleton race for this school.
+   * Held across the ENTIRE test lifecycle (beforeEach + test body +
+   * afterEach) so a parallel spec on the same schoolId blocks until
+   * `cleanupTimetableRun()` calls `_lock.release()`.
    *
-   * Why a held connection: `pg_advisory_lock(N)` is session-scoped,
-   * not transaction-scoped (we can't use the cheaper xact_lock variant
-   * because the fixture seeds + the test body + the cleanup span
-   * MULTIPLE separate Prisma calls, each of which would commit and
-   * release a xact_lock). The only way to keep the lock alive across
-   * those calls is to keep the underlying connection alive.
-   *
-   * Connection-cost analysis: Playwright runs ~4 workers; each holds
-   * 1 fixture-bound connection while its test is in flight; plus the
-   * regular API connection pool. Postgres default max_connections=100
-   * → plenty of headroom.
-   *
-   * Crash-safety: if a test process is killed mid-test without calling
-   * cleanup, Postgres releases the lock when TCP keepalive eventually
-   * detects the dead connection (~minutes). Acceptable for E2E.
+   * Implementation moved into `helpers/advisory-lock.ts` so the
+   * mechanic can be reused by CalendarToken / TimeGrid / Classbook
+   * waves without duplicating the connection-lifecycle code.
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  _lockClient: any;
-  /** The bigint lock key — released by cleanup via `pg_advisory_unlock`. */
-  _lockKey: string;
+  _lock: AdvisoryLock;
 }
 
 /**
- * Deterministic schoolId → bigint lock key. We only need uniqueness
- * within the E2E `pg_advisory_lock` namespace, not crypto strength.
- *
- * 32-bit FNV-1a over the schoolId string, returned as a decimal string
- * (BigInt-safe for the $queryRawUnsafe path).
+ * Resource-key namespace for the per-school active-TimetableRun lock.
+ * Kept colocated with `seedTimetableRun` so future callers / readers
+ * can see the exact key shape this fixture uses. Different namespaces
+ * MUST NOT collide; we prefix every resource type explicitly
+ * (`active-timetable-run:`, `calendar-token:…`, …).
  */
-function schoolLockKey(schoolId: string): string {
-  let h = 2166136261; // FNV offset basis (32-bit)
-  for (let i = 0; i < schoolId.length; i++) {
-    h ^= schoolId.charCodeAt(i);
-    // FNV prime, kept in 32-bit by Math.imul.
-    h = Math.imul(h, 16777619);
-  }
-  // Coerce to non-negative 32-bit unsigned for Postgres.
-  return (h >>> 0).toString();
+function timetableRunLockKey(schoolId: string): string {
+  return `active-timetable-run:${schoolId}`;
 }
 
 /**
@@ -261,12 +239,9 @@ export async function seedTimetableRun(
   options: SeedTimetableRunOptions = {},
 ): Promise<TimetableRunFixture> {
   const { active = true } = options;
-  const prisma = new PrismaClient({
-    adapter: new PrismaPg({ connectionString: process.env.DATABASE_URL ?? '' }),
-  });
 
-  // ── Issue #112 Phase 2 — acquire per-school advisory lock ──────────
-  // Held until `cleanupTimetableRun()` calls $disconnect — covers the
+  // ── Issue #112 Phase 2 (refactored #117) — acquire per-school lock ─
+  // Held until `cleanupTimetableRun()` calls release() — covers the
   // ENTIRE test lifecycle (seed → test body → cleanup), so a parallel
   // spec on the same schoolId blocks here until we release.
   //
@@ -277,15 +252,11 @@ export async function seedTimetableRun(
   // returns the LATEST, which is whichever beforeEach committed last
   // — so Spec A could see Spec B's lessons mid-test. Serializing the
   // seed-through-cleanup window eliminates the overlap entirely.
-  //
-  // Using $queryRawUnsafe + numeric key interpolated as string: Prisma
-  // 7 driver-adapter $queryRaw template tag has historically been
-  // finicky with bigints across the pg-adapter boundary; the Unsafe
-  // variant + decimal-string lock key is simpler and just as safe
-  // because the key is derived from a controlled string via FNV-1a,
-  // not from user input.
-  const lockKey = schoolLockKey(schoolId);
-  await prisma.$executeRawUnsafe(`SELECT pg_advisory_lock(${lockKey})`);
+  const lock = await acquireAdvisoryLock(timetableRunLockKey(schoolId));
+  // Reuse the lock's held Prisma session for fixture queries so the
+  // lock survives ALL of them. A fresh client would not see the lock
+  // and a parallel spec could squeeze a write in between our queries.
+  const prisma = lock._client as InstanceType<typeof PrismaClient>;
 
   try {
     // 1. ClassSubject for seed-class-1a — deterministic FIRST entry by
@@ -434,24 +405,17 @@ export async function seedTimetableRun(
       fixtureRoomId,
       reactivatedDays,
       subjectAbbreviation: classSubject.subject.shortName,
-      _lockClient: prisma,
-      _lockKey: lockKey,
+      _lock: lock,
     };
   } catch (err) {
-    // If seeding fails, release the lock + disconnect immediately so
-    // we don't leak a connection AND don't block parallel specs.
-    try {
-      await prisma.$executeRawUnsafe(`SELECT pg_advisory_unlock(${lockKey})`);
-    } catch {
-      /* best-effort */
-    }
-    await prisma.$disconnect();
+    // If seeding fails, release the lock immediately so we don't leak
+    // a connection AND don't block parallel specs.
+    await lock.release();
     throw err;
   }
-  // NOTE: no `finally { $disconnect }` here — the lock must survive
+  // NOTE: no `finally { lock.release() }` here — the lock must survive
   // the seed call so that `cleanupTimetableRun()` releases it AFTER
-  // the test body has run. See `_lockClient` JSDoc on the fixture
-  // interface for the rationale.
+  // the test body has run. See `_lock` JSDoc on the fixture interface.
 }
 
 /**
@@ -463,22 +427,10 @@ export async function seedTimetableRun(
  * ergonomics of orphan-year.ts.
  */
 export async function cleanupTimetableRun(fixture: TimetableRunFixture): Promise<void> {
-  // Reuse the held Prisma client so we both (a) keep the advisory lock
-  // alive through the cleanup queries and (b) release it on the SAME
-  // session that holds it. A fresh client wouldn't see the lock and
-  // pg_advisory_unlock(N) would no-op + warn.
-  const prisma = fixture._lockClient as {
-    $executeRawUnsafe: (sql: string) => Promise<number>;
-    timetableRun: { deleteMany: (args: { where: { id: string } }) => Promise<unknown> };
-    room: { deleteMany: (args: { where: { id: string } }) => Promise<unknown> };
-    schoolDay: {
-      updateMany: (args: {
-        where: Record<string, unknown>;
-        data: Record<string, unknown>;
-      }) => Promise<unknown>;
-    };
-    $disconnect: () => Promise<void>;
-  };
+  // Reuse the held Prisma client so the advisory lock stays alive
+  // through cleanup queries — a fresh client wouldn't see the lock
+  // and pg_advisory_unlock(N) would no-op + warn on release.
+  const prisma = fixture._lock._client as InstanceType<typeof PrismaClient>;
   try {
     // Delete the run first so the cascade removes TimetableLesson rows and
     // releases the FK on Room.
@@ -507,23 +459,12 @@ export async function cleanupTimetableRun(fixture: TimetableRunFixture): Promise
       err,
     );
   } finally {
-    // ── Issue #112 Phase 2 — release the advisory lock + disconnect ──
-    // The pg_advisory_unlock call must run on the SAME connection that
-    // acquired the lock (Postgres session-scoping). Best-effort: an
-    // already-released or disconnected session no-ops with a server
-    // warning, which is harmless.
-    try {
-      await prisma.$executeRawUnsafe(
-        `SELECT pg_advisory_unlock(${fixture._lockKey})`,
-      );
-    } catch (lockErr) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        `[timetable-run fixture] pg_advisory_unlock failed for key=${fixture._lockKey}:`,
-        lockErr,
-      );
-    }
-    await prisma.$disconnect();
+    // ── Issue #112 Phase 2 (refactored #117) — release the lock ──
+    // The pg_advisory_unlock + $disconnect run on the SAME session
+    // that acquired the lock — encapsulated in `release()`. Idempotent
+    // and best-effort: errors are logged inside the helper but never
+    // thrown, so cleanup always completes.
+    await fixture._lock.release();
   }
 }
 

--- a/apps/web/e2e/helpers/advisory-lock.ts
+++ b/apps/web/e2e/helpers/advisory-lock.ts
@@ -1,0 +1,218 @@
+/**
+ * Generic Postgres advisory-lock helper for Playwright E2E specs.
+ *
+ * Pattern established by Issue #112 Phase 2 (commit 9991e74) for
+ * `seedTimetableRun` and extracted in Phase 2.5a (Issue #117) so the
+ * CalendarToken + TimeGrid + Classbook + Messaging waves can reuse it
+ * without copy-pasting the connection-lifecycle machinery.
+ *
+ * What it solves
+ * --------------
+ * Several E2E specs mutate per-school singleton/shared resources where
+ * Prisma alone cannot serialize parallel callers: the @@unique
+ * constraint covers schema-level invariants but says nothing about
+ * "only one spec at a time may purge-then-recreate this row". With
+ * Playwright running 2+ workers (and cross-project chromium ↔ firefox
+ * on top), two `beforeEach` blocks routinely overlap on the same
+ * resource and race.
+ *
+ * `pg_advisory_lock(N)` is a process-wide mutex keyed by a bigint. We
+ * key it deterministically off the resource identity (e.g. schoolId,
+ * userId, classId, …) via a 32-bit FNV-1a hash + namespace prefix,
+ * acquire it on a held Prisma connection, run the danger-zone work,
+ * and release it on the SAME connection at the end of the test.
+ *
+ * Why a held connection
+ * ---------------------
+ * The lock is session-scoped, not transaction-scoped — we deliberately
+ * use `pg_advisory_lock` (not `pg_advisory_xact_lock`) because the
+ * fixture seed + the test body + the cleanup span MULTIPLE separate
+ * Prisma calls, each of which would commit and release a xact_lock.
+ * The only way to keep the lock alive across those calls is to keep
+ * the underlying connection alive. We expose it on the returned
+ * AdvisoryLock handle so cleanup can close it; callers that need to
+ * run their own Prisma queries on the SAME session can reach for
+ * `lock._client` (deliberately marked private-by-convention).
+ *
+ * Why FNV-1a + 32-bit namespace
+ * -----------------------------
+ * Postgres advisory locks take a bigint. We pick a 32-bit hash on
+ * purpose: lock keys are reserved per-test-suite and any spec that
+ * collides with another resource's hash would block both. FNV-1a is
+ * trivially deterministic, fast, and the collision rate at 32 bits is
+ * acceptable for the small (~dozens) lock-key population in this
+ * codebase. The namespace prefix is concatenated INTO the string
+ * before hashing, so `time-grid:${schoolId}` and `calendar-token:lehrer:${schoolId}`
+ * have orthogonal probability spaces.
+ *
+ * Multi-key acquisition order
+ * ---------------------------
+ * `acquireAdvisoryLock(['a', 'b'])` sorts the keys before acquisition
+ * so two callers that overlap on a subset cannot deadlock — the
+ * classic ABBA pattern is impossible when every caller agrees on
+ * sort order. Sort is on the RESOURCE STRINGS (pre-hash), so behaviour
+ * is independent of hash collisions or platform locale (`localeCompare`
+ * is NOT used — we sort by code-unit order so identical inputs always
+ * sort identically regardless of system locale).
+ *
+ * Connection-cost analysis
+ * ------------------------
+ * Playwright runs ~4 workers; each holds 1 fixture-bound connection
+ * while its test is in flight; plus the regular API connection pool.
+ * Postgres default max_connections=100 → plenty of headroom even when
+ * multiple specs hold multiple locks each.
+ *
+ * Crash-safety
+ * ------------
+ * If a test process is killed mid-test without calling `release()`,
+ * Postgres releases the lock when TCP keepalive eventually detects the
+ * dead connection (~minutes). Acceptable for E2E.
+ */
+import 'dotenv/config';
+import { config as dotenvConfig } from 'dotenv';
+import { createRequire } from 'node:module';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+dotenvConfig({ path: path.resolve(__dirname, '../../../../.env') });
+
+const require = createRequire(import.meta.url);
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { PrismaClient } = require('../../../api/dist/config/database/generated/client.js') as {
+  PrismaClient: new (opts?: { adapter?: unknown }) => {
+    $executeRawUnsafe: (sql: string) => Promise<number>;
+    $disconnect: () => Promise<void>;
+  };
+};
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { PrismaPg } = require('../../../api/node_modules/@prisma/adapter-pg') as {
+  PrismaPg: new (opts: { connectionString: string }) => unknown;
+};
+
+/**
+ * Handle returned by `acquireAdvisoryLock`. Always call `release()`
+ * in a `finally` block — Postgres only frees the lock when the
+ * underlying TCP connection disconnects, so leaking handles would
+ * pin Postgres connections for the lifetime of the process.
+ */
+export interface AdvisoryLock {
+  /**
+   * Release every lock this handle holds (in REVERSE acquisition
+   * order, so the last-acquired is unlocked first — defensive
+   * mirroring of mutex lock-order even though Postgres advisory
+   * locks themselves have no required release order).
+   *
+   * Then disconnects the Prisma client. Idempotent — repeated calls
+   * are no-ops with a warning. Best-effort: errors are logged but
+   * not thrown so cleanup can finish.
+   */
+  release(): Promise<void>;
+  /**
+   * INTERNAL — the Prisma client that holds the lock(s). Exposed so
+   * specialised helpers (`seedTimetableRun`, `seedCalendarTokenContext`,
+   * …) can run their own queries on the same session and keep the lock
+   * alive throughout. Treat as readonly; never call `$disconnect()`
+   * yourself — `release()` owns the connection lifecycle.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  readonly _client: any;
+  /** Resource-key strings, sorted, for debug + logging. */
+  readonly resourceKeys: ReadonlyArray<string>;
+}
+
+/**
+ * 32-bit FNV-1a returned as a non-negative decimal string suitable
+ * for interpolation into `pg_advisory_lock(<digits>)` calls.
+ *
+ * We use decimal-string + $executeRawUnsafe instead of the templated
+ * $executeRaw bigint path because Prisma 7 driver-adapter has been
+ * finicky with bigints across the pg-adapter boundary; the Unsafe
+ * variant + decimal-string is simpler and just as safe because the
+ * key is derived from a controlled string via FNV-1a, not from user
+ * input.
+ */
+function fnv1a32(input: string): string {
+  let h = 2166136261; // FNV offset basis (32-bit)
+  for (let i = 0; i < input.length; i++) {
+    h ^= input.charCodeAt(i);
+    h = Math.imul(h, 16777619); // FNV prime, kept in 32-bit
+  }
+  return (h >>> 0).toString();
+}
+
+/**
+ * Acquire one or more session-scoped Postgres advisory locks on a
+ * single held Prisma connection. Returns an `AdvisoryLock` handle
+ * whose `release()` MUST be called in a `finally` block.
+ *
+ * For multi-key acquisition, the keys are sorted by code-unit order
+ * BEFORE hashing + locking so two callers that overlap on a subset
+ * cannot deadlock (every caller agrees on order). Duplicate keys
+ * in the input array are deduplicated.
+ *
+ * Best-effort cleanup: if acquisition fails mid-way (e.g. lock #3 of
+ * 5 throws), the locks already acquired on this session are released
+ * via `release()` semantics before the error propagates, so partial
+ * state cannot leak.
+ */
+export async function acquireAdvisoryLock(
+  resourceKeys: string | ReadonlyArray<string>,
+): Promise<AdvisoryLock> {
+  const inputs = typeof resourceKeys === 'string' ? [resourceKeys] : Array.from(resourceKeys);
+  if (inputs.length === 0) {
+    throw new Error('acquireAdvisoryLock requires at least one resource key');
+  }
+  const sortedKeys = [...new Set(inputs)].sort();
+
+  const prisma = new PrismaClient({
+    adapter: new PrismaPg({ connectionString: process.env.DATABASE_URL ?? '' }),
+  });
+
+  const acquiredHashes: string[] = [];
+  try {
+    for (const key of sortedKeys) {
+      const hashed = fnv1a32(key);
+      await prisma.$executeRawUnsafe(`SELECT pg_advisory_lock(${hashed})`);
+      acquiredHashes.push(hashed);
+    }
+  } catch (err) {
+    // Release whatever we managed to acquire on this session, then
+    // disconnect — same shape as release() to keep the lifecycle
+    // symmetric.
+    for (const hashed of [...acquiredHashes].reverse()) {
+      try {
+        await prisma.$executeRawUnsafe(`SELECT pg_advisory_unlock(${hashed})`);
+      } catch {
+        /* best-effort */
+      }
+    }
+    await prisma.$disconnect();
+    throw err;
+  }
+
+  let released = false;
+  return {
+    _client: prisma,
+    resourceKeys: sortedKeys,
+    release: async (): Promise<void> => {
+      if (released) return;
+      released = true;
+      for (const hashed of [...acquiredHashes].reverse()) {
+        try {
+          await prisma.$executeRawUnsafe(`SELECT pg_advisory_unlock(${hashed})`);
+        } catch (err) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `[advisory-lock] pg_advisory_unlock(${hashed}) failed:`,
+            err,
+          );
+        }
+      }
+      await prisma.$disconnect();
+    },
+  };
+}

--- a/apps/web/e2e/helpers/calendar-tokens.ts
+++ b/apps/web/e2e/helpers/calendar-tokens.ts
@@ -47,6 +47,7 @@ import {
   SEED_PERSON_KC_SCHUELER_UUID,
   SEED_PERSON_KC_SCHULLEITUNG_UUID,
 } from '../fixtures/seed-uuids';
+import { acquireAdvisoryLock, type AdvisoryLock } from './advisory-lock';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -112,49 +113,124 @@ export function apiBaseFromE2eEnv(): string {
   return apiUrl.replace(/\/api\/v1\/?$/, '');
 }
 
+
+// ---------------------------------------------------------------------------
+// Lock-bound CalendarToken context (Issue #112 Phase 2.5a / #117)
+// ---------------------------------------------------------------------------
+
 /**
- * Resolve Keycloak user UUIDs from the Person table for the given
- * roles. Returns only the userIds that have a non-null
- * keycloakUserId — defensive against a seed run that skipped
- * Keycloak linking (e.g. when Keycloak was unreachable and seed
- * fell back to default UUIDs).
+ * Handle returned by `seedCalendarTokenContext` — carries the held
+ * advisory lock so cleanup can release it and the seed-school + roles
+ * so afterEach can re-purge on the SAME locked session.
  */
-async function resolveKeycloakUserIds(
+export interface CalendarTokenContext {
+  schoolId: string;
+  roles: ReadonlyArray<CalendarTestRole>;
+  /** Held advisory lock(s) — released in `cleanupCalendarTokenContext`. */
+  _lock: AdvisoryLock;
+}
+
+/**
+ * Resource-key namespace for CalendarToken locks. Distinct namespace
+ * prefix per resource type so a 32-bit FNV-1a hash collision with the
+ * `active-timetable-run:` keys (or any future namespace) is impossible
+ * by construction — they live in orthogonal namespaces by string
+ * prefix, hash collision only matters within the same namespace.
+ *
+ * One lock per (schoolId, role) — that's the row-identity the
+ * @@unique-less CalendarToken table effectively keys by (the service
+ * does `findFirst({ schoolId, userId })` and unconditionally INSERTs
+ * a new row when missing). Specs sharing a role serialize; specs on
+ * disjoint roles run in parallel without blocking each other.
+ */
+function calendarTokenLockKeys(
+  schoolId: string,
   roles: ReadonlyArray<CalendarTestRole>,
-): Promise<string[]> {
-  const personIds = roles.map((r) => PERSON_UUID_BY_ROLE[r]);
-  const prisma = new PrismaClient({
-    adapter: new PrismaPg({ connectionString: process.env.DATABASE_URL ?? '' }),
-  });
+): string[] {
+  return roles.map((r) => `calendar-token:${schoolId}:${r}`);
+}
+
+/**
+ * Acquire the per-(schoolId, role) advisory lock(s) for the given
+ * personas + purge any leftover CalendarToken rows on the locked
+ * session. The returned context MUST be passed to
+ * `cleanupCalendarTokenContext` in `afterEach` so the lock is
+ * released — leaking it would block parallel specs forever.
+ *
+ * Why purge here AND in afterEach: parallel specs that share a role
+ * (e.g. generate-lehrer and rbac-lehrer-eltern) serialize on the
+ * `calendar-token:<schoolId>:lehrer` lock, but each STILL needs to
+ * see a clean empty state at the start of its test body — the
+ * previous holder may have left rows in the table (the test body
+ * itself creates rows; only afterEach + this function clean them up).
+ * Purge inside the locked window so no parallel writer can squeeze
+ * a row in between.
+ */
+export async function seedCalendarTokenContext(
+  schoolId: string,
+  roles: CalendarTestRole | ReadonlyArray<CalendarTestRole>,
+): Promise<CalendarTokenContext> {
+  const roleList = Array.isArray(roles)
+    ? (roles as ReadonlyArray<CalendarTestRole>)
+    : [roles as CalendarTestRole];
+
+  const lock = await acquireAdvisoryLock(calendarTokenLockKeys(schoolId, roleList));
   try {
-    const rows = await prisma.person.findMany({
-      where: { id: { in: personIds } },
-      select: { id: true, keycloakUserId: true },
-    });
-    return rows
-      .map((p) => p.keycloakUserId)
-      .filter((id): id is string => id != null && id.length > 0);
-  } finally {
-    await prisma.$disconnect();
+    await purgeCalendarTokensOnSession(lock, schoolId, roleList);
+    return { schoolId, roles: roleList, _lock: lock };
+  } catch (err) {
+    // Acquisition succeeded but purge failed — release the lock so
+    // parallel specs aren't blocked and re-throw.
+    await lock.release();
+    throw err;
   }
 }
 
 /**
- * Hard-delete every CalendarToken row for the given roles on the
- * seed school. Used in beforeEach and afterEach so each spec starts
- * with a deterministic empty-state and leaves no residue.
- *
- * Implementation note: the helper resolves keycloakUserId via the
- * Person table at call time rather than hard-coding UUIDs, because
- * Keycloak generates fresh user UUIDs per realm-import and the
- * realm-export.json IDs do NOT survive a re-import. Hard-coding
- * would silently no-op against a re-imported realm.
+ * Re-purge CalendarToken rows on the still-locked session, then
+ * release the lock. Idempotent: callers can invoke this safely from
+ * an `afterEach` even when the test failed early — the purge is
+ * scoped to the seed school + specific roles, so it cannot interfere
+ * with other specs (which hold their own locks on their own
+ * roles).
  */
-export async function purgeCalendarTokensForRoles(
+export async function cleanupCalendarTokenContext(
+  ctx: CalendarTokenContext,
+): Promise<void> {
+  try {
+    await purgeCalendarTokensOnSession(ctx._lock, ctx.schoolId, ctx.roles);
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[calendar-tokens helper] cleanupCalendarTokenContext purge failed for roles=${ctx.roles.join(',')}:`,
+      err,
+    );
+  } finally {
+    await ctx._lock.release();
+  }
+}
+
+/**
+ * INTERNAL — purge CalendarToken rows on the Prisma session that
+ * holds the advisory lock. We resolve keycloakUserId on the SAME
+ * session so the (already-running) Person.findMany participates in
+ * the lock's session and we don't open + close a second connection
+ * per call.
+ */
+async function purgeCalendarTokensOnSession(
+  lock: AdvisoryLock,
   schoolId: string,
   roles: ReadonlyArray<CalendarTestRole>,
 ): Promise<void> {
-  const userIds = await resolveKeycloakUserIds(roles);
+  const personIds = roles.map((r) => PERSON_UUID_BY_ROLE[r]);
+  const prisma = lock._client as InstanceType<typeof PrismaClient>;
+  const rows = await prisma.person.findMany({
+    where: { id: { in: personIds } },
+    select: { id: true, keycloakUserId: true },
+  });
+  const userIds = rows
+    .map((p) => p.keycloakUserId)
+    .filter((id): id is string => id != null && id.length > 0);
   if (userIds.length === 0) {
     // eslint-disable-next-line no-console
     console.warn(
@@ -162,20 +238,7 @@ export async function purgeCalendarTokensForRoles(
     );
     return;
   }
-  const prisma = new PrismaClient({
-    adapter: new PrismaPg({ connectionString: process.env.DATABASE_URL ?? '' }),
+  await prisma.calendarToken.deleteMany({
+    where: { schoolId, userId: { in: userIds } },
   });
-  try {
-    await prisma.calendarToken.deleteMany({
-      where: { schoolId, userId: { in: userIds } },
-    });
-  } catch (err) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      `[calendar-tokens helper] purgeCalendarTokensForRoles failed for roles=${roles.join(',')}:`,
-      err,
-    );
-  } finally {
-    await prisma.$disconnect();
-  }
 }

--- a/apps/web/e2e/settings-ical-generate.spec.ts
+++ b/apps/web/e2e/settings-ical-generate.spec.ts
@@ -39,18 +39,18 @@
  * "my calendar app silently stops syncing" — no toast, no error,
  * no log line on the user's side.
  *
- * Race-Family-Achtung: chromium-only-skip + purgeCalendarTokensFor
- * in both beforeEach and afterEach. CalendarToken is per-(userId,
- * schoolId) — multiple workers running this spec for the same
- * lehrer would race the @@unique constraint on the `token` column
- * and the unconditional INSERT (calendar.service.ts:32 has no
- * upsert), so chromium is the sole writer.
+ * Race-Family-Achtung: Issue #112 Phase 2.5a (#117) — a per-(schoolId,
+ * role) Postgres advisory lock serializes the purge → seed → test
+ * body → cleanup window across parallel specs that share the lehrer
+ * persona. Cross-browser safe; previous chromium-only-skip removed.
  */
 import { test, expect } from '@playwright/test';
 import { loginAsRole } from './helpers/login';
 import {
   apiBaseFromE2eEnv,
-  purgeCalendarTokensForRoles,
+  seedCalendarTokenContext,
+  cleanupCalendarTokenContext,
+  type CalendarTokenContext,
 } from './helpers/calendar-tokens';
 import { SEED_SCHOOL_UUID } from './fixtures/seed-uuids';
 
@@ -61,17 +61,18 @@ test.describe('Issue #88 — iCal generate (desktop)', () => {
     ({ isMobile }) => isMobile,
     'iCal subscription is a desktop-anchored workflow (URL is copied into a desktop calendar app). Mobile coverage belongs to its own *.mobile.spec.ts that asserts the "URL kopieren" button surfaces below the URL field on base/sm.',
   );
-  test.skip(
-    ({ browserName }) => browserName !== 'chromium',
-    'Mutates the singleton CalendarToken row for lehrer-user on the seed school — chromium is the sole writer (race-family precedent).',
-  );
+
+  let ctx: CalendarTokenContext | undefined;
 
   test.beforeEach(async () => {
-    await purgeCalendarTokensForRoles(SEED_SCHOOL_UUID, [ROLE]);
+    ctx = await seedCalendarTokenContext(SEED_SCHOOL_UUID, [ROLE]);
   });
 
   test.afterEach(async () => {
-    await purgeCalendarTokensForRoles(SEED_SCHOOL_UUID, [ROLE]);
+    if (ctx) {
+      await cleanupCalendarTokenContext(ctx);
+      ctx = undefined;
+    }
   });
 
   test('ICAL-GEN-LEHRER: "Kalender-URL erstellen" → toast + URL renders → public GET returns valid VCALENDAR', async ({

--- a/apps/web/e2e/settings-ical-rbac.spec.ts
+++ b/apps/web/e2e/settings-ical-rbac.spec.ts
@@ -33,48 +33,45 @@
  * findFirst that mis-orders the where clause and grabs an
  * arbitrary token.
  *
- * Race-Family-Achtung: chromium-only-skip + purge BOTH personas in
- * beforeEach/afterEach (the purge helper takes an array of roles).
+ * Race-Family-Achtung: Issue #112 Phase 2.5a (#117) — per-(schoolId,
+ * role) Postgres advisory lock acquired on BOTH personas in sorted
+ * order (eltern → lehrer). The sibling generate.spec (lehrer) and
+ * revoke.spec (eltern) acquire their single lock and block on this
+ * spec's set; the sorted acquisition order makes ABBA deadlock
+ * impossible. Cross-browser safe; previous chromium-only-skip and
+ * disjoint-personas workaround (schueler+admin) removed — this spec
+ * is back on the originally-intended lehrer+eltern personas now that
+ * the advisory lock eliminates the race.
  */
 import { test, expect } from '@playwright/test';
 import { loginAsRole } from './helpers/login';
 import {
   apiBaseFromE2eEnv,
-  purgeCalendarTokensForRoles,
+  seedCalendarTokenContext,
+  cleanupCalendarTokenContext,
+  type CalendarTokenContext,
 } from './helpers/calendar-tokens';
 import { SEED_SCHOOL_UUID } from './fixtures/seed-uuids';
 
-/**
- * Use personas that are NOT shared with the sibling generate.spec
- * (lehrer) or revoke.spec (eltern). Without this isolation, parallel
- * workers running across the three files race on the same persona's
- * CalendarToken row — observed 2026-05-18 as the empty-state
- * assertion in generate.spec going red because rbac.spec had just
- * created a lehrer token in its own beforeEach window.
- *
- * `schueler` and `admin` are otherwise-untouched by #88 specs.
- * Both have calendar-token CRUD permissions per
- * apps/api/prisma/seed.ts (lines 460-462 schueler, line 217 admin
- * "manage all").
- */
-const ROLES = ['schueler', 'admin'] as const;
+const ROLES = ['lehrer', 'eltern'] as const;
 
 test.describe('Issue #88 — iCal RBAC / per-user isolation (desktop)', () => {
   test.skip(
     ({ isMobile }) => isMobile,
     'iCal subscription is a desktop-anchored workflow.',
   );
-  test.skip(
-    ({ browserName }) => browserName !== 'chromium',
-    'Mutates singleton CalendarToken rows for two personas on the seed school — chromium is the sole writer.',
-  );
+
+  let ctx: CalendarTokenContext | undefined;
 
   test.beforeEach(async () => {
-    await purgeCalendarTokensForRoles(SEED_SCHOOL_UUID, ROLES);
+    ctx = await seedCalendarTokenContext(SEED_SCHOOL_UUID, ROLES);
   });
 
   test.afterEach(async () => {
-    await purgeCalendarTokensForRoles(SEED_SCHOOL_UUID, ROLES);
+    if (ctx) {
+      await cleanupCalendarTokenContext(ctx);
+      ctx = undefined;
+    }
   });
 
   test('ICAL-RBAC-PER-USER: two different users get distinct tokens, both URLs serve valid ICS', async ({
@@ -89,8 +86,8 @@ test.describe('Issue #88 — iCal RBAC / per-user isolation (desktop)', () => {
       const pageA = await ctxA.newPage();
       const pageB = await ctxB.newPage();
 
-      // --- Schueler in context A --------------------------------------
-      await loginAsRole(pageA, 'schueler');
+      // --- Lehrer in context A ----------------------------------------
+      await loginAsRole(pageA, 'lehrer');
       await pageA.goto('/settings');
       await pageA
         .getByRole('button', { name: 'Kalender-URL erstellen' })
@@ -106,8 +103,8 @@ test.describe('Issue #88 — iCal RBAC / per-user isolation (desktop)', () => {
       const urlA = (await urlElementA.textContent())?.trim() ?? '';
       expect(urlA).toMatch(/^\/api\/v1\/calendar\/[0-9a-f-]{36}\.ics$/i);
 
-      // --- Admin in context B -----------------------------------------
-      await loginAsRole(pageB, 'admin');
+      // --- Eltern in context B ----------------------------------------
+      await loginAsRole(pageB, 'eltern');
       await pageB.goto('/settings');
       await pageB
         .getByRole('button', { name: 'Kalender-URL erstellen' })
@@ -139,8 +136,8 @@ test.describe('Issue #88 — iCal RBAC / per-user isolation (desktop)', () => {
         request.get(`${apiBase}${urlA}`, { headers: {} }),
         request.get(`${apiBase}${urlB}`, { headers: {} }),
       ]);
-      expect(icsA.status(), 'Schueler ICS endpoint must return 200').toBe(200);
-      expect(icsB.status(), 'Admin ICS endpoint must return 200').toBe(200);
+      expect(icsA.status(), 'Lehrer ICS endpoint must return 200').toBe(200);
+      expect(icsB.status(), 'Eltern ICS endpoint must return 200').toBe(200);
       const bodyA = await icsA.text();
       const bodyB = await icsB.text();
       expect(bodyA.startsWith('BEGIN:VCALENDAR')).toBe(true);

--- a/apps/web/e2e/settings-ical-revoke.spec.ts
+++ b/apps/web/e2e/settings-ical-revoke.spec.ts
@@ -50,14 +50,18 @@
  * working, but the public endpoint still serves their personal
  * timetable + Klausur dates to whoever cached the old URL.
  *
- * Race-Family-Achtung: chromium-only-skip + purge in beforeEach/
- * afterEach for the same singleton-row reason as the generate spec.
+ * Race-Family-Achtung: Issue #112 Phase 2.5a (#117) — per-(schoolId,
+ * role) Postgres advisory lock serializes parallel specs sharing the
+ * eltern persona. Cross-browser safe; previous chromium-only-skip
+ * removed.
  */
 import { test, expect } from '@playwright/test';
 import { loginAsRole } from './helpers/login';
 import {
   apiBaseFromE2eEnv,
-  purgeCalendarTokensForRoles,
+  seedCalendarTokenContext,
+  cleanupCalendarTokenContext,
+  type CalendarTokenContext,
 } from './helpers/calendar-tokens';
 import { SEED_SCHOOL_UUID } from './fixtures/seed-uuids';
 
@@ -68,17 +72,18 @@ test.describe('Issue #88 — iCal revoke (desktop)', () => {
     ({ isMobile }) => isMobile,
     'iCal subscription is a desktop-anchored workflow (URL is copied into a desktop calendar app).',
   );
-  test.skip(
-    ({ browserName }) => browserName !== 'chromium',
-    'Mutates the singleton CalendarToken row for eltern-user on the seed school — chromium is the sole writer.',
-  );
+
+  let ctx: CalendarTokenContext | undefined;
 
   test.beforeEach(async () => {
-    await purgeCalendarTokensForRoles(SEED_SCHOOL_UUID, [ROLE]);
+    ctx = await seedCalendarTokenContext(SEED_SCHOOL_UUID, [ROLE]);
   });
 
   test.afterEach(async () => {
-    await purgeCalendarTokensForRoles(SEED_SCHOOL_UUID, [ROLE]);
+    if (ctx) {
+      await cleanupCalendarTokenContext(ctx);
+      ctx = undefined;
+    }
   });
 
   test('ICAL-REVOKE-ELTERN: "Token erneuern" hard-deletes the old token (old URL → 404, new URL → 200)', async ({


### PR DESCRIPTION
Closes #117. Refs #112.

## Summary

Phase 2.5a of the #112 E2E-determinism program: extract the
`pg_advisory_lock`-based serializer that was inlined in
`seedTimetableRun()` (PR #115) into a generic reusable helper, then
apply it to the CalendarToken race so the three iCal specs can drop
their chromium-only-skip + disjoint-personas workarounds.

- New `apps/web/e2e/helpers/advisory-lock.ts` —
  `acquireAdvisoryLock(resourceKeys)` returning `{ release(), _client }`.
  Multi-key acquisition sorts inputs before locking ⇒ ABBA deadlock
  impossible. Held Prisma session survives across the test lifecycle.
- `seedTimetableRun()` refactored to consume the helper. The fixture's
  `_lockClient + _lockKey` collapse into one `_lock: AdvisoryLock`.
  Cleanup delegates to `lock.release()`. Behavior unchanged — all
  existing consumers compile + run green.
- `seedCalendarTokenContext(schoolId, roles)` +
  `cleanupCalendarTokenContext(ctx)` in calendar-tokens helper.
  One lock per (schoolId, role). Purge on the locked session in both
  seed (defensive — guards stale rows from a prior crashed test) and
  cleanup.
- 3 iCal specs migrated. `settings-ical-rbac.spec.ts` reverts to its
  originally-intended `lehrer + eltern` personas now that the lock
  eliminates the race that forced the disjoint `schueler + admin`
  hack in PR #111. chromium-only-skip removed from all three.

## Test plan

- [x] `pnpm exec playwright test --project=desktop settings-ical-*.spec.ts` — 3 passed
- [x] `pnpm exec playwright test --project=desktop --project=desktop-firefox settings-ical-*.spec.ts` — 6 passed (20.9s). Cross-browser sanity for the advisory lock.
- [x] `pnpm exec playwright test --project=desktop timetable-lehrer-view.spec.ts classbook-attendance.spec.ts` — 3 passed. Refactored `seedTimetableRun` still green.
- [ ] CI green (full suite) before merge — per CLAUDE.md D3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)