### PR TITLE
chore(e2e): #112 phase 4 wave 2b — Messaging DIRECT lock + drop chromium-only-skips

### DIFF
--- a/apps/web/e2e/messaging-broadcast.spec.ts
+++ b/apps/web/e2e/messaging-broadcast.spec.ts
@@ -52,10 +52,6 @@ test.describe('Issue #84 — Messaging broadcast via ComposeDialog (desktop)', (
     ({ isMobile }) => isMobile,
     'ComposeDialog is desktop-prioritised — mobile layout uses a different sheet pattern that will be locked in a follow-up.',
   );
-  test.skip(
-    ({ browserName }) => browserName !== 'chromium',
-    'Shared seed-school broadcasts race on parallel browser projects.',
-  );
 
   test.afterEach(async ({ request }) => {
     // Scope to this spec's own sub-prefix so a sibling spec's afterEach

--- a/apps/web/e2e/messaging-conversation-list.spec.ts
+++ b/apps/web/e2e/messaging-conversation-list.spec.ts
@@ -35,10 +35,6 @@ test.describe('Issue #84 — Messaging conversation list + detail (desktop)', ()
     ({ isMobile }) => isMobile,
     'List-detail two-pane layout is desktop-only; mobile has a separate route the next slice will cover.',
   );
-  test.skip(
-    ({ browserName }) => browserName !== 'chromium',
-    'Conversation rows on the shared seed school race on parallel browser projects.',
-  );
 
   let created: CreatedConversation | null = null;
 

--- a/apps/web/e2e/messaging-direct-1on1.spec.ts
+++ b/apps/web/e2e/messaging-direct-1on1.spec.ts
@@ -39,18 +39,29 @@ import {
   createDirectConversation,
   type CreatedConversation,
 } from './helpers/messaging';
+import { acquireAdvisoryLock, type AdvisoryLock } from './helpers/advisory-lock';
+import { SEED_SCHOOL_UUID } from './fixtures/seed-uuids';
 
 test.describe('Issue #84 — Messaging DIRECT 1:1 (lehrer → eltern, desktop)', () => {
   test.skip(
     ({ isMobile }) => isMobile,
     'List-detail two-pane layout is desktop-only; mobile has a separate route a future slice will cover.',
   );
-  test.skip(
-    ({ browserName }) => browserName !== 'chromium',
-    'DIRECT rows share a per-pair singleton (directPairKey) on the seed users; parallel browser projects collide mid-flight.',
-  );
 
+  // Issue #112 Phase 4 wave 2b (#120): DIRECT lehrer↔eltern is a per-pair
+  // singleton (find-or-create on `directPairKey`). The realtime spec
+  // (messaging-realtime.spec.ts) also writes to the same pair — without
+  // the lock, two parallel specs would see each other's mid-test
+  // messages on the shared row. Lock serializes both specs cross-spec
+  // AND cross-project.
+  let lock: AdvisoryLock | undefined;
   let created: CreatedConversation | null = null;
+
+  test.beforeEach(async () => {
+    lock = await acquireAdvisoryLock(
+      `messaging:direct:lehrer-eltern:${SEED_SCHOOL_UUID}`,
+    );
+  });
 
   test.afterEach(async ({ request }) => {
     // Sweep DIRECT rows whose latest message body carries the E2E-MSG-
@@ -65,6 +76,10 @@ test.describe('Issue #84 — Messaging DIRECT 1:1 (lehrer → eltern, desktop)',
     // other spec's conversations).
     await cleanupE2EConversations(request, `${MESSAGING_PREFIX}DIRECT-`, 'lehrer');
     created = null;
+    if (lock) {
+      await lock.release();
+      lock = undefined;
+    }
   });
 
   test('MSG-DIRECT-01: lehrer-sent DIRECT message appears in eltern-user list and opens with body', async ({

--- a/apps/web/e2e/messaging-polls.spec.ts
+++ b/apps/web/e2e/messaging-polls.spec.ts
@@ -54,10 +54,6 @@ test.describe('Issue #84 — Messaging inline polls (desktop)', () => {
     ({ isMobile }) => isMobile,
     'PollDisplay is desktop-prioritised — mobile rendering is identical but the list-detail navigation differs.',
   );
-  test.skip(
-    ({ browserName }) => browserName !== 'chromium',
-    'Shared seed-school conversations race on parallel browser projects.',
-  );
 
   let created: CreatedConversation | null = null;
 

--- a/apps/web/e2e/messaging-realtime.spec.ts
+++ b/apps/web/e2e/messaging-realtime.spec.ts
@@ -45,24 +45,39 @@ import {
   sendMessageViaAPI,
   type CreatedConversation,
 } from './helpers/messaging';
+import { acquireAdvisoryLock, type AdvisoryLock } from './helpers/advisory-lock';
+import { SEED_SCHOOL_UUID } from './fixtures/seed-uuids';
 
 test.describe('Issue #84 — Messaging realtime (Socket.IO, desktop)', () => {
   test.skip(
     ({ isMobile }) => isMobile,
     'List-detail two-pane layout is desktop-only; mobile realtime parity is a follow-up once the mobile route lands.',
   );
-  test.skip(
-    ({ browserName }) => browserName !== 'chromium',
-    'DIRECT lehrer↔eltern is a per-pair singleton; parallel browser projects collide on the directPairKey.',
-  );
 
+  // Issue #112 Phase 4 wave 2b (#120): DIRECT lehrer↔eltern is a per-pair
+  // singleton (find-or-create on `directPairKey`). Shared with the
+  // messaging-direct-1on1 spec — without the lock, a parallel run on
+  // the other spec would interleave messages into the same row and
+  // contaminate the realtime delivery assertion. Lock acquired here
+  // serializes both specs cross-spec AND cross-project.
+  let lock: AdvisoryLock | undefined;
   let created: CreatedConversation | null = null;
+
+  test.beforeEach(async () => {
+    lock = await acquireAdvisoryLock(
+      `messaging:direct:lehrer-eltern:${SEED_SCHOOL_UUID}`,
+    );
+  });
 
   test.afterEach(async ({ request }) => {
     // Scope sweep to this spec's own sub-prefix so sibling messaging
     // specs running in parallel don't sweep our mid-test DIRECT row.
     await cleanupE2EConversations(request, `${MESSAGING_PREFIX}RT-`, 'lehrer');
     created = null;
+    if (lock) {
+      await lock.release();
+      lock = undefined;
+    }
   });
 
   test('MSG-REALTIME-01: kc-eltern sees a kc-lehrer-sent message land via Socket.IO without page.reload()', async ({


### PR DESCRIPTION
Closes #120. Refs #112.

## Summary

Two distinct race surfaces in messaging — each gets the appropriate fix:

- **DIRECT lehrer↔eltern** is a per-pair singleton (backend find-or-create on `directPairKey`). `messaging-direct-1on1.spec.ts` and `messaging-realtime.spec.ts` both write to that row. Acquire `messaging:direct:lehrer-eltern:${SEED_SCHOOL_UUID}` advisory lock in beforeEach, release in afterEach. Serializes the two specs cross-spec AND cross-project.
- **Broadcast conversations** on the shared seed school. Each spec uses a unique sub-prefix (`E2E-MSG-BROADCAST-UI-`, `E2E-MSG-LIST-`, `E2E-MSG-POLL-`) for assertions + sweep, so rows don't collide on data. No lock needed — just drop the skip on `messaging-broadcast.spec.ts`, `messaging-conversation-list.spec.ts`, `messaging-polls.spec.ts`.

Helper unchanged — `acquireAdvisoryLock` (extracted in PR #125) imported directly, same pattern as time-grid.spec.ts (#118 / PR #128).

## Test plan

- [x] `pnpm exec playwright test --project=desktop --project=desktop-firefox messaging-*.spec.ts` — 10/10 green in 26.9s. Firefox per-spec durations (8-15s) confirm the DIRECT-pair lock serializing.
- [ ] CI green before merge — per CLAUDE.md D3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)