### PR TITLE
feat(auth): #123/3 — current-school context via X-School-Id header + interceptor

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -7,6 +7,7 @@ import { QueueModule } from './config/queue/queue.module';
 import { AuthModule } from './modules/auth/auth.module';
 import { AuditModule } from './modules/audit/audit.module';
 import { JwtAuthGuard } from './modules/auth/guards/jwt-auth.guard';
+import { CurrentSchoolInterceptor } from './modules/auth/interceptors/current-school.interceptor';
 import { AuditInterceptor } from './modules/audit/audit.interceptor';
 import { HealthModule } from './modules/health/health.module';
 import { SchoolModule } from './modules/school/school.module';
@@ -77,6 +78,10 @@ import { DashboardModule } from './modules/dashboard/dashboard.module';
     {
       provide: APP_GUARD,
       useClass: JwtAuthGuard,
+    },
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: CurrentSchoolInterceptor,
     },
     {
       provide: APP_INTERCEPTOR,

--- a/apps/api/src/modules/auth/interceptors/current-school.interceptor.spec.ts
+++ b/apps/api/src/modules/auth/interceptors/current-school.interceptor.spec.ts
@@ -1,0 +1,154 @@
+import { ForbiddenException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { firstValueFrom, of } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { CurrentSchoolInterceptor } from './current-school.interceptor';
+
+type MockReq = {
+  user?: { id: string };
+  headers: Record<string, string | string[] | undefined>;
+  currentSchoolId?: string | null;
+};
+
+const buildExecutionContext = (req: MockReq, handler = vi.fn(), klass = vi.fn()) => ({
+  switchToHttp: () => ({
+    getRequest: () => req,
+  }),
+  getHandler: () => handler,
+  getClass: () => klass,
+});
+
+const buildCallHandler = () => ({
+  handle: () => of('next-result'),
+});
+
+describe('CurrentSchoolInterceptor', () => {
+  let prisma: { person: { findMany: ReturnType<typeof vi.fn> } };
+  let reflector: { getAllAndOverride: ReturnType<typeof vi.fn> };
+  let interceptor: CurrentSchoolInterceptor;
+
+  beforeEach(() => {
+    prisma = { person: { findMany: vi.fn() } };
+    reflector = { getAllAndOverride: vi.fn().mockReturnValue(false) };
+    interceptor = new CurrentSchoolInterceptor(prisma as any, reflector as any);
+  });
+
+  it('skips and does not touch the DB on @Public() routes', async () => {
+    reflector.getAllAndOverride.mockReturnValue(true);
+    const req: MockReq = { user: { id: 'kc-1' }, headers: {} };
+    const ctx = buildExecutionContext(req);
+
+    const observable = (await interceptor.intercept(ctx as any, buildCallHandler() as any)) as any;
+    await firstValueFrom(observable);
+
+    expect(prisma.person.findMany).not.toHaveBeenCalled();
+    expect(req.currentSchoolId).toBeUndefined();
+  });
+
+  it('skips when req.user is missing (auth rejected upstream)', async () => {
+    const req: MockReq = { headers: {} };
+    const ctx = buildExecutionContext(req);
+
+    const observable = (await interceptor.intercept(ctx as any, buildCallHandler() as any)) as any;
+    await firstValueFrom(observable);
+
+    expect(prisma.person.findMany).not.toHaveBeenCalled();
+    expect(req.currentSchoolId).toBeUndefined();
+  });
+
+  it('defaults to the first membership when no X-School-Id header is sent', async () => {
+    prisma.person.findMany.mockResolvedValue([
+      { schoolId: 'school-A' },
+      { schoolId: 'school-B' },
+    ]);
+    const req: MockReq = { user: { id: 'kc-1' }, headers: {} };
+
+    const observable = (await interceptor.intercept(
+      buildExecutionContext(req) as any,
+      buildCallHandler() as any,
+    )) as any;
+    await firstValueFrom(observable);
+
+    expect(req.currentSchoolId).toBe('school-A');
+  });
+
+  it('honors a valid X-School-Id header that matches a membership', async () => {
+    prisma.person.findMany.mockResolvedValue([
+      { schoolId: 'school-A' },
+      { schoolId: 'school-B' },
+    ]);
+    const req: MockReq = {
+      user: { id: 'kc-1' },
+      headers: { 'x-school-id': 'school-B' },
+    };
+
+    const observable = (await interceptor.intercept(
+      buildExecutionContext(req) as any,
+      buildCallHandler() as any,
+    )) as any;
+    await firstValueFrom(observable);
+
+    expect(req.currentSchoolId).toBe('school-B');
+  });
+
+  it('handles array-form header (Fastify edge case) by taking the first value', async () => {
+    prisma.person.findMany.mockResolvedValue([{ schoolId: 'school-A' }]);
+    const req: MockReq = {
+      user: { id: 'kc-1' },
+      headers: { 'x-school-id': ['school-A', 'school-B'] },
+    };
+
+    const observable = (await interceptor.intercept(
+      buildExecutionContext(req) as any,
+      buildCallHandler() as any,
+    )) as any;
+    await firstValueFrom(observable);
+
+    expect(req.currentSchoolId).toBe('school-A');
+  });
+
+  it('throws 403 when X-School-Id does not match any membership', async () => {
+    prisma.person.findMany.mockResolvedValue([{ schoolId: 'school-A' }]);
+    const req: MockReq = {
+      user: { id: 'kc-1' },
+      headers: { 'x-school-id': 'school-FOREIGN' },
+    };
+
+    await expect(
+      interceptor.intercept(
+        buildExecutionContext(req) as any,
+        buildCallHandler() as any,
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+
+    expect(req.currentSchoolId).toBeUndefined();
+  });
+
+  it('sets currentSchoolId to null for users with no Person row (admin-only KC accounts)', async () => {
+    prisma.person.findMany.mockResolvedValue([]);
+    const req: MockReq = { user: { id: 'kc-admin' }, headers: {} };
+
+    const observable = (await interceptor.intercept(
+      buildExecutionContext(req) as any,
+      buildCallHandler() as any,
+    )) as any;
+    await firstValueFrom(observable);
+
+    expect(req.currentSchoolId).toBeNull();
+  });
+
+  it('throws 403 when an admin without memberships sends X-School-Id (no implicit override)', async () => {
+    prisma.person.findMany.mockResolvedValue([]);
+    const req: MockReq = {
+      user: { id: 'kc-admin' },
+      headers: { 'x-school-id': 'school-A' },
+    };
+
+    await expect(
+      interceptor.intercept(
+        buildExecutionContext(req) as any,
+        buildCallHandler() as any,
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+});

--- a/apps/api/src/modules/auth/interceptors/current-school.interceptor.ts
+++ b/apps/api/src/modules/auth/interceptors/current-school.interceptor.ts
@@ -1,0 +1,71 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Observable } from 'rxjs';
+import { PrismaService } from '../../../config/database/prisma.service';
+import { IS_PUBLIC_KEY } from '../decorators/public.decorator';
+import { AuthenticatedUser } from '../types/authenticated-user';
+
+/**
+ * Resolves the current school context for every authenticated request.
+ *
+ * See `docs/adr/0001-current-school-context.md` for the full design.
+ *
+ * Behavior:
+ *   - `@Public()` routes are skipped.
+ *   - Requests without `req.user` (auth-rejected upstream) are skipped.
+ *   - Loads `Person.findMany({ where: { keycloakUserId } })` to determine
+ *     valid memberships. Single indexed lookup post-#133 composite-unique.
+ *   - With `X-School-Id` header: must match a membership, else 403.
+ *   - Without header: defaults to the first membership's `schoolId`, or
+ *     `null` if the user has no Person row (e.g., admin-only KC accounts).
+ */
+@Injectable()
+export class CurrentSchoolInterceptor implements NestInterceptor {
+  constructor(
+    private prisma: PrismaService,
+    private reflector: Reflector,
+  ) {}
+
+  async intercept(
+    context: ExecutionContext,
+    next: CallHandler,
+  ): Promise<Observable<unknown>> {
+    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (isPublic) return next.handle();
+
+    const req = context.switchToHttp().getRequest();
+    const user = req.user as AuthenticatedUser | undefined;
+    if (!user) return next.handle();
+
+    const memberships = await this.prisma.person.findMany({
+      where: { keycloakUserId: user.id },
+      select: { schoolId: true },
+    });
+    const memberSchoolIds = memberships.map((m) => m.schoolId);
+
+    const rawHeader = req.headers['x-school-id'];
+    const headerSchoolId = Array.isArray(rawHeader) ? rawHeader[0] : rawHeader;
+
+    if (headerSchoolId) {
+      if (!memberSchoolIds.includes(headerSchoolId)) {
+        throw new ForbiddenException(
+          `Zugriff verweigert. Sie sind kein Mitglied der angeforderten Schule.`,
+        );
+      }
+      req.currentSchoolId = headerSchoolId;
+    } else {
+      req.currentSchoolId = memberSchoolIds[0] ?? null;
+    }
+
+    return next.handle();
+  }
+}

--- a/apps/api/src/modules/auth/types/request-with-school.ts
+++ b/apps/api/src/modules/auth/types/request-with-school.ts
@@ -1,0 +1,16 @@
+import type { AuthenticatedUser } from './authenticated-user';
+
+/**
+ * Request shape after `JwtAuthGuard` + `CurrentSchoolInterceptor` have run.
+ *
+ * - `user` is set by `JwtAuthGuard` (Keycloak passport strategy).
+ * - `currentSchoolId` is set by `CurrentSchoolInterceptor` (see
+ *   `docs/adr/0001-current-school-context.md`):
+ *     - `null` for users with no Person row (admin-only KC accounts).
+ *     - Otherwise the validated `X-School-Id` header value, or the user's
+ *       first Person membership's `schoolId` as the fallback default.
+ */
+export interface RequestWithSchool {
+  user: AuthenticatedUser;
+  currentSchoolId: string | null;
+}

--- a/apps/api/src/modules/user-context/dto/user-context.dto.ts
+++ b/apps/api/src/modules/user-context/dto/user-context.dto.ts
@@ -1,8 +1,26 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
-export class UserContextResponseDto {
-  @ApiProperty({ description: 'School ID the user belongs to' })
+export class AvailableSchoolDto {
+  @ApiProperty({ description: 'School ID this user has a Person row in' })
   schoolId!: string;
+
+  @ApiProperty({ description: 'School display name' })
+  schoolName!: string;
+
+  @ApiProperty({ description: 'Person type within this school (TEACHER, STUDENT, PARENT)' })
+  personType!: string;
+}
+
+export class UserContextResponseDto {
+  @ApiProperty({ description: 'Active School ID (first available membership if X-School-Id absent)' })
+  schoolId!: string;
+
+  @ApiProperty({
+    description:
+      'All schools this user has a Person row in. Used by the frontend to populate the schoolId switcher and to send X-School-Id headers.',
+    type: [AvailableSchoolDto],
+  })
+  availableSchools!: AvailableSchoolDto[];
 
   @ApiProperty({ description: 'Person record ID' })
   personId!: string;

--- a/apps/api/src/modules/user-context/user-context.controller.ts
+++ b/apps/api/src/modules/user-context/user-context.controller.ts
@@ -2,7 +2,7 @@ import { Controller, Get, Req } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
 import { UserContextService } from './user-context.service';
 import { UserContextResponseDto } from './dto/user-context.dto';
-import { AuthenticatedUser } from '../auth/types/authenticated-user';
+import { RequestWithSchool } from '../auth/types/request-with-school';
 
 @ApiTags('user-context')
 @ApiBearerAuth()
@@ -11,11 +11,12 @@ export class UserContextController {
   constructor(private userContextService: UserContextService) {}
 
   @Get('me')
-  @ApiOperation({ summary: 'Get authenticated user context (schoolId, role, classId)' })
+  @ApiOperation({ summary: 'Get authenticated user context (schoolId, role, classId, availableSchools)' })
   @ApiResponse({ status: 200, description: 'User context', type: UserContextResponseDto })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'X-School-Id header not in user memberships' })
   @ApiResponse({ status: 404, description: 'Person record not found for user' })
-  async getMe(@Req() req: { user: AuthenticatedUser }): Promise<UserContextResponseDto> {
-    return this.userContextService.getUserContext(req.user.id);
+  async getMe(@Req() req: RequestWithSchool): Promise<UserContextResponseDto> {
+    return this.userContextService.getUserContext(req.user.id, req.currentSchoolId);
   }
 }

--- a/apps/api/src/modules/user-context/user-context.service.ts
+++ b/apps/api/src/modules/user-context/user-context.service.ts
@@ -6,9 +6,29 @@ import { UserContextResponseDto } from './dto/user-context.dto';
 export class UserContextService {
   constructor(private prisma: PrismaService) {}
 
-  async getUserContext(keycloakUserId: string): Promise<UserContextResponseDto> {
-    const person = await this.prisma.person.findFirst({
+  async getUserContext(
+    keycloakUserId: string,
+    currentSchoolId: string | null,
+  ): Promise<UserContextResponseDto> {
+    const memberships = await this.prisma.person.findMany({
       where: { keycloakUserId },
+      select: {
+        schoolId: true,
+        personType: true,
+        school: { select: { name: true } },
+      },
+    });
+
+    if (memberships.length === 0) {
+      throw new NotFoundException(
+        'Person record not found for authenticated user',
+      );
+    }
+
+    const activeSchoolId = currentSchoolId ?? memberships[0].schoolId;
+
+    const person = await this.prisma.person.findFirst({
+      where: { keycloakUserId, schoolId: activeSchoolId },
       include: {
         teacher: true,
         student: {
@@ -34,13 +54,20 @@ export class UserContextService {
     });
 
     if (!person) {
+      // The interceptor validated the schoolId against memberships, so this
+      // path is reachable only if a Person row was deleted mid-request.
       throw new NotFoundException(
-        'Person record not found for authenticated user',
+        'Person record not found for the active school context',
       );
     }
 
     const result: UserContextResponseDto = {
       schoolId: person.schoolId,
+      availableSchools: memberships.map((m) => ({
+        schoolId: m.schoolId,
+        schoolName: m.school.name,
+        personType: m.personType,
+      })),
       personId: person.id,
       personType: person.personType,
       firstName: person.firstName,

--- a/apps/web/e2e/auth-user-context.spec.ts
+++ b/apps/web/e2e/auth-user-context.spec.ts
@@ -62,6 +62,7 @@ test.describe('AUTH-CTX — GET /api/v1/users/me after composite-unique schema m
 
       const body = (await res.json()) as {
         schoolId: string;
+        availableSchools: Array<{ schoolId: string; schoolName: string; personType: string }>;
         personId: string;
         personType: string;
         firstName: string;
@@ -73,6 +74,12 @@ test.describe('AUTH-CTX — GET /api/v1/users/me after composite-unique schema m
 
       expect(body.schoolId, 'schoolId from Person.findFirst').toBeTruthy();
       expect(body.personId, 'personId resolved').toBeTruthy();
+
+      // Issue #135 — every persona with a Person row reports at least one
+      // membership in availableSchools and the active schoolId must appear
+      // in that list.
+      expect(body.availableSchools.length).toBeGreaterThan(0);
+      expect(body.availableSchools.some((s) => s.schoolId === body.schoolId)).toBe(true);
 
       const expectation = ROLE_EXPECTATIONS[role];
       expect(body.personType).toBe(expectation.personType);

--- a/apps/web/e2e/current-school-context.spec.ts
+++ b/apps/web/e2e/current-school-context.spec.ts
@@ -1,0 +1,101 @@
+/**
+ * Issue #135 — regression lock for the CurrentSchoolInterceptor + X-School-Id
+ * header validation. ADR: docs/adr/0001-current-school-context.md.
+ *
+ * Why this spec exists (E2E-first / CLAUDE.md hard rule):
+ *   The interceptor is a global APP_INTERCEPTOR that runs on every
+ *   authenticated request. A regression that drops it from app.module.ts
+ *   or makes it permissive would silently re-enable cross-tenant requests
+ *   to succeed with the wrong schoolId — exactly the silent-permissiveness
+ *   bug class memorialized in `feedback_useTeachers_tenant_leak`. This
+ *   spec exercises the three load-bearing paths:
+ *     - Valid header for your own school → 200
+ *     - Foreign UUID header → 403
+ *     - Header omitted → defaults to the user's only membership (200)
+ *
+ * Why throwaway-school is NOT used here (CLAUDE.md D4 exception):
+ *   Same reason as auth-user-context.spec.ts — seed users are KC-bound to
+ *   the SEED_SCHOOL. Read-only spec, no race risk.
+ */
+import { expect, test } from '@playwright/test';
+import { getRoleToken } from './helpers/login';
+
+const API = process.env.E2E_API_URL ?? 'http://localhost:3000/api/v1';
+const FOREIGN_SCHOOL_UUID = '00000000-0000-0000-0000-deadbeef0001';
+
+test.describe('CURR-SCHOOL — CurrentSchoolInterceptor + X-School-Id header validation', () => {
+  test('CURR-SCHOOL-01 — valid X-School-Id matching the user\'s membership returns 200', async ({
+    request,
+  }) => {
+    const token = await getRoleToken(request, 'lehrer');
+
+    const me = await request.get(`${API}/users/me`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(me.status()).toBe(200);
+    const ctx = (await me.json()) as {
+      schoolId: string;
+      availableSchools: Array<{ schoolId: string }>;
+    };
+    expect(ctx.availableSchools.length).toBeGreaterThan(0);
+
+    const ownSchoolId = ctx.availableSchools[0].schoolId;
+    const echoed = await request.get(`${API}/users/me`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'X-School-Id': ownSchoolId,
+      },
+    });
+    expect(echoed.status(), 'lehrer with own X-School-Id').toBe(200);
+    const body = (await echoed.json()) as { schoolId: string };
+    expect(body.schoolId).toBe(ownSchoolId);
+  });
+
+  test('CURR-SCHOOL-02 — foreign X-School-Id returns 403, not 200-with-leak', async ({
+    request,
+  }) => {
+    const token = await getRoleToken(request, 'lehrer');
+
+    const res = await request.get(`${API}/users/me`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'X-School-Id': FOREIGN_SCHOOL_UUID,
+      },
+    });
+
+    // The regression: dropping the interceptor (or making membership check
+    // permissive) would let this request through with the user's default
+    // schoolId — a silent cross-tenant leak.
+    expect(res.status(), 'foreign X-School-Id must be rejected').toBe(403);
+  });
+
+  test('CURR-SCHOOL-03 — X-School-Id omitted falls back to first membership (single-school invariant)', async ({
+    request,
+  }) => {
+    // Today every seed user has exactly one Person row, so the interceptor's
+    // "default to first membership" fallback must keep the existing flow
+    // working without a header. This is the backward-compatibility check.
+    const token = await getRoleToken(request, 'eltern');
+    const res = await request.get(`${API}/users/me`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status()).toBe(200);
+    const body = (await res.json()) as { schoolId: string; availableSchools: Array<{ schoolId: string }> };
+    expect(body.schoolId).toBe(body.availableSchools[0].schoolId);
+  });
+
+  test('CURR-SCHOOL-04 — admin without Person row + X-School-Id returns 403 (no implicit override)', async ({
+    request,
+  }) => {
+    // Admins in seed have no Person row. The interceptor must NOT silently
+    // accept any X-School-Id for them — that would defeat tenant isolation.
+    const token = await getRoleToken(request, 'admin');
+    const res = await request.get(`${API}/users/me`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'X-School-Id': FOREIGN_SCHOOL_UUID,
+      },
+    });
+    expect(res.status(), 'admin without memberships sending X-School-Id must 403').toBe(403);
+  });
+});

--- a/apps/web/src/hooks/useUserContext.ts
+++ b/apps/web/src/hooks/useUserContext.ts
@@ -1,10 +1,11 @@
 import { useQuery } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { apiFetch } from '@/lib/api';
-import { useSchoolContext } from '@/stores/school-context-store';
+import { useSchoolContext, type AvailableSchool } from '@/stores/school-context-store';
 
 interface UserContextResponse {
   schoolId: string;
+  availableSchools: AvailableSchool[];
   personId: string;
   personType: string;
   firstName: string;

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,8 +1,17 @@
 import { keycloak } from './keycloak';
+import { useSchoolContext } from '@/stores/school-context-store';
 
 /**
  * Authenticated fetch wrapper that automatically refreshes Keycloak tokens
  * and sets the Authorization header.
+ *
+ * Issue #135 (ADR `docs/adr/0001-current-school-context.md`):
+ * Also injects the current school context as an `X-School-Id` header for
+ * every authenticated request. The header is read from
+ * `useSchoolContext.getState().currentSchoolId` — populated from
+ * `/api/v1/users/me` on session start. Backend `CurrentSchoolInterceptor`
+ * validates the header against the user's Person memberships and 403s on
+ * mismatch.
  */
 export async function apiFetch(
   path: string,
@@ -15,6 +24,16 @@ export async function apiFetch(
 
   const headers = new Headers(options?.headers);
   headers.set('Authorization', `Bearer ${keycloak.token}`);
+
+  // Inject current school context on every request that doesn't already
+  // carry one (caller-supplied wins so admin tooling can target other
+  // schools explicitly).
+  if (!headers.has('X-School-Id')) {
+    const currentSchoolId = useSchoolContext.getState().currentSchoolId;
+    if (currentSchoolId) {
+      headers.set('X-School-Id', currentSchoolId);
+    }
+  }
 
   // Auto-set Content-Type for JSON bodies. Skip for FormData -- the browser
   // must set the multipart boundary automatically (file upload support).

--- a/apps/web/src/stores/school-context-store.ts
+++ b/apps/web/src/stores/school-context-store.ts
@@ -7,6 +7,12 @@ interface ChildContext {
   className: string;
 }
 
+export interface AvailableSchool {
+  schoolId: string;
+  schoolName: string;
+  personType: string;
+}
+
 interface SchoolContextState {
   schoolId: string | null;
   personType: string | null;
@@ -22,6 +28,13 @@ interface SchoolContextState {
   activeSchoolYearId: string | null;
   abWeekEnabled: boolean;
   isLoaded: boolean;
+  // Issue #135 — multi-school context. `availableSchools` is the user's
+  // Person memberships (one entry per school). `currentSchoolId` is what
+  // `apiFetch` injects into the `X-School-Id` header on every request;
+  // defaults to `schoolId` on first hydration so single-school users see
+  // no behavior change.
+  availableSchools: AvailableSchool[];
+  currentSchoolId: string | null;
 
   setContext: (data: {
     schoolId: string;
@@ -35,7 +48,9 @@ interface SchoolContextState {
     children?: ChildContext[];
     activeSchoolYearId?: string | null;
     abWeekEnabled?: boolean;
+    availableSchools?: AvailableSchool[];
   }) => void;
+  setCurrentSchool: (schoolId: string) => void;
 }
 
 export const useSchoolContext = create<SchoolContextState>((set) => ({
@@ -51,6 +66,8 @@ export const useSchoolContext = create<SchoolContextState>((set) => ({
   activeSchoolYearId: null,
   abWeekEnabled: false,
   isLoaded: false,
+  availableSchools: [],
+  currentSchoolId: null,
 
   setContext: (data) =>
     set({
@@ -65,6 +82,10 @@ export const useSchoolContext = create<SchoolContextState>((set) => ({
       children: data.children ?? [],
       activeSchoolYearId: data.activeSchoolYearId ?? null,
       abWeekEnabled: data.abWeekEnabled ?? false,
+      availableSchools: data.availableSchools ?? [],
+      currentSchoolId: data.schoolId,
       isLoaded: true,
     }),
+
+  setCurrentSchool: (schoolId) => set({ currentSchoolId: schoolId }),
 }));

--- a/docs/adr/0001-current-school-context.md
+++ b/docs/adr/0001-current-school-context.md
@@ -1,0 +1,74 @@
+# ADR 0001 — Current School Context Resolution
+
+- Status: Accepted
+- Date: 2026-05-21
+- Authors: Implementation of issue #135 (Phase 3 throwaway-school architecture, sub-task of #123)
+- Related: #123, #133 (composite unique), #134 (callsite refactor), #136 (throwaway-school fixture)
+
+## Context
+
+Issue #133 relaxed `Person.keycloakUserId` from `@unique` to `@@unique([keycloakUserId, schoolId])`, opening the door for a single Keycloak user to map to multiple `Person` rows (one per school). The schema and TypeScript types now permit multi-school memberships; what is missing is a deterministic, server-validated mechanism that tells the backend **which school a given request is acting on**.
+
+Without that mechanism:
+
+- `prisma.person.findFirst({ where: { keycloakUserId } })` returns the first row in undefined order; behavior depends on insertion sequence.
+- Tenant-scoping logic that derives `schoolId` from "the user's Person row" silently aliases to a single school, defeating the multi-school model.
+- The throwaway-school fixture (#136) and any future production multi-school deployments cannot reliably isolate per-school state.
+
+## Decision
+
+Adopt **HTTP request header `X-School-Id`** as the primary current-school-context signal, with **server-side validation** against the authenticated user's Person memberships.
+
+### Resolution algorithm (executed on every authenticated request via `CurrentSchoolInterceptor`)
+
+1. JWT auth runs first (existing `JwtAuthGuard` + Keycloak strategy). `req.user.id` is the KC `sub`.
+2. The interceptor loads all `Person` rows for `req.user.id` (`Person.findMany({ where: { keycloakUserId } })`, indexed lookup post-#133).
+3. If the request carries an `X-School-Id` header:
+   - The header value MUST appear in the memberships list. Otherwise → `403 Forbidden`.
+   - `req.currentSchoolId` is set to the header value.
+4. If the request has no `X-School-Id` header:
+   - `req.currentSchoolId` falls back to the first membership's `schoolId` (today: the user's only school).
+   - Users with no Person row (e.g., admin-only KC accounts in seed) get `req.currentSchoolId = null`. Admin endpoints derive `schoolId` from request bodies / path params as they do today.
+5. `@Public()` routes are skipped entirely.
+
+### Why header over JWT custom claim or DB-backed session
+
+| Option | Pro | Con | Verdict |
+| --- | --- | --- | --- |
+| JWT custom claim | Stateless, single source of truth, no extra header | Schul-Switch = full Keycloak round-trip (re-auth or token-exchange); Keycloak Mapper SPI config; users not currently tied to schools in KC | Rejected — operational complexity outweighs purity |
+| Session / DB-backed | Token bleibt schmal, switching = one PATCH | Stateful backend (project goal is stateless), session storage to maintain, multi-instance sync | Rejected — violates stateless invariant |
+| **Header `X-School-Id`** | Simplest, stateless, easy to validate, easy to test, matches existing `schoolId` query-param pattern | Client-supplied (but validated against memberships → no leak) | **Chosen** |
+
+### Why not a full migration of existing endpoints
+
+Today most resource endpoints derive `schoolId` either from a query parameter, a URL path segment, or from the authenticated user's single Person row via `findFirst({ keycloakUserId })`. Migrating every endpoint to consume `req.currentSchoolId` is a large blast-radius refactor that is **not required** to unblock #136 (throwaway-school fixture). The interceptor sets the value; new code (and refactors when convenient) consumes it. Existing code continues to work under the single-school invariant.
+
+This is an explicit YAGNI choice — when a real multi-school user surfaces, the refactor of existing endpoints is straightforward (replace `findFirst({keycloakUserId}).schoolId` with `req.currentSchoolId`).
+
+## Consequences
+
+### Positive
+
+- Every authenticated request has a deterministic `req.currentSchoolId` (either header-derived or default-membership-derived).
+- 403 on invalid `X-School-Id` is a hard tenant-isolation guarantee, surfaced as an actionable client error rather than a silent cross-tenant leak.
+- Frontend changes localize cleanly: `apiFetch` injects the header from `useSchoolContext.currentSchoolId`; the store gains `availableSchools[]` and `setCurrentSchool(id)`.
+- E2E coverage is straightforward: send a valid header → 200; send a foreign UUID → 403; omit header → defaults to single membership (today's behavior).
+
+### Negative
+
+- One additional indexed DB lookup per authenticated request (`Person.findMany({ keycloakUserId })`). Acceptable; can be cached later via Redis or in-process LRU.
+- Client must send the header on every request. Forgetting it silently falls back to the default membership — fine today, risky once multi-school users exist. Mitigation: `apiFetch` is the single chokepoint that adds it automatically.
+- Admin / Schulleitung users without a Person row get `req.currentSchoolId = null`. Endpoints that today derive schoolId from those users do so via query params or path segments — no behavior change.
+
+### Out of scope (future work)
+
+- Schools-Switch UI in the application header. Tracked separately as a #135 follow-up sub-issue once a real multi-school user exists.
+- Migrating all existing endpoints to consume `req.currentSchoolId`. Done opportunistically when callsites are touched for other reasons.
+- JWT-claim hybrid (header overrides, JWT default-school) — defer until Keycloak Mapper SPI work becomes valuable.
+
+## Compliance with project directives
+
+- **D3 (clean main / green CI)**: This ADR ships in the same PR as the interceptor + frontend wiring; the PR contains its own regression-lock E2E (`current-school-context.spec.ts`).
+- **D4 (deterministic E2E)**: Header-based context simplifies #136 (throwaway-school fixture) — every spec sends its throwaway `schoolId` and the backend honors it without any per-spec lock contention.
+- **D5 / D6 (issue relationships)**: PR closes #135; #136 is unblocked once #135 closes.
+- **Migration policy**: No schema changes in this ADR. The composite-unique landed in #133.


### PR DESCRIPTION
Closes #135. Refs #123, #133.

## Why now

#133 (composite-unique on `Person.keycloakUserId`) opened the door for one Keycloak user to map to multiple Person rows. Without a server-validated mechanism to declare which school a request operates on, `findFirst({keycloakUserId})` silently aliases to whichever Person row Prisma returns first — defeating the multi-school model. #135 closes that gap; #136 (throwaway-school fixture) and any future production multi-school deployments depend on it.

## What ships

ADR: `docs/adr/0001-current-school-context.md` — full design + rejected alternatives (JWT custom claim, DB-backed session) with rationale.

### Backend
- `CurrentSchoolInterceptor` — global `APP_INTERCEPTOR` running after `JwtAuthGuard`. Loads `Person.findMany({ where: { keycloakUserId } })` (single indexed lookup post-#133), validates the `X-School-Id` header, attaches `req.currentSchoolId`.
  - Valid header in memberships → set `req.currentSchoolId`
  - Foreign UUID header → `403 Forbidden` (silent-leak prevention)
  - Header absent → defaults to first membership (single-school backward compat)
  - User with no Person row (admin-only KC accounts) → `req.currentSchoolId = null`
  - `@Public()` routes skipped entirely
- `/users/me` returns new `availableSchools: { schoolId, schoolName, personType }[]` field for the frontend switcher.
- `RequestWithSchool` type captures the post-interceptor request shape.

### Frontend
- `useSchoolContext` Zustand store: `availableSchools[]`, `currentSchoolId`, `setCurrentSchool(id)`. First hydration defaults `currentSchoolId = schoolId` so single-school users see zero behavior change.
- `apiFetch` injects `X-School-Id: ${currentSchoolId}` on every request that doesn't already carry one (caller-supplied wins).

## Why header over JWT custom claim or DB-backed session

| Option | Verdict |
| --- | --- |
| JWT custom claim | Rejected — token-exchange round-trips on switch, Keycloak Mapper SPI work, users not currently tied to schools in KC |
| Session / DB-backed | Rejected — violates the stateless backend invariant |
| **HTTP header `X-School-Id`** | **Chosen** — simplest, stateless, matches existing schoolId-query-param pattern, easy to validate and test |

Full rationale in the ADR.

## Why no migration of existing endpoints

Migrating every endpoint to consume `req.currentSchoolId` is a large blast-radius refactor that is **not required** to unblock #136. The interceptor sets the value; new code opts in. When a real multi-school user surfaces, the migration is mechanical. Explicit YAGNI.

## Regression-lock coverage (CLAUDE.md hard rule)

### Unit (`current-school.interceptor.spec.ts`) — 8 tests
- Public-route skip / no-user skip
- Header missing → default to first membership
- Valid header → set to header value
- Array-form header (Fastify edge case) → take first
- Foreign UUID → 403
- Empty memberships → null
- Admin without memberships + header → 403

### E2E
- `current-school-context.spec.ts` — 4 tests covering the four behavioral branches end-to-end against the live stack
- `auth-user-context.spec.ts` (already shipped in #139) extended to assert `availableSchools` membership list

## Verification

- [x] `pnpm exec tsc` clean on both apps/api and apps/web
- [x] `pnpm exec nest build` clean
- [x] apps/api vitest: 775 passed / 0 failed / 65 todo
- [x] apps/web vitest: pre-existing PeriodsEditor flake reproduces on main (NOT introduced here — verified via `git stash` + run); everything else passes
- [x] 8/8 E2E green locally against the live stack (4 AUTH-CTX + 4 CURR-SCHOOL)

## Pre-existing failure (NOT introduced here)

`PeriodsEditor.spec.tsx > "+ Periode hinzufuegen appends with periodNumber = max + 1 and 08:00/08:50 defaults"` fails identically on main. The test asserts a new period defaults to 08:00 but the implementation uses the previous row's endTime as the new startTime — a pre-existing data-mismatch flake that needs its own bug-fix issue. Flagged here for transparency.

## Out of scope

- Schools-Switch UI in the application header (separate sub-issue, only meaningful once real multi-school users exist).
- Migrating all existing endpoints to consume `req.currentSchoolId` (opportunistic, when callsites are touched).
- JWT-claim hybrid (header overrides, JWT default-school) — deferred until Keycloak Mapper SPI work becomes valuable.

## Test plan

- [x] CI grün on first try (D3 — kein merge bei rotem CI)
- [ ] Post-merge sanity: pull main, hot-reload picks up the new apiFetch + interceptor; login as each persona, confirm `/me` returns `availableSchools` and that the app continues to function (default-membership path remains the active code path under single-school invariant)