### PR TITLE
chore(e2e): #112 phase 4 wave 2d — admin-config race fixes + canary lock

### DIFF
--- a/apps/web/e2e/admin-classes-home-room.spec.ts
+++ b/apps/web/e2e/admin-classes-home-room.spec.ts
@@ -32,6 +32,7 @@ import {
   createClassViaAPI,
 } from './helpers/students';
 import { SEED_SCHOOL_UUID } from './fixtures/seed-uuids';
+import { acquireAdvisoryLock, type AdvisoryLock } from './helpers/advisory-lock';
 
 const PREFIX = 'E2E-HR-';
 const NO_HOME_ROOM_SENTINEL = '__no_home_room__';
@@ -77,23 +78,34 @@ test.describe('Issue #67 — Admin Classes Heimraum (desktop)', () => {
     ({ isMobile }) => isMobile,
     'Heimraum form contract is identical across viewports — desktop only.',
   );
-  // Mutating classes on the seed school from parallel browser projects
-  // races on the same school resources (PUT /classes/:id from chromium
-  // and firefox can land on a class that the other project's cleanup
-  // just deleted, or share a colliding timestamp suffix). Scope to
-  // chromium until the throwaway-school fixture lands — same pattern as
-  // timetable-generation-flow.spec.ts and project_e2e_parallel_cleanup_race_family.md.
-  test.skip(
-    ({ browserName }) => browserName !== 'chromium',
-    'flaky on parallel browser projects — shared seed-school race (see #54).',
-  );
+
+  // Issue #112 phase 4 wave 2d (#122): per-spec advisory lock serializes
+  // parallel browser projects on the cleanup-by-prefix race. Both
+  // chromium and firefox running this spec would otherwise sweep each
+  // other's mid-test classes via the `E2E-HR-` afterEach.
+  let lock: AdvisoryLock | undefined;
 
   test.beforeEach(async ({ page }) => {
+    // Two locks acquired in sorted order:
+    //   - per-spec key serializes parallel browser projects on the
+    //     `E2E-HR-` cleanup sweep
+    //   - shared `e2e-rows-on-seed-school` key blocks the
+    //     `e2e-sweep-canary` spec from running its destructive
+    //     `sweepE2ELeftovers` (which deletes EVERY E2E-* row in the
+    //     school) while our mid-test classes are alive
+    lock = await acquireAdvisoryLock([
+      `admin-classes-home-room:${SEED_SCHOOL_UUID}`,
+      `e2e-rows-on-seed-school:${SEED_SCHOOL_UUID}`,
+    ]);
     await loginAsAdmin(page);
   });
 
   test.afterEach(async ({ request }) => {
     await cleanupE2EClasses(request, PREFIX);
+    if (lock) {
+      await lock.release();
+      lock = undefined;
+    }
   });
 
   test('E2E-CLS-HR-EDIT-ASSIGN: pick Heimraum via Select → save → persists', async ({

--- a/apps/web/e2e/admin-stundentafel-teacher-assignment.spec.ts
+++ b/apps/web/e2e/admin-stundentafel-teacher-assignment.spec.ts
@@ -25,6 +25,7 @@ import {
   createClassViaAPI,
 } from './helpers/students';
 import { SEED_SCHOOL_UUID } from './fixtures/seed-uuids';
+import { acquireAdvisoryLock, type AdvisoryLock } from './helpers/advisory-lock';
 
 const PREFIX = 'E2E-TA-';
 const API = 'http://localhost:3000/api/v1';
@@ -103,17 +104,27 @@ test.describe('Issue #71 — Stundentafel Teacher-Zuweisung (desktop)', () => {
     ({ isMobile }) => isMobile,
     'Stundentafel teacher picker uses identical Select on mobile — desktop is enough.',
   );
-  test.skip(
-    ({ browserName }) => browserName !== 'chromium',
-    'flaky on parallel browser projects — shared seed-school race.',
-  );
+
+  // Issue #112 phase 4 wave 2d (#122): per-spec advisory lock serializes
+  // parallel browser projects on the cleanup-by-prefix race.
+  let lock: AdvisoryLock | undefined;
 
   test.beforeEach(async ({ page }) => {
+    // See admin-classes-home-room.spec.ts for the two-lock rationale —
+    // per-spec key + shared canary-sweep guard.
+    lock = await acquireAdvisoryLock([
+      `admin-stundentafel-teacher-assignment:${SEED_SCHOOL_UUID}`,
+      `e2e-rows-on-seed-school:${SEED_SCHOOL_UUID}`,
+    ]);
     await loginAsAdmin(page);
   });
 
   test.afterEach(async ({ request }) => {
     await cleanupE2EClasses(request, PREFIX);
+    if (lock) {
+      await lock.release();
+      lock = undefined;
+    }
   });
 
   test('E2E-CLS-TEACHER-ASSIGN: pick teacher → save → PUT body + persist', async ({

--- a/apps/web/e2e/admin-subjects-required-room-type.spec.ts
+++ b/apps/web/e2e/admin-subjects-required-room-type.spec.ts
@@ -27,6 +27,7 @@ import { expect, test } from '@playwright/test';
 import { getAdminToken, loginAsAdmin } from './helpers/login';
 import { cleanupE2ESubjects, createSubjectViaAPI } from './helpers/subjects';
 import { SEED_SCHOOL_UUID } from './fixtures/seed-uuids';
+import { acquireAdvisoryLock, type AdvisoryLock } from './helpers/advisory-lock';
 
 const PREFIX = 'E2E-RRT-';
 const API = 'http://localhost:3000/api/v1';
@@ -66,20 +67,27 @@ test.describe('Issue #69 — Subject Pflicht-Raumtyp (desktop)', () => {
     ({ isMobile }) => isMobile,
     'Pflicht-Raumtyp form contract is identical across viewports — desktop only.',
   );
-  // Mutating subjects on the seed school from parallel browser projects
-  // shares school resources; the chromium-only pattern is the established
-  // mitigation for this surface (same as admin-classes-home-room.spec.ts).
-  test.skip(
-    ({ browserName }) => browserName !== 'chromium',
-    'flaky on parallel browser projects — shared seed-school race.',
-  );
+
+  // Issue #112 phase 4 wave 2d (#122): per-spec advisory lock serializes
+  // parallel browser projects on the cleanup-by-prefix race.
+  let lock: AdvisoryLock | undefined;
 
   test.beforeEach(async ({ page }) => {
+    // See admin-classes-home-room.spec.ts for the two-lock rationale —
+    // per-spec key + shared canary-sweep guard.
+    lock = await acquireAdvisoryLock([
+      `admin-subjects-required-room-type:${SEED_SCHOOL_UUID}`,
+      `e2e-rows-on-seed-school:${SEED_SCHOOL_UUID}`,
+    ]);
     await loginAsAdmin(page);
   });
 
   test.afterEach(async ({ request }) => {
     await cleanupE2ESubjects(request, PREFIX);
+    if (lock) {
+      await lock.release();
+      lock = undefined;
+    }
   });
 
   test('E2E-SUB-RRT-CREATE: dialog with Pflicht-Raumtyp=Turnsaal → POST carries TURNSAAL', async ({

--- a/apps/web/e2e/e2e-sweep-canary.spec.ts
+++ b/apps/web/e2e/e2e-sweep-canary.spec.ts
@@ -12,9 +12,16 @@
  * and assert every canary is gone. Direct DB I/O — no HTTP — so the
  * sweep helper is exercised in the same path globalSetup uses.
  *
- * Chromium-only: matches the parallel-cleanup race-family precedent
- * (`project_e2e_parallel_cleanup_race_family.md`). Two browser projects
- * inserting + sweeping concurrently would race each other.
+ * Chromium-only by design — NOT a per-resource race like the
+ * #122 admin-config family. `sweepE2ELeftovers` is destructive on
+ * EVERY `startsWith: 'E2E-'` row in persons / classes / subjects /
+ * rooms / dsfa / constraints / audit-reasons / attachments. Dropping
+ * the skip would let a parallel-project canary run mid-test through
+ * an unrelated CRUD spec (admin-classes-*, admin-subjects-*, …) and
+ * delete its in-flight rows. A proper fix requires routing every
+ * `E2E-` writer through a shared advisory lock — out of scope for
+ * #122. FIXME: deterministic-e2e #112 — drop this skip once the
+ * global-sweep-vs-writers lock lands.
  */
 import 'dotenv/config';
 import { config as dotenvConfig } from 'dotenv';
@@ -24,6 +31,7 @@ import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { sweepE2ELeftovers, totalSwept } from './helpers/sweep-leftovers';
 import { SEED_SCHOOL_UUID } from './fixtures/seed-uuids';
+import { acquireAdvisoryLock } from './helpers/advisory-lock';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -57,12 +65,24 @@ test.describe('Issue #79 — E2E sweep regression lock', () => {
     ({ isMobile }) => isMobile,
     'Sweep is viewport-agnostic — desktop chromium is enough.',
   );
+  // FIXME: deterministic-e2e #112 — sweep helper is destructive across
+  // EVERY E2E-* row in the seed school; serializing it cross-project
+  // requires a global lock acquired by every E2E-* writer. Tracked as
+  // a #112 follow-up; for now the chromium-only-skip stays.
   test.skip(
     ({ browserName }) => browserName !== 'chromium',
-    'Parallel browser projects would race on the canary rows (#79 race-family precedent).',
+    'sweepE2ELeftovers is destructive globally — see #112 follow-up.',
   );
 
   test('CANARY-SWEEP-01: sweepE2ELeftovers removes E2E-prefixed rows in persons / school_classes / subjects / rooms / dsfa_entries', async () => {
+    // Issue #112 phase 4 wave 2d (#122): acquire the `e2e-rows-on-seed-school`
+    // lock so admin-config specs (admin-classes-home-room, -stundentafel-,
+    // -subjects-required-room-type) cannot have mid-flight rows when our
+    // destructive `sweepE2ELeftovers` runs. The lock is held for the
+    // entire test body — release in `finally`.
+    const lock = await acquireAdvisoryLock(
+      `e2e-rows-on-seed-school:${SEED_SCHOOL_UUID}`,
+    );
     const prisma = new PrismaClient({
       adapter: new PrismaPg({ connectionString: process.env.DATABASE_URL ?? '' }),
     });
@@ -137,6 +157,7 @@ test.describe('Issue #79 — E2E sweep regression lock', () => {
       expect(totalSwept(postCounts), 'sweep is idempotent — second run is a no-op').toBe(0);
     } finally {
       await prisma.$disconnect();
+      await lock.release();
     }
   });
 });


### PR DESCRIPTION
Closes #122. Refs #112.

## Summary

Scope reality vs issue body: the 7 `admin-solver-tuning-*` specs are already cross-browser — no chromium-only-skip in the current code. The 4 specs that still had the skip are the actual wave-2d scope.

**3 admin-config specs** each acquire a per-spec advisory lock plus a shared `e2e-rows-on-seed-school` lock so the canary spec cannot run its destructive `sweepE2ELeftovers` while our mid-test rows are alive.

- `admin-classes-home-room.spec.ts` (E2E-HR- prefix)
- `admin-stundentafel-teacher-assignment.spec.ts` (E2E-TA- prefix)
- `admin-subjects-required-room-type.spec.ts` (E2E-SRRT- prefix)

**1 canary spec** — `e2e-sweep-canary.spec.ts` (#79) acquires the same shared `e2e-rows-on-seed-school` lock around the sweep call, then keeps its chromium-only-skip with an updated FIXME pointer. The skip stays because `sweepE2ELeftovers` is destructive on EVERY `E2E-*` row in persons / classes / subjects / rooms / dsfa / constraints / audit-reasons / attachments. Dropping it cross-browser without adding the same lock to every other E2E-* writer (admin-classes-crud, admin-students-crud, admin-teachers-crud, etc.) would expose them to the same race I just fixed for the 3 admin-config specs. Tracked as a #112 follow-up.

## Race I caught while iterating locally

First cross-browser run failed: firefox's admin-classes-home-room hit "Klasse nicht gefunden" toast + PUT 404 because the chromium canary worker's `sweepE2ELeftovers` deleted the in-flight class. Shared canary-lock fixes it.

## Test plan

- [x] `pnpm exec playwright test --project=desktop --project=desktop-firefox <4 specs>` — 17/17 green + 1 expected-skipped (canary on firefox) in 47.1s. Same-project parallel runs of canary + admin-config visibly serialize.
- [ ] CI green before merge — per CLAUDE.md D3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)