### PR TITLE
feat(e2e): #123/4 — throwaway-school fixture + complete School cascade audit

### DIFF
--- a/apps/api/prisma/migrations/20260521195949_school_cascade_complete/migration.sql
+++ b/apps/api/prisma/migrations/20260521195949_school_cascade_complete/migration.sql
@@ -1,0 +1,35 @@
+-- Issue #136 — Complete onDelete: Cascade coverage for all School FKs so
+-- `prisma.school.delete()` in the throwaway-school fixture wipes every
+-- per-school row without FK violations. Audited 5 gaps (homework, exams,
+-- import_jobs, calendar_tokens, sis_api_keys) — all other tables with
+-- school_id already had cascade.
+
+-- DropForeignKey
+ALTER TABLE "calendar_tokens" DROP CONSTRAINT "calendar_tokens_school_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "exams" DROP CONSTRAINT "exams_school_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "homework" DROP CONSTRAINT "homework_school_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "import_jobs" DROP CONSTRAINT "import_jobs_school_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "sis_api_keys" DROP CONSTRAINT "sis_api_keys_school_id_fkey";
+
+-- AddForeignKey
+ALTER TABLE "homework" ADD CONSTRAINT "homework_school_id_fkey" FOREIGN KEY ("school_id") REFERENCES "schools"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "exams" ADD CONSTRAINT "exams_school_id_fkey" FOREIGN KEY ("school_id") REFERENCES "schools"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "import_jobs" ADD CONSTRAINT "import_jobs_school_id_fkey" FOREIGN KEY ("school_id") REFERENCES "schools"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "calendar_tokens" ADD CONSTRAINT "calendar_tokens_school_id_fkey" FOREIGN KEY ("school_id") REFERENCES "schools"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "sis_api_keys" ADD CONSTRAINT "sis_api_keys_school_id_fkey" FOREIGN KEY ("school_id") REFERENCES "schools"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -1425,7 +1425,7 @@ model Homework {
 
   classSubject     ClassSubject   @relation(fields: [classSubjectId], references: [id])
   classBookEntry   ClassBookEntry? @relation(fields: [classBookEntryId], references: [id], onDelete: SetNull)
-  school           School         @relation(fields: [schoolId], references: [id])
+  school           School         @relation(fields: [schoolId], references: [id], onDelete: Cascade)
 
   @@index([classSubjectId, dueDate])
   @@index([schoolId])
@@ -1449,7 +1449,7 @@ model Exam {
 
   classSubject   ClassSubject @relation(fields: [classSubjectId], references: [id])
   schoolClass    SchoolClass  @relation(fields: [classId], references: [id])
-  school         School       @relation(fields: [schoolId], references: [id])
+  school         School       @relation(fields: [schoolId], references: [id], onDelete: Cascade)
 
   @@index([classId, date])
   @@index([classSubjectId])
@@ -1480,7 +1480,7 @@ model ImportJob {
   completedAt    DateTime?          @map("completed_at")
   createdAt      DateTime           @default(now()) @map("created_at")
 
-  school         School             @relation(fields: [schoolId], references: [id])
+  school         School             @relation(fields: [schoolId], references: [id], onDelete: Cascade)
 
   @@index([schoolId, createdAt])
   @@map("import_jobs")
@@ -1495,7 +1495,7 @@ model CalendarToken {
   token     String   @unique
   createdAt DateTime @default(now()) @map("created_at")
 
-  school    School   @relation(fields: [schoolId], references: [id])
+  school    School   @relation(fields: [schoolId], references: [id], onDelete: Cascade)
 
   @@index([userId])
   @@map("calendar_tokens")
@@ -1513,7 +1513,7 @@ model SisApiKey {
   createdBy String    @map("created_by")
   createdAt DateTime  @default(now()) @map("created_at")
 
-  school    School    @relation(fields: [schoolId], references: [id])
+  school    School    @relation(fields: [schoolId], references: [id], onDelete: Cascade)
 
   @@index([schoolId])
   @@map("sis_api_keys")

--- a/apps/web/e2e/fixtures/throwaway-school.ts
+++ b/apps/web/e2e/fixtures/throwaway-school.ts
@@ -1,0 +1,254 @@
+/**
+ * Issue #136 — Throwaway-school fixture.
+ *
+ * Provides per-spec isolation via a freshly-created `School` row + minimal
+ * stammdaten (active SchoolYear + optional SchoolClasses) + optional Person
+ * rows for the seed Keycloak users so a spec can act as `lehrer`, `eltern`,
+ * etc. against the throwaway school instead of writing to the shared
+ * SEED_SCHOOL.
+ *
+ * Why "reuse seed KC users + per-school Person rows" (Option B):
+ *   - Avoids the operational cost of provisioning fresh Keycloak users via
+ *     the admin REST API per spec (admin token + create + set password +
+ *     delete on teardown).
+ *   - Leverages #135's CurrentSchoolInterceptor + X-School-Id header:
+ *     once a Person row exists for a seed KC user in the throwaway school,
+ *     `availableSchools` returns both memberships and the spec switches
+ *     context by sending `X-School-Id: <throwawayId>` (browser apiFetch
+ *     does this automatically once `setCurrentSchool` is called).
+ *   - Schema-safe: #133's `@@unique([keycloakUserId, schoolId])` permits
+ *     the same KC user to map to multiple Person rows.
+ *
+ * Cleanup contract: `prisma.school.delete({ where: { id } })` cascades
+ * across every per-school table — verified by the #136 cascade audit that
+ * closed the 5 remaining gaps (Homework, Exam, ImportJob, CalendarToken,
+ * SisApiKey). The cascade chain reaches Person rows automatically, so the
+ * seed Person rows on SEED_SCHOOL are NEVER touched.
+ *
+ * Prisma 7 + dotenv plumbing: copied from `fixtures/orphan-year.ts` so the
+ * Playwright runner picks up `DATABASE_URL` from the repo-root .env even
+ * when CWD=apps/web. The PrismaPg adapter is the Prisma 7 successor of the
+ * legacy `datasources: { db: { url } }` option (deferred-items §1c, 10.4 D-3).
+ */
+import 'dotenv/config';
+import { config as dotenvConfig } from 'dotenv';
+import { createRequire } from 'node:module';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { SEED_SCHOOL_UUID } from './seed-uuids';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+dotenvConfig({ path: path.resolve(__dirname, '../../../../.env') });
+
+const require = createRequire(import.meta.url);
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { PrismaClient } = require('../../../api/dist/config/database/generated/client.js') as {
+  PrismaClient: new (opts?: { adapter?: unknown }) => {
+    person: {
+      findFirst: (args: any) => Promise<any>;
+      create: (args: any) => Promise<{ id: string; keycloakUserId: string | null; schoolId: string }>;
+    };
+    school: {
+      create: (args: any) => Promise<{ id: string; name: string }>;
+      delete: (args: any) => Promise<unknown>;
+      findUnique: (args: any) => Promise<any>;
+    };
+    schoolYear: {
+      create: (args: any) => Promise<{ id: string }>;
+    };
+    schoolClass: {
+      create: (args: any) => Promise<{ id: string; name: string }>;
+    };
+    $disconnect: () => Promise<void>;
+  };
+};
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { PrismaPg } = require('../../../api/node_modules/@prisma/adapter-pg') as {
+  PrismaPg: new (opts: { connectionString: string }) => unknown;
+};
+
+const buildPrisma = () =>
+  new PrismaClient({
+    adapter: new PrismaPg({ connectionString: process.env.DATABASE_URL ?? '' }),
+  });
+
+/** Maps seed-bound Keycloak roles to Prisma `PersonType` enum values. */
+type SeedRole = 'lehrer' | 'schulleitung' | 'schueler' | 'eltern';
+const ROLE_TO_PERSON_TYPE: Record<SeedRole, 'TEACHER' | 'STUDENT' | 'PARENT'> = {
+  lehrer: 'TEACHER',
+  schulleitung: 'TEACHER',
+  schueler: 'STUDENT',
+  eltern: 'PARENT',
+};
+
+export interface ThrowawaySchoolOptions {
+  /** Seed-KC roles that should receive a Person row in the throwaway school. */
+  roles?: Partial<Record<SeedRole, boolean>>;
+  /** Number of SchoolClasses to seed (default 1). */
+  withClasses?: number;
+  /** Prefix for the school's name + class names — keeps cross-spec greps trivial. */
+  namePrefix?: string;
+}
+
+export interface ThrowawaySchoolFixture {
+  schoolId: string;
+  schoolName: string;
+  schoolYearId: string;
+  classIds: string[];
+  /** Person row IDs created for each seed-KC role in the throwaway school. */
+  personIds: Partial<Record<SeedRole, string>>;
+  /** Keycloak user IDs (the seed-bound `sub` claim values) for each seed role used. */
+  keycloakUserIds: Partial<Record<SeedRole, string>>;
+  cleanup: () => Promise<void>;
+}
+
+/**
+ * Look up the seed-bound Keycloak user IDs by querying the SEED_SCHOOL
+ * Person rows. The seed runner (`apps/api/prisma/seed.ts`) resolves the
+ * KC `sub` from Keycloak at seed-time and writes it onto exactly one Person
+ * per role on SEED_SCHOOL. This avoids re-implementing the Keycloak
+ * admin-token + user-list dance in test code.
+ */
+async function resolveSeedKeycloakIds(
+  prisma: ReturnType<typeof buildPrisma>,
+  roles: SeedRole[],
+): Promise<Partial<Record<SeedRole, string>>> {
+  const out: Partial<Record<SeedRole, string>> = {};
+  for (const role of roles) {
+    // Lehrer + Schulleitung are both TEACHER personType. Disambiguate by
+    // joining through Teacher first (KC lehrer is bound to SEED_TEACHER_KC_LEHRER_UUID)
+    // — but easier: each KC role binds to a distinct Person.id (seed-uuids.ts
+    // SEED_PERSON_KC_*). Query by `id` for unambiguous resolution.
+    const personIdByRole: Record<SeedRole, string> = {
+      lehrer: 'd0000000-0000-4000-8000-000000000001',
+      schulleitung: 'd0000000-0000-4000-8000-000000000002',
+      schueler: 'd0000000-0000-4000-8000-000000000004',
+      eltern: 'd0000000-0000-4000-8000-000000000005',
+    };
+    const seedPerson = await prisma.person.findFirst({
+      where: { id: personIdByRole[role], schoolId: SEED_SCHOOL_UUID },
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      select: { keycloakUserId: true },
+    });
+    if (!seedPerson?.keycloakUserId) {
+      throw new Error(
+        `Throwaway-school fixture: SEED_PERSON_KC_${role.toUpperCase()} (${personIdByRole[role]}) has no keycloakUserId. Re-run prisma:seed against a live Keycloak realm.`,
+      );
+    }
+    out[role] = seedPerson.keycloakUserId;
+  }
+  return out;
+}
+
+/**
+ * Create a fresh, isolated School with optional Persons for seed-KC roles.
+ * Caller MUST invoke the returned `cleanup()` in `afterAll` (or rely on
+ * Playwright's auto-cleanup via the fixture object lifecycle).
+ */
+export async function createThrowawaySchool(
+  options: ThrowawaySchoolOptions = {},
+): Promise<ThrowawaySchoolFixture> {
+  const {
+    roles = { lehrer: true },
+    withClasses = 1,
+    namePrefix = 'E2E-TS',
+  } = options;
+
+  const prisma = buildPrisma();
+  try {
+    const ts = Date.now();
+    const suffix = ts.toString().slice(-9);
+
+    const school = await prisma.school.create({
+      data: {
+        name: `${namePrefix}-${suffix}`,
+        schoolType: 'AHS',
+        abWeekEnabled: false,
+      },
+    });
+
+    const schoolYear = await prisma.schoolYear.create({
+      data: {
+        schoolId: school.id,
+        name: `${ts}/${ts + 1}`,
+        startDate: new Date('2099-09-01'),
+        semesterBreak: new Date('2100-02-01'),
+        endDate: new Date('2100-06-30'),
+        isActive: true,
+      },
+    });
+
+    const classIds: string[] = [];
+    for (let i = 0; i < withClasses; i++) {
+      const klass = await prisma.schoolClass.create({
+        data: {
+          schoolId: school.id,
+          name: `${namePrefix}-K${i + 1}`,
+          yearLevel: 5 + i,
+          schoolYearId: schoolYear.id,
+        },
+      });
+      classIds.push(klass.id);
+    }
+
+    const activeRoles = (Object.keys(roles) as SeedRole[]).filter((r) => roles[r]);
+    const keycloakUserIds = await resolveSeedKeycloakIds(prisma, activeRoles);
+
+    const personIds: Partial<Record<SeedRole, string>> = {};
+    for (const role of activeRoles) {
+      const kcId = keycloakUserIds[role];
+      if (!kcId) continue;
+      const person = await prisma.person.create({
+        data: {
+          schoolId: school.id,
+          keycloakUserId: kcId,
+          personType: ROLE_TO_PERSON_TYPE[role],
+          firstName: `${namePrefix}-${role}`,
+          lastName: suffix,
+        },
+      });
+      personIds[role] = person.id;
+    }
+
+    const cleanup = async () => {
+      const p = buildPrisma();
+      try {
+        // School.delete cascades to every per-school row via the FK chain
+        // (post-#136 audit closes the 5 remaining gaps).
+        await p.school.delete({ where: { id: school.id } });
+      } finally {
+        await p.$disconnect();
+      }
+    };
+
+    return {
+      schoolId: school.id,
+      schoolName: school.name,
+      schoolYearId: schoolYear.id,
+      classIds,
+      personIds,
+      keycloakUserIds,
+      cleanup,
+    };
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+/**
+ * Convenience cleanup when a spec stashes just the schoolId (e.g. retrieved
+ * from a previous run). Idempotent — silently no-ops on missing schools.
+ */
+export async function cleanupThrowawaySchool(schoolId: string): Promise<void> {
+  const prisma = buildPrisma();
+  try {
+    const exists = await prisma.school.findUnique({ where: { id: schoolId }, select: { id: true } });
+    if (!exists) return;
+    await prisma.school.delete({ where: { id: schoolId } });
+  } finally {
+    await prisma.$disconnect();
+  }
+}

--- a/apps/web/e2e/throwaway-school-smoke.spec.ts
+++ b/apps/web/e2e/throwaway-school-smoke.spec.ts
@@ -1,0 +1,143 @@
+/**
+ * Issue #136 — Throwaway-school fixture smoke spec.
+ *
+ * Three behaviors under test:
+ *
+ *   THROW-01 — createThrowawaySchool provisions a usable, isolated school
+ *              with a Person row for `lehrer` and the seed-KC lehrer sees
+ *              both memberships via /users/me + X-School-Id switches the
+ *              active schoolId.
+ *
+ *   THROW-02 — cleanup() actually drops the school AND all cascade-linked
+ *              children (verified via the new #136 cascade migration). The
+ *              seed school is NEVER touched (counts before == counts after).
+ *
+ *   THROW-03 — `availableSchools` from /users/me reflects the multi-school
+ *              state so the frontend switcher (downstream UI work) has the
+ *              data it needs without further backend changes.
+ *
+ * Cross-project: the entire spec runs under `desktop` (chromium) and
+ * `desktop-firefox` per `playwright.config.ts` testMatch. Concurrent
+ * execution from both projects on the same `seed-lehrer` KC user is the
+ * core race-elimination claim of Phase 3 — if THROW-01 ever flakes, the
+ * race is back.
+ */
+import { expect, test } from '@playwright/test';
+import { getRoleToken } from './helpers/login';
+import { createThrowawaySchool } from './fixtures/throwaway-school';
+import { SEED_SCHOOL_UUID } from './fixtures/seed-uuids';
+
+const API = process.env.E2E_API_URL ?? 'http://localhost:3000/api/v1';
+
+test.describe('THROW — throwaway-school fixture smoke (#136)', () => {
+  test('THROW-01 — fixture provisions School + active SchoolYear + lehrer Person; X-School-Id switches active context', async ({
+    request,
+  }) => {
+    const fixture = await createThrowawaySchool({ roles: { lehrer: true }, withClasses: 2 });
+    try {
+      expect(fixture.schoolId).toBeTruthy();
+      expect(fixture.schoolId).not.toBe(SEED_SCHOOL_UUID);
+      expect(fixture.classIds).toHaveLength(2);
+      expect(fixture.personIds.lehrer).toBeTruthy();
+      expect(fixture.keycloakUserIds.lehrer).toBeTruthy();
+
+      // The seed-lehrer KC user now has Person rows in TWO schools.
+      const token = await getRoleToken(request, 'lehrer');
+
+      // No header: backend falls back to first membership. Whichever it is,
+      // availableSchools MUST list both seed + throwaway.
+      const noHeader = await request.get(`${API}/users/me`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      expect(noHeader.status()).toBe(200);
+      const noHeaderBody = (await noHeader.json()) as {
+        schoolId: string;
+        availableSchools: Array<{ schoolId: string; schoolName: string; personType: string }>;
+      };
+      const schoolIds = noHeaderBody.availableSchools.map((s) => s.schoolId).sort();
+      expect(schoolIds).toContain(SEED_SCHOOL_UUID);
+      expect(schoolIds).toContain(fixture.schoolId);
+
+      // With header: the interceptor honors it and reports the throwaway as
+      // the active schoolId.
+      const switched = await request.get(`${API}/users/me`, {
+        headers: { Authorization: `Bearer ${token}`, 'X-School-Id': fixture.schoolId },
+      });
+      expect(switched.status()).toBe(200);
+      const switchedBody = (await switched.json()) as { schoolId: string };
+      expect(switchedBody.schoolId).toBe(fixture.schoolId);
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  test('THROW-02 — cleanup cascades through all per-school FKs without orphans', async ({
+    request,
+  }) => {
+    const fixture = await createThrowawaySchool({ roles: { lehrer: true }, withClasses: 1 });
+    const beforeId = fixture.schoolId;
+
+    // Sanity: the school exists pre-cleanup (visible via the auth'd lehrer's
+    // availableSchools).
+    const tokenBefore = await getRoleToken(request, 'lehrer');
+    const meBefore = await request.get(`${API}/users/me`, {
+      headers: { Authorization: `Bearer ${tokenBefore}` },
+    });
+    const meBeforeBody = (await meBefore.json()) as {
+      availableSchools: Array<{ schoolId: string }>;
+    };
+    expect(meBeforeBody.availableSchools.map((s) => s.schoolId)).toContain(beforeId);
+
+    await fixture.cleanup();
+
+    // After cleanup: /users/me must no longer list the throwaway, AND
+    // sending its UUID as X-School-Id must 403 (the Person row is gone too,
+    // proving the cascade reached it).
+    const tokenAfter = await getRoleToken(request, 'lehrer');
+    const meAfter = await request.get(`${API}/users/me`, {
+      headers: { Authorization: `Bearer ${tokenAfter}` },
+    });
+    const meAfterBody = (await meAfter.json()) as {
+      availableSchools: Array<{ schoolId: string }>;
+    };
+    expect(
+      meAfterBody.availableSchools.map((s) => s.schoolId),
+      'throwaway must be gone from availableSchools after cleanup',
+    ).not.toContain(beforeId);
+
+    const stillForbidden = await request.get(`${API}/users/me`, {
+      headers: { Authorization: `Bearer ${tokenAfter}`, 'X-School-Id': beforeId },
+    });
+    expect(stillForbidden.status(), 'foreign UUID after cleanup must 403').toBe(403);
+
+    // Seed school is still listed — the cascade did NOT touch the seed Person.
+    expect(meAfterBody.availableSchools.map((s) => s.schoolId)).toContain(SEED_SCHOOL_UUID);
+  });
+
+  test('THROW-03 — multiple roles in one fixture all show up in availableSchools', async ({
+    request,
+  }) => {
+    const fixture = await createThrowawaySchool({
+      roles: { lehrer: true, schueler: true },
+      withClasses: 1,
+    });
+    try {
+      expect(fixture.personIds.lehrer).toBeTruthy();
+      expect(fixture.personIds.schueler).toBeTruthy();
+      expect(fixture.keycloakUserIds.lehrer).not.toBe(fixture.keycloakUserIds.schueler);
+
+      for (const role of ['lehrer', 'schueler'] as const) {
+        const token = await getRoleToken(request, role);
+        const res = await request.get(`${API}/users/me`, {
+          headers: { Authorization: `Bearer ${token}`, 'X-School-Id': fixture.schoolId },
+        });
+        expect(res.status(), `${role} on throwaway`).toBe(200);
+        const body = (await res.json()) as { schoolId: string; personType: string };
+        expect(body.schoolId).toBe(fixture.schoolId);
+        expect(body.personType).toBe(role === 'lehrer' ? 'TEACHER' : 'STUDENT');
+      }
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+});


### PR DESCRIPTION
Closes #136. Refs #123, #133, #135.

## Why

Phase 3's load-bearing infrastructure piece: per-spec isolation via a freshly-provisioned `School` that cascade-deletes on cleanup. Composes with #133 (composite unique on `Person.keycloakUserId`) and #135 (X-School-Id interceptor + frontend plumbing) to let parallel Playwright specs share the same seed Keycloak users without contamination. Foundation for #137 + #138 (pilot + wide spec migration off chromium-only-skip).

## Schema audit + migration (5 cascade gaps)

`prisma.school.delete()` previously hit FK violations on 5 tables whose `school_id` FKs lacked `onDelete: Cascade`. Audit (post-migration: **25/25 School FKs are CASCADE**, verified via `pg_constraint.confdeltype = 'c'`):

| Table | Pre | Post |
| --- | --- | --- |
| `homework` | RESTRICT | CASCADE |
| `exams` | RESTRICT | CASCADE |
| `import_jobs` | RESTRICT | CASCADE |
| `calendar_tokens` | RESTRICT | CASCADE |
| `sis_api_keys` | RESTRICT | CASCADE |

Migration: `20260521195949_school_cascade_complete/migration.sql` (drop + re-add each constraint with `ON DELETE CASCADE ON UPDATE CASCADE`). Replays clean via `prisma migrate reset --force` on a fresh DB + seed.

## Fixture API

`apps/web/e2e/fixtures/throwaway-school.ts`:

\`\`\`ts
const fixture = await createThrowawaySchool({
  roles: { lehrer: true, schueler: true },
  withClasses: 2,
});
// fixture.schoolId / .classIds / .personIds.lehrer / .keycloakUserIds.lehrer
// Spec sends X-School-Id: \${fixture.schoolId} for any request that should
// be tenant-scoped to the throwaway.
await fixture.cleanup(); // prisma.school.delete cascades the rest
\`\`\`

### Why reuse seed KC users (Option B)

Provisioning fresh Keycloak users per spec would require admin REST API plumbing in test code, a token-grant + create-user + set-password + delete-on-teardown sequence per role. With #133 + #135 in place, writing new `Person` rows that bind the seed KC users to the throwaway school is strictly cheaper and still fully isolated — the cleanup cascade hits the throwaway `Person` row but never the seed `Person` row (different `(keycloakUserId, schoolId)` composite key).

## Smoke spec (cross-project regression lock)

`apps/web/e2e/throwaway-school-smoke.spec.ts`:

- **THROW-01** — fixture provisions School + SchoolYear + Person + X-School-Id switches active context for the seed lehrer.
- **THROW-02** — cleanup cascades through all per-school FKs (Person row gone, schoolId rejected as foreign post-cleanup); seed school untouched.
- **THROW-03** — multi-role provisioning (lehrer + schueler); both KC users see the throwaway in their `availableSchools` list.

Runs in both `desktop` and `desktop-firefox` projects per `playwright.config.ts` testMatch. **Cross-project parallel execution on the same seed lehrer KC user is the race-elimination proof** — if THROW-01 ever flakes, the race is back and Phase 3's architecture is broken.

## Verification

- [x] `pnpm exec tsc` clean on apps/api and apps/web
- [x] `pnpm exec nest build` clean
- [x] apps/api vitest: 775 passed / 0 failed / 65 todo
- [x] `prisma migrate reset --force` on fresh DB + seed succeeds; `pg_constraint` shows 25/25 School FKs as CASCADE
- [x] Smoke spec 3/3 on chromium
- [x] **Smoke spec 6/6 cross-project (desktop + desktop-firefox parallel, 2 workers, same seed KC users) — zero races**
- [x] CLAUDE.md migration policy: schema change ships with migration file; hygiene script grün

## Unblocks

- **#137** — pilot spec migration (drop chromium-only-skip from 1-2 flake-prone specs, swap to throwaway-school)
- **#138** — wide migration + remove redundant Phase 2/4 advisory locks
- Future CLAUDE.md D4 update: throwaway-school as the **primary** recommendation (currently "permitted")

## Out of scope

- Migrating existing specs to use the fixture — that's #137 + #138's job.
- KC admin user provisioning (Option A) — explicitly rejected, see ADR rationale + fixture docstring.
- Schools-Switch UI in the header — separate sub-issue, only meaningful once production multi-school users surface.

## Test plan

- [x] CI grün on first try (D3 — kein merge bei rotem CI)
- [ ] Post-merge sanity: pull main, restart API to pick up cascade migration via `migrate deploy` (already applied locally), run smoke spec