### PR TITLE
chore(e2e): #112 phase 4 wave 2c — Substitution + Excuse race fixes

### DIFF
--- a/apps/web/e2e/admin-substitutions-create.spec.ts
+++ b/apps/web/e2e/admin-substitutions-create.spec.ts
@@ -45,10 +45,6 @@ test.describe('Issue #85 — Admin Neue Abwesenheit erfassen UI flow (desktop)',
     ({ isMobile }) => isMobile,
     'AbsenceForm is desktop-prioritised — mobile flow is a follow-up slice once the form layout is mobile-audited.',
   );
-  test.skip(
-    ({ browserName }) => browserName !== 'chromium',
-    'Race-family: mutates the shared seed-school TimetableRun + absences.',
-  );
 
   let fixture: TimetableRunFixture | undefined;
   // The UI flow leaves the absence row created via POST /absences on

--- a/apps/web/e2e/admin-substitutions-list.spec.ts
+++ b/apps/web/e2e/admin-substitutions-list.spec.ts
@@ -42,10 +42,6 @@ test.describe('Issue #85 — Admin Offene Vertretungen (desktop)', () => {
     ({ isMobile }) => isMobile,
     'Panel rendering is identical across viewports — desktop only for the first lock.',
   );
-  test.skip(
-    ({ browserName }) => browserName !== 'chromium',
-    'Race-family: mutates the shared seed-school TimetableRun.',
-  );
 
   // Per-test seeding — describe-level test.skip does NOT gate
   // beforeAll/afterAll (CI lesson from #81/#86). Per-test hooks ARE

--- a/apps/web/e2e/excuses-attachments.spec.ts
+++ b/apps/web/e2e/excuses-attachments.spec.ts
@@ -53,17 +53,18 @@ import {
   uploadExcuseAttachmentViaAPI,
   type CreatedExcuse,
 } from './helpers/excuses';
+import { acquireAdvisoryLock, type AdvisoryLock } from './helpers/advisory-lock';
 
 const SEED_STUDENT_LISA_HUBER_UUID = 'e0000000-0000-4000-8000-000000000001';
+// Per #112 phase 4 wave 2c (#121): shared with the other two excuses
+// specs so cross-spec AND cross-project parallel runs serialize on the
+// per-student row family.
+const EXCUSES_STUDENT_LOCK_KEY = `excuses:${SEED_STUDENT_LISA_HUBER_UUID}`;
 
 test.describe('Issue #83 — Excuses attachments (desktop)', () => {
   test.skip(
     ({ isMobile }) => isMobile,
     'Attachment chip layout is identical across viewports — desktop only for the first lock.',
-  );
-  test.skip(
-    ({ browserName }) => browserName !== 'chromium',
-    'AbsenceExcuse rows for kc-eltern accumulate on parallel projects — chromium is the sole writer.',
   );
 
   // Sibling specs (excuses-parent-submit, excuses-teacher-review) use
@@ -73,8 +74,18 @@ test.describe('Issue #83 — Excuses attachments (desktop)', () => {
   // teacher-review race recorded in `excuses-teacher-review.spec.ts:73`).
   const ATT_PREFIX = `${EXCUSES_NOTE_PREFIX}ATT-`;
 
+  let lock: AdvisoryLock | undefined;
+
+  test.beforeEach(async () => {
+    lock = await acquireAdvisoryLock(EXCUSES_STUDENT_LOCK_KEY);
+  });
+
   test.afterEach(async () => {
     await cleanupE2EExcuses(ATT_PREFIX);
+    if (lock) {
+      await lock.release();
+      lock = undefined;
+    }
   });
 
   test('EXC-ATT-PARENT-01: eltern submits an excuse with PDF attachment → toast → attachment chip visible after reload', async ({

--- a/apps/web/e2e/excuses-parent-submit.spec.ts
+++ b/apps/web/e2e/excuses-parent-submit.spec.ts
@@ -25,16 +25,28 @@
 import { test, expect } from '@playwright/test';
 import { loginAsRole } from './helpers/login';
 import { EXCUSES_NOTE_PREFIX, cleanupE2EExcuses } from './helpers/excuses';
+import { acquireAdvisoryLock, type AdvisoryLock } from './helpers/advisory-lock';
+
+// All three excuses specs target the same seed student (Lisa Huber,
+// kc-eltern's only child) and share `AbsenceExcuse` rows on that
+// student. Sub-prefix isolation prevents cross-spec data collisions,
+// but parallel runs of the SAME spec across browser projects would
+// still interleave list views + cleanup sweeps. The per-student lock
+// (shared by all three excuses specs) serializes them — both
+// intra-spec (chromium ↔ firefox) and inter-spec.
+const EXCUSES_STUDENT_LOCK_KEY = 'excuses:e0000000-0000-4000-8000-000000000001';
 
 test.describe('Issue #83 — Excuses parent submit (desktop)', () => {
   test.skip(
     ({ isMobile }) => isMobile,
     'Form layout is identical across viewports — desktop only for the first lock.',
   );
-  test.skip(
-    ({ browserName }) => browserName !== 'chromium',
-    'AbsenceExcuse rows for kc-eltern accumulate on parallel projects — chromium is the sole writer.',
-  );
+
+  let lock: AdvisoryLock | undefined;
+
+  test.beforeEach(async () => {
+    lock = await acquireAdvisoryLock(EXCUSES_STUDENT_LOCK_KEY);
+  });
 
   test.afterEach(async () => {
     // Sweep ALL E2E-EXC- excuses, not just the one created here. A
@@ -42,6 +54,10 @@ test.describe('Issue #83 — Excuses parent submit (desktop)', () => {
     // those would clutter the list assertion below the next time the
     // spec runs against an unclean DB.
     await cleanupE2EExcuses(`${EXCUSES_NOTE_PREFIX}PARENT-`);
+    if (lock) {
+      await lock.release();
+      lock = undefined;
+    }
   });
 
   test('EXC-PARENT-01: eltern submits an excuse → toast → row visible in submitted list with PENDING badge', async ({

--- a/apps/web/e2e/excuses-teacher-review.spec.ts
+++ b/apps/web/e2e/excuses-teacher-review.spec.ts
@@ -33,23 +33,26 @@ import {
   todayISODate,
   type CreatedExcuse,
 } from './helpers/excuses';
+import { acquireAdvisoryLock, type AdvisoryLock } from './helpers/advisory-lock';
 
 const SEED_STUDENT_LISA_HUBER_UUID = 'e0000000-0000-4000-8000-000000000001';
+// Per #112 phase 4 wave 2c (#121): shared with excuses-parent-submit
+// and excuses-attachments so cross-spec AND cross-project parallel
+// runs serialize on the per-student row family.
+const EXCUSES_STUDENT_LOCK_KEY = `excuses:${SEED_STUDENT_LISA_HUBER_UUID}`;
 
 test.describe('Issue #83 — Excuses teacher review (desktop)', () => {
   test.skip(
     ({ isMobile }) => isMobile,
     'Review-list layout is identical across viewports — desktop only for the first lock.',
   );
-  test.skip(
-    ({ browserName }) => browserName !== 'chromium',
-    'AbsenceExcuse rows for kc-eltern accumulate on parallel projects — chromium is the sole writer.',
-  );
 
+  let lock: AdvisoryLock | undefined;
   let excuse: CreatedExcuse | undefined;
   let noteText: string;
 
   test.beforeEach(async ({ request }) => {
+    lock = await acquireAdvisoryLock(EXCUSES_STUDENT_LOCK_KEY);
     const today = todayISODate();
     noteText = `${EXCUSES_NOTE_PREFIX}REVIEW-${Date.now()} — review-flow test`;
     excuse = await createExcuseAsParentViaAPI(request, {
@@ -74,6 +77,10 @@ test.describe('Issue #83 — Excuses teacher review (desktop)', () => {
     // then 404'd silently (success toast never fired).
     await cleanupE2EExcuses(`${EXCUSES_NOTE_PREFIX}REVIEW-`);
     excuse = undefined;
+    if (lock) {
+      await lock.release();
+      lock = undefined;
+    }
   });
 
   test('EXC-TEACHER-01: kc-lehrer accepts a PENDING excuse → toast → card disappears from PENDING list', async ({

--- a/apps/web/e2e/substitutions-handover.spec.ts
+++ b/apps/web/e2e/substitutions-handover.spec.ts
@@ -67,10 +67,6 @@ test.describe('Issue #85 — Uebergabenotiz author flow + attachment (desktop)',
     ({ isMobile }) => isMobile,
     'HandoverNoteEditor dialog is desktop-prioritised; mobile layout is a follow-up audit once the dialog\'s textarea height is mobile-tuned.',
   );
-  test.skip(
-    ({ browserName }) => browserName !== 'chromium',
-    'Race-family: mutates the shared seed-school TimetableRun + absences.',
-  );
 
   let fixture: TimetableRunFixture | undefined;
   let absence: CreatedAbsence | undefined;

--- a/apps/web/e2e/teacher-substitutions-incoming.spec.ts
+++ b/apps/web/e2e/teacher-substitutions-incoming.spec.ts
@@ -62,10 +62,6 @@ test.describe('Issue #85 — Teacher Offene Anfragen Section 1 (desktop)', () =>
     ({ isMobile }) => isMobile,
     'Section-1 rendering is desktop-only for the first lock; mobile is a follow-up if the SubstituteOfferCard layout drifts.',
   );
-  test.skip(
-    ({ browserName }) => browserName !== 'chromium',
-    'Race-family: mutates the shared seed-school TimetableRun + assigns kc-lehrer as substitute.',
-  );
 
   let fixture: TimetableRunFixture | undefined;
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/apps/web/e2e/teacher-substitutions-my-absences.spec.ts
+++ b/apps/web/e2e/teacher-substitutions-my-absences.spec.ts
@@ -46,10 +46,6 @@ test.describe('Issue #85 — Teacher Meine Abwesenheiten (desktop)', () => {
     ({ isMobile }) => isMobile,
     'Section-2 rendering is identical across viewports — desktop only for the first lock.',
   );
-  test.skip(
-    ({ browserName }) => browserName !== 'chromium',
-    'Race-family: mutates the shared seed-school TimetableRun + substitutions.',
-  );
 
   // Per-test seed; describe-level test.skip does NOT gate beforeAll/afterAll
   // (lesson from #86 / #81). Per-test hooks ARE gated; the if-guard belts-and-


### PR DESCRIPTION
Closes #121. Refs #112.

## Summary

Two race surfaces in this wave, each handled appropriately:

**5 Substitution / TeacherAbsence specs** all use `seedTimetableRun(SEED_SCHOOL_UUID)`, which acquires the per-schoolId Postgres advisory lock (PR #115, refactored in PR #125, now on main) for the entire test lifecycle. That lock already serializes every spec on the seed school cross-spec AND cross-project, so the chromium-only-skip is redundant. Just drop it.

- admin-substitutions-create.spec.ts
- admin-substitutions-list.spec.ts
- substitutions-handover.spec.ts
- teacher-substitutions-my-absences.spec.ts
- teacher-substitutions-incoming.spec.ts

**3 Excuses specs** write `AbsenceExcuse` rows for the same seed student (Lisa Huber). Sub-prefix isolation (`E2E-EXC-PARENT-/REVIEW-/ATT-`) keeps cleanup sweeps disjoint, but parallel runs of the SAME spec across browser projects still interleave list views + cleanup mid-flight. Acquire a per-student advisory lock (`excuses:e0000000-…-001`, shared by all three) in beforeEach, release in afterEach. Drop the chromium-only-skip.

- excuses-parent-submit.spec.ts
- excuses-teacher-review.spec.ts
- excuses-attachments.spec.ts

## Test plan

- [x] `pnpm exec playwright test --project=desktop --project=desktop-firefox <8 specs>` — 18/18 green in 40.5s. Firefox per-spec durations confirm the per-school + per-student locks serializing chromium ↔ firefox.
- [ ] CI green before merge — per CLAUDE.md D3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)