### PR TITLE
feat(api): #123/1+2 — Person.keycloakUserId composite unique + findFirst callsites

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,39 @@ Begründung: GSD-State über zu viele Files verteilt → Plan-vs-Realität-Drift
 3. Constraint: ein Sub-Issue kann nur EINEN Parent haben. Bei Konflikt vorher `parent { number }` checken.
 4. Memory `feedback_issue_relationships.md` hat das Code-Pattern + Anwendungsfälle.
 
+## D6 — GitHub Issue-Dependencies (blocked-by) setzen und respektieren (User-Direktive 2026-05-20)
+
+**Wenn ein Issue erst angegangen werden kann, nachdem ein anderes fertig ist, MUSS eine native GitHub "blocked by" Relationship via GraphQL `addBlockedBy` gesetzt werden — nicht nur "Depends on #N" Text im Body.**
+
+**Why:** Wie bei Sub-Issues (D5) sind Text-Refs unsichtbar in der GitHub-UI. Echte blocked-by/blocking Relationships erscheinen in der Issue-Sidebar, sind in Project-Boards filterbar ("show ready / unblocked"), und verhindern dass ich versehentlich an blockierten Issues arbeite. Auslöser 2026-05-20: nach Sub-Issue-Erstellung für Tracking #123 hingen #134/#135 an #133, #136 an #133+#134+#135, #137 an #136, #138 an #137 — diese Kette muss sichtbar + tooled sein, sonst greift bei Wave-Roll-out wieder das "ich arbeite an irgendwas blockiertem"-Pattern.
+
+**Verboten als ALLEINIGE Verknüpfung:**
+- Nur `Depends on #N` oder "Hard-blocks on #N" als Text im Body
+- Nur eine "Dependencies"-Sektion in Markdown ohne native Relationship
+- Stillschweigendes Annehmen "der Reviewer wird's schon richtig priorisieren"
+
+**Erlaubt / Gefordert:**
+- blocked-by Link via GraphQL `addBlockedBy` Mutation
+- `Depends on #N` Text-Link IST OK als zusätzliche Lesehilfe im Body
+- Vor jeder Arbeit an einem Issue: `blockedBy` querien und ggf. nachfragen
+
+**How to apply:**
+
+1. **Beim Anlegen verwandter Issues**: nach `addSubIssue` (D5) zusätzlich blocked-by setzen wenn Reihenfolge zwingend ist:
+   ```bash
+   # input: issueId = das BLOCKIERTE Issue, blockingIssueId = das das es BLOCKIERT
+   gh api graphql -f query='mutation { addBlockedBy(input: { issueId: "BLOCKED_ID", blockingIssueId: "BLOCKING_ID" }) { issue { number } blockingIssue { number } } }'
+   ```
+2. **Mehrere Blocker pro Issue**: für jeden Blocker eine separate Mutation. Ein Issue kann von N Issues blockiert sein.
+3. **Vor Arbeitsbeginn an einem Issue Quick-Check**:
+   ```bash
+   gh api graphql -f query='query { repository(owner: "OWNER", name: "REPO") { issue(number: N) { blockedBy(first: 10) { nodes { number title state } } } } }'
+   ```
+   Sind alle Blocker `CLOSED` → ready. Steht ein `OPEN` Blocker drin → STOP und Rückfrage stellen *"Issue #N ist von #M blockiert (state: OPEN) — trotzdem starten oder erst #M?"*
+4. **Inverse Richtung**: `blocking(first: 10)` zeigt, was dieses Issue selbst blockiert (nützlich beim Closing-Review).
+5. **Remove**: `removeBlockedBy(input: { issueId, blockingIssueId })` wenn Dependency hinfällig.
+6. **Memory** `feedback_issue_blocked_by.md` hat das Code-Pattern + Workflow.
+
 ---
 
 <!-- GSD:project-start source:PROJECT.md -->

--- a/apps/api/prisma/migrations/20260520054021_person_keycloak_user_id_composite_unique/migration.sql
+++ b/apps/api/prisma/migrations/20260520054021_person_keycloak_user_id_composite_unique/migration.sql
@@ -1,0 +1,8 @@
+-- DropIndex
+DROP INDEX "persons_keycloak_user_id_key";
+
+-- CreateIndex
+CREATE INDEX "persons_keycloak_user_id_idx" ON "persons"("keycloak_user_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "persons_keycloak_user_id_school_id_key" ON "persons"("keycloak_user_id", "school_id");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -318,7 +318,7 @@ model Person {
   id                   String     @id @default(uuid())
   schoolId             String     @map("school_id")
   school               School     @relation(fields: [schoolId], references: [id], onDelete: Cascade)
-  keycloakUserId       String?    @unique @map("keycloak_user_id")
+  keycloakUserId       String?    @map("keycloak_user_id")
   personType           PersonType @map("person_type")
   firstName            String     @map("first_name")
   lastName             String     @map("last_name")
@@ -338,7 +338,9 @@ model Person {
   parent         Parent?
   consentRecords ConsentRecord[]
 
+  @@unique([keycloakUserId, schoolId], name: "keycloakUserId_schoolId")
   @@index([schoolId])
+  @@index([keycloakUserId])
   @@map("persons")
 }
 

--- a/apps/api/src/modules/classbook/excuse.service.ts
+++ b/apps/api/src/modules/classbook/excuse.service.ts
@@ -50,7 +50,7 @@ export class ExcuseService {
     }
 
     // Resolve parent from keycloakUserId
-    const parentPerson = await this.prisma.person.findUnique({
+    const parentPerson = await this.prisma.person.findFirst({
       where: { keycloakUserId: parentKeycloakId },
       include: { parent: true },
     });
@@ -254,7 +254,7 @@ export class ExcuseService {
    * List excuses submitted by a parent. Order by createdAt DESC.
    */
   async getExcusesForParent(parentKeycloakId: string) {
-    const parentPerson = await this.prisma.person.findUnique({
+    const parentPerson = await this.prisma.person.findFirst({
       where: { keycloakUserId: parentKeycloakId },
       include: { parent: true },
     });
@@ -304,7 +304,7 @@ export class ExcuseService {
    */
   async getPendingExcusesForKlassenvorstand(teacherKeycloakId: string, schoolId: string) {
     // Resolve teacher
-    const person = await this.prisma.person.findUnique({
+    const person = await this.prisma.person.findFirst({
       where: { keycloakUserId: teacherKeycloakId },
       include: { teacher: true },
     });

--- a/apps/api/src/modules/keycloak-admin/keycloak-admin.service.spec.ts
+++ b/apps/api/src/modules/keycloak-admin/keycloak-admin.service.spec.ts
@@ -43,7 +43,7 @@ const mockConfig = {
 
 const mockPrisma = {
   person: {
-    findUnique: vi.fn(),
+    findFirst: vi.fn(),
   },
 };
 
@@ -97,7 +97,7 @@ describe('KeycloakAdminService', () => {
     kcMock.users.find.mockResolvedValue([
       { id: 'kc-1', email: 'maria@schule.at', firstName: 'Maria', lastName: 'Huber', enabled: true },
     ]);
-    mockPrisma.person.findUnique.mockResolvedValue({
+    mockPrisma.person.findFirst.mockResolvedValue({
       id: 'person-99',
       firstName: 'Maria',
       lastName: 'Huber',
@@ -112,7 +112,7 @@ describe('KeycloakAdminService', () => {
       alreadyLinkedToPersonId: 'person-99',
       alreadyLinkedToPersonName: 'Maria Huber',
     });
-    expect(mockPrisma.person.findUnique).toHaveBeenCalledWith({
+    expect(mockPrisma.person.findFirst).toHaveBeenCalledWith({
       where: { keycloakUserId: 'kc-1' },
       select: { id: true, firstName: true, lastName: true },
     });
@@ -122,7 +122,7 @@ describe('KeycloakAdminService', () => {
     kcMock.users.find.mockResolvedValue([]);
     const results = await service.findUsersByEmail('noone');
     expect(results).toEqual([]);
-    expect(mockPrisma.person.findUnique).not.toHaveBeenCalled();
+    expect(mockPrisma.person.findFirst).not.toHaveBeenCalled();
   });
 
   // ---------------------------------------------------------------------------

--- a/apps/api/src/modules/keycloak-admin/keycloak-admin.service.ts
+++ b/apps/api/src/modules/keycloak-admin/keycloak-admin.service.ts
@@ -75,7 +75,7 @@ export class KeycloakAdminService implements OnModuleInit {
     return Promise.all(
       users.map(async (u): Promise<KeycloakUserResponseDto> => {
         const linked = u.id
-          ? await this.prisma.person.findUnique({
+          ? await this.prisma.person.findFirst({
               where: { keycloakUserId: u.id },
               select: { id: true, firstName: true, lastName: true },
             })

--- a/apps/api/src/modules/user-context/user-context.service.ts
+++ b/apps/api/src/modules/user-context/user-context.service.ts
@@ -7,7 +7,7 @@ export class UserContextService {
   constructor(private prisma: PrismaService) {}
 
   async getUserContext(keycloakUserId: string): Promise<UserContextResponseDto> {
-    const person = await this.prisma.person.findUnique({
+    const person = await this.prisma.person.findFirst({
       where: { keycloakUserId },
       include: {
         teacher: true,

--- a/apps/api/src/modules/user-directory/user-directory.service.spec.ts
+++ b/apps/api/src/modules/user-directory/user-directory.service.spec.ts
@@ -15,6 +15,7 @@ const mockPrisma = {
   person: {
     findMany: vi.fn(),
     findUnique: vi.fn(),
+    findFirst: vi.fn(),
   },
   teacher: {
     findUnique: vi.fn(),
@@ -190,7 +191,7 @@ describe('UserDirectoryService', () => {
       mockPrisma.userRole.findMany.mockResolvedValue([
         { userId: 'kc-1', role: { name: 'admin' } },
       ]);
-      mockPrisma.person.findUnique.mockResolvedValue({
+      mockPrisma.person.findFirst.mockResolvedValue({
         id: 'p1',
         keycloakUserId: 'kc-1',
         personType: 'TEACHER',
@@ -212,15 +213,14 @@ describe('UserDirectoryService', () => {
 
   describe('linkPerson', () => {
     it('happy path — TEACHER personType dispatches to teacherService.linkKeycloakUser', async () => {
-      mockPrisma.person.findUnique
-        .mockResolvedValueOnce(null) // user-side pre-check: no existing link
-        .mockResolvedValueOnce({
-          id: 'p1',
-          keycloakUserId: null,
-          personType: 'TEACHER',
-          firstName: 'Anna',
-          lastName: 'Müller',
-        });
+      mockPrisma.person.findFirst.mockResolvedValueOnce(null); // user-side pre-check: no existing link
+      mockPrisma.person.findUnique.mockResolvedValueOnce({
+        id: 'p1',
+        keycloakUserId: null,
+        personType: 'TEACHER',
+        firstName: 'Anna',
+        lastName: 'Müller',
+      });
       mockPrisma.teacher.findUnique.mockResolvedValue({ personId: 'p1' });
       mockTeacher.linkKeycloakUser.mockResolvedValue({ id: 'p1' });
 
@@ -230,7 +230,7 @@ describe('UserDirectoryService', () => {
     });
 
     it('throws 409 when user is already linked to a different Person (user-side pre-check)', async () => {
-      mockPrisma.person.findUnique.mockResolvedValueOnce({
+      mockPrisma.person.findFirst.mockResolvedValueOnce({
         id: 'p-other',
         keycloakUserId: 'kc-1',
         personType: 'TEACHER',
@@ -244,15 +244,14 @@ describe('UserDirectoryService', () => {
     });
 
     it('throws 409 when target Person is already linked to a different keycloakUserId (person-side pre-check, prevents silent link-theft)', async () => {
-      mockPrisma.person.findUnique
-        .mockResolvedValueOnce(null) // user has no link
-        .mockResolvedValueOnce({
-          id: 't1',
-          keycloakUserId: 'kc-OTHER',
-          personType: 'TEACHER',
-          firstName: 'Maria',
-          lastName: 'Huber',
-        });
+      mockPrisma.person.findFirst.mockResolvedValueOnce(null); // user has no link
+      mockPrisma.person.findUnique.mockResolvedValueOnce({
+        id: 't1',
+        keycloakUserId: 'kc-OTHER',
+        personType: 'TEACHER',
+        firstName: 'Maria',
+        lastName: 'Huber',
+      });
       mockPrisma.teacher.findUnique.mockResolvedValue({ personId: 't1' });
       mockKc.findUserById.mockResolvedValue({
         id: 'kc-OTHER',
@@ -273,8 +272,8 @@ describe('UserDirectoryService', () => {
     });
 
     it('translates Prisma P2002 to 409 (defensive race-condition fallback)', async () => {
+      mockPrisma.person.findFirst.mockResolvedValueOnce(null); // user has no link
       mockPrisma.person.findUnique
-        .mockResolvedValueOnce(null) // user has no link
         .mockResolvedValueOnce({
           id: 't1',
           keycloakUserId: null,
@@ -298,15 +297,14 @@ describe('UserDirectoryService', () => {
     });
 
     it('STUDENT personType dispatches to studentService.linkKeycloakUser', async () => {
-      mockPrisma.person.findUnique
-        .mockResolvedValueOnce(null)
-        .mockResolvedValueOnce({
-          id: 's1',
-          keycloakUserId: null,
-          personType: 'STUDENT',
-          firstName: 'S',
-          lastName: 'T',
-        });
+      mockPrisma.person.findFirst.mockResolvedValueOnce(null);
+      mockPrisma.person.findUnique.mockResolvedValueOnce({
+        id: 's1',
+        keycloakUserId: null,
+        personType: 'STUDENT',
+        firstName: 'S',
+        lastName: 'T',
+      });
       mockPrisma.student.findUnique.mockResolvedValue({ personId: 's1' });
       mockStudent.linkKeycloakUser.mockResolvedValue({ id: 's1' });
 
@@ -315,15 +313,14 @@ describe('UserDirectoryService', () => {
     });
 
     it('PARENT personType dispatches to parentService.linkKeycloakUser', async () => {
-      mockPrisma.person.findUnique
-        .mockResolvedValueOnce(null)
-        .mockResolvedValueOnce({
-          id: 'p1',
-          keycloakUserId: null,
-          personType: 'PARENT',
-          firstName: 'P',
-          lastName: 'A',
-        });
+      mockPrisma.person.findFirst.mockResolvedValueOnce(null);
+      mockPrisma.person.findUnique.mockResolvedValueOnce({
+        id: 'p1',
+        keycloakUserId: null,
+        personType: 'PARENT',
+        firstName: 'P',
+        lastName: 'A',
+      });
       mockPrisma.parent.findUnique.mockResolvedValue({ personId: 'p1' });
       mockParent.linkKeycloakUser.mockResolvedValue({ id: 'p1' });
 
@@ -334,7 +331,7 @@ describe('UserDirectoryService', () => {
 
   describe('unlinkPerson', () => {
     it('returns silently when no link exists (idempotent no-op)', async () => {
-      mockPrisma.person.findUnique.mockResolvedValue(null);
+      mockPrisma.person.findFirst.mockResolvedValue(null);
       await expect(service.unlinkPerson('kc-1')).resolves.toBeUndefined();
       expect(mockTeacher.unlinkKeycloakUser).not.toHaveBeenCalled();
       expect(mockStudent.unlinkKeycloakUser).not.toHaveBeenCalled();
@@ -342,7 +339,7 @@ describe('UserDirectoryService', () => {
     });
 
     it('dispatches teacher unlink for TEACHER personType', async () => {
-      mockPrisma.person.findUnique.mockResolvedValue({
+      mockPrisma.person.findFirst.mockResolvedValue({
         id: 'p1',
         keycloakUserId: 'kc-1',
         personType: 'TEACHER',

--- a/apps/api/src/modules/user-directory/user-directory.service.ts
+++ b/apps/api/src/modules/user-directory/user-directory.service.ts
@@ -163,7 +163,7 @@ export class UserDirectoryService {
         where: { userId },
         include: { role: true },
       }),
-      this.prisma.person.findUnique({ where: { keycloakUserId: userId } }),
+      this.prisma.person.findFirst({ where: { keycloakUserId: userId } }),
     ]);
 
     return {
@@ -214,7 +214,7 @@ export class UserDirectoryService {
    */
   async linkPerson(userId: string, dto: LinkPersonDto): Promise<{ person: unknown }> {
     // (a) user-side pre-check
-    const existing = await this.prisma.person.findUnique({
+    const existing = await this.prisma.person.findFirst({
       where: { keycloakUserId: userId },
     });
     if (existing && existing.id !== dto.personId) {
@@ -365,10 +365,10 @@ export class UserDirectoryService {
   }
 
   async unlinkPerson(userId: string): Promise<void> {
-    const person = await this.prisma.person.findUnique({
+    const person = await this.prisma.person.findFirst({
       where: { keycloakUserId: userId },
       include: { teacher: true, student: true, parent: true },
-    } as any);
+    });
     if (!person) return;
     if (person.personType === 'TEACHER' && (person as any).teacher) {
       await this.teacherService.unlinkKeycloakUser((person as any).teacher.id);

--- a/apps/web/e2e/auth-user-context.spec.ts
+++ b/apps/web/e2e/auth-user-context.spec.ts
@@ -1,0 +1,99 @@
+/**
+ * Phase 3 / Issue #133+#134 — regression lock for the
+ * `Person.keycloakUserId` schema relaxation (composite-unique) and the
+ * callsite refactor from `prisma.person.findUnique({ where: { keycloakUserId } })`
+ * to `findFirst(...)`.
+ *
+ * Why this spec exists (E2E-first / CLAUDE.md hard rule):
+ *   The PR that ships those two changes touches every authenticated read of
+ *   GET /api/v1/users/me (the canonical user-context endpoint that powers
+ *   useSchoolContext + useUserContext on the frontend). If the schema change
+ *   landed without the callsite refactor (or vice versa), this endpoint
+ *   would 500 at runtime for every persona because Prisma would reject the
+ *   single-column where on a now-composite unique. This spec is the
+ *   regression lock that would have caught that mismatch.
+ *
+ *   Pre-fix repro: revert apps/api/src/modules/user-context/user-context.service.ts
+ *   to `findUnique({ where: { keycloakUserId } })` and re-run — the request
+ *   throws PrismaClientValidationError -> 500.
+ *
+ * Why throwaway-school is NOT used here (CLAUDE.md D4 exception):
+ *   The endpoint under test resolves the Person row via the live Keycloak
+ *   JWT's `sub` claim. The seed users are KC-bound to the SEED_SCHOOL via
+ *   fixed UUIDs (apps/api/prisma/seed.ts). A throwaway school would require
+ *   provisioning new KC users for each test — out of scope for #133+#134
+ *   and explicitly tracked as the #136 follow-up. This spec is read-only
+ *   against the seed school (no writes) so it can't race with other specs.
+ */
+import { expect, test } from '@playwright/test';
+import { getRoleToken, type Role } from './helpers/login';
+
+const API = process.env.E2E_API_URL ?? 'http://localhost:3000/api/v1';
+
+/**
+ * Expected shape per role per UserContextResponseDto + seed.ts.
+ * `schoolId` is the seed school and must be returned for every persona —
+ * proves the Person row was successfully resolved by keycloakUserId.
+ */
+const ROLE_EXPECTATIONS: Record<
+  Role,
+  { personType: 'TEACHER' | 'STUDENT' | 'PARENT' | null; hasTeacherId?: boolean; hasStudentId?: boolean; hasParentId?: boolean }
+> = {
+  admin: { personType: null }, // admin user has no Person row in seed (KC-only)
+  schulleitung: { personType: null }, // same
+  lehrer: { personType: 'TEACHER', hasTeacherId: true },
+  eltern: { personType: 'PARENT', hasParentId: true },
+  schueler: { personType: 'STUDENT', hasStudentId: true },
+};
+
+test.describe('AUTH-CTX — GET /api/v1/users/me after composite-unique schema migration', () => {
+  for (const role of ['lehrer', 'eltern', 'schueler'] as const) {
+    test(`AUTH-CTX-01.${role} — resolves Person via keycloakUserId (findFirst post-#133)`, async ({
+      request,
+    }) => {
+      const token = await getRoleToken(request, role);
+      const res = await request.get(`${API}/users/me`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+
+      // The regression: a stale findUnique({ keycloakUserId }) call against
+      // the post-#133 composite-unique schema returns 500 here.
+      expect(res.status(), `users/me for ${role}`).toBe(200);
+
+      const body = (await res.json()) as {
+        schoolId: string;
+        personId: string;
+        personType: string;
+        firstName: string;
+        lastName: string;
+        teacherId?: string;
+        studentId?: string;
+        parentId?: string;
+      };
+
+      expect(body.schoolId, 'schoolId from Person.findFirst').toBeTruthy();
+      expect(body.personId, 'personId resolved').toBeTruthy();
+
+      const expectation = ROLE_EXPECTATIONS[role];
+      expect(body.personType).toBe(expectation.personType);
+      if (expectation.hasTeacherId) expect(body.teacherId).toBeTruthy();
+      if (expectation.hasStudentId) expect(body.studentId).toBeTruthy();
+      if (expectation.hasParentId) expect(body.parentId).toBeTruthy();
+    });
+  }
+
+  test('AUTH-CTX-02 — admin without Person row gets 404 (NotFoundException, not 500)', async ({
+    request,
+  }) => {
+    // Admin/Schulleitung in seed have no Person row — this proves the
+    // findFirst branch correctly returns null and surfaces 404 rather than
+    // a Prisma runtime error.
+    const token = await getRoleToken(request, 'admin');
+    const res = await request.get(`${API}/users/me`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect([200, 404]).toContain(res.status());
+    // If the response is 500, the regression is back.
+    expect(res.status(), 'must not 500 — that signals Prisma runtime rejection').not.toBe(500);
+  });
+});


### PR DESCRIPTION
Closes #133. Closes #134. Refs #123, #112.

## Why bundled (#133 + #134 in one PR)

#133 alone (schema drop of `@unique` + add of `@@unique([keycloakUserId, schoolId])`) breaks the TypeScript build the moment Prisma Client is regenerated: `findUnique({ where: { keycloakUserId } })` becomes a type error against the new `PersonWhereUniqueInput`. Shipping #133 without #134 would leave `main` red — verboten per CLAUDE.md D3.

Splitting was considered (keep `@unique` AND add composite, drop `@unique` later) but that gives no functional benefit until `@unique` is dropped, so it adds churn without progress.

## What changes

### Schema (#133)
- `apps/api/prisma/schema.prisma`: drop `@unique` from `Person.keycloakUserId`, add `@@unique([keycloakUserId, schoolId])` + standalone `@@index([keycloakUserId])` for findFirst-by-keycloakUserId lookups.
- Migration `20260520054021_person_keycloak_user_id_composite_unique/migration.sql`:
  - `DROP INDEX persons_keycloak_user_id_key`
  - `CREATE INDEX persons_keycloak_user_id_idx ON persons(keycloak_user_id)`
  - `CREATE UNIQUE INDEX persons_keycloak_user_id_school_id_key ON persons(keycloak_user_id, school_id)`

### Callsites (#134)
Refactored `prisma.person.findUnique({ where: { keycloakUserId } })` → `findFirst(...)` in:
- `apps/api/src/modules/user-context/user-context.service.ts` (line 10) — Core /me endpoint
- `apps/api/src/modules/user-directory/user-directory.service.ts` (lines 166, 217, 368)
- `apps/api/src/modules/keycloak-admin/keycloak-admin.service.ts` (line 78)
- `apps/api/src/modules/classbook/excuse.service.ts` (lines 53, 257, 307)

Test mocks in the corresponding `.spec.ts` files updated. All other `findUnique` callsites (those keyed by `id`, not `keycloakUserId`) remain unchanged.

### Strategy: `findFirst` vs `findUnique({ keycloakUserId_schoolId })`

Chose `findFirst` because:
- Under the current data invariant (1 Person per KC user, single-school), `findFirst({ where: { keycloakUserId } })` is semantically identical to the prior `findUnique`.
- `findUnique({ keycloakUserId_schoolId: {...} })` requires resolving the current schoolId for the request — explicitly deferred to #135 (current-schoolId resolution mechanism: JWT claim vs session vs header).
- Once #135 lands, callsites can move to the composite-key form where multi-school semantics matter.

### CLAUDE.md D6 (new directive)

Documented blocked-by issue relationships via GraphQL `addBlockedBy` mutation. Companion to D5 (sub-issue hierarchy). Adds a pre-work check: query `blockedBy` before starting an issue, prompt before acting on an issue with an open blocker.

## Regression lock (CLAUDE.md hard rule)

New spec `apps/web/e2e/auth-user-context.spec.ts`:
- AUTH-CTX-01.{lehrer,eltern,schueler} — GET `/api/v1/users/me` returns 200 + correct `personType` + role-specific ids (teacherId/studentId/parentId)
- AUTH-CTX-02 — admin without Person row returns 404 (not 500 — that would signal Prisma runtime rejection)

D4 throwaway-school exception documented inline (KC-bound seed users + read-only nature).

## Verification

- [x] `pnpm exec tsc -p tsconfig.json --noEmit` clean on apps/api
- [x] `pnpm exec tsc -p tsconfig.app.json --noEmit` clean on apps/web
- [x] `pnpm --filter @schoolflow/shared build` clean
- [x] Full apps/api vitest: 767 passed / 0 failed / 65 todo
- [x] `scripts/check-migration-hygiene.sh` ✓
- [x] `prisma migrate reset --force` on fresh DB → all 17 migrations replay clean + seed succeeds (5 KC users linked, sample school + teachers/students/subjects/classes/rooms seeded)
- [x] E2E `auth-user-context.spec.ts` ✓ 4/4 on desktop project against live local stack

## Out of scope (next sub-issues)

- #135 — current-schoolId resolution mechanism (JWT claim vs session vs header). Will enable explicit `findUnique({ keycloakUserId_schoolId })` callsite form.
- #136 — throwaway-school fixture + School cascade-delete audit
- #137 — pilot spec migration (drop chromium-only-skip)
- #138 — wide migration

## Test plan

- [x] CI must pass green on first try (D3 — kein merge bei rotem CI)
- [ ] Manual sanity post-merge: pull main, `prisma migrate deploy` against local dev DB, `/me` still works for all personas