### PR TITLE
chore(e2e): #112 phase 4 wave 2a — drop chromium-only-skip from 6 classbook specs

### DIFF
--- a/apps/web/e2e/classbook-attendance.spec.ts
+++ b/apps/web/e2e/classbook-attendance.spec.ts
@@ -5,11 +5,6 @@
  * Lehrer öffnet die Stunde → "Alle anwesend" → cyclet einen Schüler auf
  * ABSENT → speichert (debounced bulk PUT) → reload zeigt den Zustand.
  *
- * Chromium-only-skip because every spec mutates the SAME seeded
- * `ClassBookEntry` — parallel browser projects would race on the same
- * Anwesenheitsliste. Matches the race-family pattern documented in
- * `project_e2e_parallel_cleanup_race_family.md`.
- *
  * CI/local divergence note (2026-05-15): the seed (`apps/api/prisma/seed.ts`)
  * does NOT create any `TimetableLesson` rows — those are produced by a
  * solver run, which only happens in local dev. The first commit of this
@@ -38,11 +33,6 @@ test.describe('Issue #81 — Classbook Attendance (desktop)', () => {
     ({ isMobile }) => isMobile,
     'Attendance contract is identical across viewports — desktop only for the first lock.',
   );
-  test.skip(
-    ({ browserName }) => browserName !== 'chromium',
-    'Mutates the shared seed ClassBookEntry — parallel projects race.',
-  );
-
   // Per-test seeding instead of beforeAll/afterAll. Reason: describe-
   // level `test.skip(condition, reason)` does NOT gate beforeAll —
   // beforeAll runs in EVERY project including skipped ones (CI run

--- a/apps/web/e2e/classbook-exams.spec.ts
+++ b/apps/web/e2e/classbook-exams.spec.ts
@@ -45,10 +45,6 @@ test.describe('Issue #82 — Classbook Exam create + collision (desktop)', () =>
     ({ isMobile }) => isMobile,
     'Dialog + collision-warning layout is identical across viewports — desktop only for the first lock.',
   );
-  test.skip(
-    ({ browserName }) => browserName !== 'chromium',
-    'Mutates Exam rows on the shared seed class — chromium is the sole writer.',
-  );
 
   let fixture: TimetableRunFixture | undefined;
 

--- a/apps/web/e2e/classbook-grades.spec.ts
+++ b/apps/web/e2e/classbook-grades.spec.ts
@@ -37,10 +37,6 @@ test.describe('Issue #81 — Classbook Grade-Matrix (desktop)', () => {
     ({ isMobile }) => isMobile,
     'GradeMatrix layout is identical across viewports — desktop only for the first lock.',
   );
-  test.skip(
-    ({ browserName }) => browserName !== 'chromium',
-    'Mutates Grade rows on the shared seed ClassSubject — chromium is the sole writer.',
-  );
 
   let fixture: TimetableRunFixture | undefined;
 

--- a/apps/web/e2e/classbook-homework.spec.ts
+++ b/apps/web/e2e/classbook-homework.spec.ts
@@ -40,10 +40,6 @@ test.describe('Issue #82 — Classbook Homework create (desktop)', () => {
     ({ isMobile }) => isMobile,
     'Dialog layout is identical across viewports — desktop only for the first lock.',
   );
-  test.skip(
-    ({ browserName }) => browserName !== 'chromium',
-    'Mutates Homework rows on the shared seed ClassSubject — chromium is the sole writer.',
-  );
 
   let fixture: TimetableRunFixture | undefined;
 

--- a/apps/web/e2e/classbook-lesson-content.spec.ts
+++ b/apps/web/e2e/classbook-lesson-content.spec.ts
@@ -40,10 +40,6 @@ test.describe('Issue #81 — Classbook Lesson-Content (desktop)', () => {
     ({ isMobile }) => isMobile,
     'Content form is identical across viewports — desktop only for the first lock.',
   );
-  test.skip(
-    ({ browserName }) => browserName !== 'chromium',
-    'Mutates the shared seed ClassBookEntry — parallel projects race.',
-  );
 
   // Per-test seeding — describe-level test.skip does NOT gate beforeAll
   // (CI lesson from #81 attendance run). Per-test hooks ARE gated.

--- a/apps/web/e2e/classbook-student-notes.spec.ts
+++ b/apps/web/e2e/classbook-student-notes.spec.ts
@@ -40,10 +40,6 @@ test.describe('Issue #81 — Classbook Student-Notes (desktop)', () => {
     ({ isMobile }) => isMobile,
     'Note-create flow is identical across viewports — desktop only for the first lock.',
   );
-  test.skip(
-    ({ browserName }) => browserName !== 'chromium',
-    'Mutates the shared seed ClassBookEntry — parallel projects race.',
-  );
 
   // Per-test seeding — describe-level test.skip does NOT gate beforeAll
   // (CI lesson from #81 attendance). Per-test hooks ARE gated.


### PR DESCRIPTION
Closes #119. Refs #112.

Re-opens what was PR #127 (auto-closed when its base `chore/e2e-112-2-5a-…` was deleted on the #125 squash-merge). Rebased onto main.

## Summary

All 6 `classbook-*.spec.ts` files build on `seedTimetableRun(SEED_SCHOOL_UUID)`, which acquires a per-schoolId Postgres advisory lock (PR #115, refactored in PR #125, now on main) and holds it for the entire test lifecycle. That lock already serializes every classbook spec cross-spec AND cross-project on the seed school — the chromium-only-skip from pre-#115 is redundant.

Just remove the 6 skip blocks. No helper changes needed.

Specs affected:
- classbook-attendance.spec.ts
- classbook-exams.spec.ts
- classbook-grades.spec.ts
- classbook-homework.spec.ts
- classbook-lesson-content.spec.ts
- classbook-student-notes.spec.ts

## Test plan

- [x] `pnpm exec playwright test --project=desktop --project=desktop-firefox classbook-*.spec.ts` — 12/12 green in 1.1 min. Firefox durations (18-24s) serialize visibly against chromium's lock holds.
- [ ] CI green before merge — per CLAUDE.md D3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)