### PR TITLE
feat(e2e): #123/5 — pilot migration of timetable-cell-badges to throwaway-school

### DIFF
--- a/apps/api/prisma/migrations/20260524191019_exam_homework_cascade_via_class_subject/migration.sql
+++ b/apps/api/prisma/migrations/20260524191019_exam_homework_cascade_via_class_subject/migration.sql
@@ -1,0 +1,30 @@
+-- Issue #137 — Throwaway-school cleanup discovered a "diamond" cascade
+-- gap: School deletion cascades to BOTH the school_classes / class_subjects
+-- chain AND directly to exams + homework (post-#136). PostgreSQL processes
+-- these cascades non-deterministically, so when the SchoolClass branch
+-- fires first it tries to delete the class while exams.class_id (RESTRICT)
+-- still references the not-yet-cascaded exam row → FK violation.
+--
+-- Fix: make exams + homework cascade-delete via their class / class_subject
+-- parents too, so any order PG picks for the diamond resolves cleanly.
+-- Semantic intent matches: deleting a SchoolClass or ClassSubject already
+-- implies its exams + homework are obsolete (no academic schedule to
+-- attach them to).
+
+-- DropForeignKey
+ALTER TABLE "exams" DROP CONSTRAINT "exams_class_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "exams" DROP CONSTRAINT "exams_class_subject_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "homework" DROP CONSTRAINT "homework_class_subject_id_fkey";
+
+-- AddForeignKey
+ALTER TABLE "homework" ADD CONSTRAINT "homework_class_subject_id_fkey" FOREIGN KEY ("class_subject_id") REFERENCES "class_subjects"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "exams" ADD CONSTRAINT "exams_class_subject_id_fkey" FOREIGN KEY ("class_subject_id") REFERENCES "class_subjects"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "exams" ADD CONSTRAINT "exams_class_id_fkey" FOREIGN KEY ("class_id") REFERENCES "school_classes"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -1423,7 +1423,7 @@ model Homework {
   createdAt        DateTime       @default(now()) @map("created_at")
   updatedAt        DateTime       @updatedAt @map("updated_at")
 
-  classSubject     ClassSubject   @relation(fields: [classSubjectId], references: [id])
+  classSubject     ClassSubject   @relation(fields: [classSubjectId], references: [id], onDelete: Cascade)
   classBookEntry   ClassBookEntry? @relation(fields: [classBookEntryId], references: [id], onDelete: SetNull)
   school           School         @relation(fields: [schoolId], references: [id], onDelete: Cascade)
 
@@ -1447,8 +1447,8 @@ model Exam {
   createdAt      DateTime     @default(now()) @map("created_at")
   updatedAt      DateTime     @updatedAt @map("updated_at")
 
-  classSubject   ClassSubject @relation(fields: [classSubjectId], references: [id])
-  schoolClass    SchoolClass  @relation(fields: [classId], references: [id])
+  classSubject   ClassSubject @relation(fields: [classSubjectId], references: [id], onDelete: Cascade)
+  schoolClass    SchoolClass  @relation(fields: [classId], references: [id], onDelete: Cascade)
   school         School       @relation(fields: [schoolId], references: [id], onDelete: Cascade)
 
   @@index([classId, date])

--- a/apps/web/e2e/auth-user-context.spec.ts
+++ b/apps/web/e2e/auth-user-context.spec.ts
@@ -27,6 +27,7 @@
  */
 import { expect, test } from '@playwright/test';
 import { getRoleToken, type Role } from './helpers/login';
+import { SEED_SCHOOL_UUID } from './fixtures/seed-uuids';
 
 const API = process.env.E2E_API_URL ?? 'http://localhost:3000/api/v1';
 
@@ -52,8 +53,12 @@ test.describe('AUTH-CTX — GET /api/v1/users/me after composite-unique schema m
       request,
     }) => {
       const token = await getRoleToken(request, role);
+      // Issue #137 — explicit X-School-Id makes this spec deterministic
+      // when sibling specs transiently provision throwaway Person rows
+      // for the same seed KC user. Without the header, /users/me falls
+      // back to "first membership" which is non-deterministic mid-flight.
       const res = await request.get(`${API}/users/me`, {
-        headers: { Authorization: `Bearer ${token}` },
+        headers: { Authorization: `Bearer ${token}`, 'X-School-Id': SEED_SCHOOL_UUID },
       });
 
       // The regression: a stale findUnique({ keycloakUserId }) call against

--- a/apps/web/e2e/fixtures/throwaway-school.ts
+++ b/apps/web/e2e/fixtures/throwaway-school.ts
@@ -61,6 +61,31 @@ const { PrismaClient } = require('../../../api/dist/config/database/generated/cl
     schoolClass: {
       create: (args: any) => Promise<{ id: string; name: string }>;
     };
+    teacher: {
+      create: (args: any) => Promise<{ id: string; personId: string }>;
+    };
+    subject: {
+      create: (args: any) => Promise<{ id: string; shortName: string }>;
+    };
+    classSubject: {
+      create: (args: any) => Promise<{ id: string; classId: string; subjectId: string }>;
+    };
+    room: {
+      create: (args: any) => Promise<{ id: string; name: string }>;
+    };
+    schoolDay: {
+      create: (args: any) => Promise<unknown>;
+    };
+    timeGrid: {
+      create: (args: any) => Promise<{ id: string }>;
+    };
+    timetableRun: {
+      create: (args: any) => Promise<{ id: string }>;
+      deleteMany: (args: any) => Promise<unknown>;
+    };
+    timetableLesson: {
+      create: (args: any) => Promise<{ id: string; dayOfWeek: string; periodNumber: number }>;
+    };
     $disconnect: () => Promise<void>;
   };
 };
@@ -91,6 +116,34 @@ export interface ThrowawaySchoolOptions {
   withClasses?: number;
   /** Prefix for the school's name + class names — keeps cross-spec greps trivial. */
   namePrefix?: string;
+  /**
+   * Issue #137 — opt-in timetable stack for UI specs that need a TimetableRun
+   * to render against. Provisions: Teacher row (for `roles.lehrer` Person),
+   * Subject, ClassSubject (joining Class[0] + Subject + Teacher), Room,
+   * TimeGrid with period 1 (08:00-08:50), SchoolDays MON-FRI active,
+   * TimetableRun (active), TimetableLesson at MONDAY/period-1.
+   *
+   * Requires `roles.lehrer` to be enabled — otherwise there's no Person to
+   * promote to a Teacher row. Throws otherwise.
+   */
+  withTimetableStack?: boolean;
+}
+
+export interface ThrowawayTimetableStack {
+  teacherId: string;
+  subjectId: string;
+  subjectShortName: string;
+  classSubjectId: string;
+  roomId: string;
+  timeGridId: string;
+  timetableRunId: string;
+  timetableLessonId: string;
+  /** The class the ClassSubject is bound to (always classIds[0] today). */
+  classId: string;
+  /** MONDAY — exposed for clarity in spec assertions. */
+  lessonDayOfWeek: 'MONDAY';
+  /** 1 — the seeded lesson's period. */
+  lessonPeriodNumber: 1;
 }
 
 export interface ThrowawaySchoolFixture {
@@ -102,6 +155,8 @@ export interface ThrowawaySchoolFixture {
   personIds: Partial<Record<SeedRole, string>>;
   /** Keycloak user IDs (the seed-bound `sub` claim values) for each seed role used. */
   keycloakUserIds: Partial<Record<SeedRole, string>>;
+  /** Populated when `withTimetableStack: true` was passed. */
+  timetable?: ThrowawayTimetableStack;
   cleanup: () => Promise<void>;
 }
 
@@ -155,7 +210,19 @@ export async function createThrowawaySchool(
     roles = { lehrer: true },
     withClasses = 1,
     namePrefix = 'E2E-TS',
+    withTimetableStack = false,
   } = options;
+
+  if (withTimetableStack && !roles.lehrer) {
+    throw new Error(
+      'createThrowawaySchool: withTimetableStack requires roles.lehrer (need a Person row to promote to Teacher)',
+    );
+  }
+  if (withTimetableStack && withClasses < 1) {
+    throw new Error(
+      'createThrowawaySchool: withTimetableStack requires withClasses >= 1 (need a class for the ClassSubject)',
+    );
+  }
 
   const prisma = buildPrisma();
   try {
@@ -213,11 +280,137 @@ export async function createThrowawaySchool(
       personIds[role] = person.id;
     }
 
+    let timetable: ThrowawayTimetableStack | undefined;
+    if (withTimetableStack) {
+      const lehrerPersonId = personIds.lehrer!;
+      const classIdForStack = classIds[0];
+
+      // Teacher row for the lehrer Person. Teacher.personId is @unique
+      // (one Teacher per Person) — the throwaway Person was created fresh
+      // above, so no collision.
+      const teacher = await prisma.teacher.create({
+        data: {
+          personId: lehrerPersonId,
+          schoolId: school.id,
+        },
+      });
+
+      const subject = await prisma.subject.create({
+        data: {
+          schoolId: school.id,
+          name: `${namePrefix}-Math`,
+          shortName: `M${suffix.slice(-4)}`, // keep @@unique([schoolId, shortName]) trivially safe
+          subjectType: 'PFLICHT',
+        },
+      });
+
+      const classSubject = await prisma.classSubject.create({
+        data: {
+          classId: classIdForStack,
+          subjectId: subject.id,
+          teacherId: teacher.id,
+          weeklyHours: 1,
+        },
+      });
+
+      const room = await prisma.room.create({
+        data: {
+          schoolId: school.id,
+          name: `${namePrefix}-R-${suffix}`,
+          roomType: 'KLASSENZIMMER',
+          capacity: 30,
+          equipment: [],
+        },
+      });
+
+      // TimeGrid + a single period — the timetable view needs at least one
+      // period to render a column slot at periodNumber=1.
+      const timeGrid = await prisma.timeGrid.create({
+        data: {
+          schoolId: school.id,
+          periods: {
+            create: [
+              {
+                periodNumber: 1,
+                startTime: '08:00',
+                endTime: '08:50',
+                isBreak: false,
+                label: '1. Stunde',
+                durationMin: 50,
+              },
+            ],
+          },
+        },
+      });
+
+      // SchoolDays MON-FRI active — the timetable view filters out inactive
+      // days from the grid columns.
+      for (const dayOfWeek of ['MONDAY', 'TUESDAY', 'WEDNESDAY', 'THURSDAY', 'FRIDAY'] as const) {
+        await prisma.schoolDay.create({
+          data: { schoolId: school.id, dayOfWeek, isActive: true },
+        });
+      }
+
+      const run = await prisma.timetableRun.create({
+        data: {
+          schoolId: school.id,
+          status: 'COMPLETED',
+          isActive: true,
+          maxSolveSeconds: 300,
+          abWeekEnabled: false,
+          hardScore: 0,
+          softScore: 0,
+          elapsedSeconds: 1,
+        },
+      });
+
+      const lesson = await prisma.timetableLesson.create({
+        data: {
+          runId: run.id,
+          classSubjectId: classSubject.id,
+          teacherId: teacher.id,
+          roomId: room.id,
+          dayOfWeek: 'MONDAY',
+          periodNumber: 1,
+          weekType: 'BOTH',
+        },
+      });
+
+      timetable = {
+        teacherId: teacher.id,
+        subjectId: subject.id,
+        subjectShortName: subject.shortName,
+        classSubjectId: classSubject.id,
+        roomId: room.id,
+        timeGridId: timeGrid.id,
+        timetableRunId: run.id,
+        timetableLessonId: lesson.id,
+        classId: classIdForStack,
+        lessonDayOfWeek: 'MONDAY',
+        lessonPeriodNumber: 1,
+      };
+    }
+
+    const capturedTimetable = timetable;
     const cleanup = async () => {
       const p = buildPrisma();
       try {
+        // Issue #137 — `timetable_lessons.room_id` is still RESTRICT (#137
+        // intentionally keeps it so admin Room deletes get a 409 instead
+        // of silently nuking lessons). For the throwaway cleanup that
+        // means we MUST delete the TimetableRun first — its CASCADE on
+        // `run_id` removes the lessons, freeing the FK on Room before the
+        // School cascade tries to drop the Room.
+        if (capturedTimetable) {
+          await p.timetableRun.deleteMany({
+            where: { id: capturedTimetable.timetableRunId },
+          });
+        }
         // School.delete cascades to every per-school row via the FK chain
-        // (post-#136 audit closes the 5 remaining gaps).
+        // (post-#136 + #137 audit closes 8 cascade gaps total). The
+        // exam.class_id + exam/homework.class_subject_id CASCADEs added in
+        // #137 resolve the diamond-cascade race PG hit when both branches
+        // fired concurrently.
         await p.school.delete({ where: { id: school.id } });
       } finally {
         await p.$disconnect();
@@ -231,6 +424,7 @@ export async function createThrowawaySchool(
       classIds,
       personIds,
       keycloakUserIds,
+      timetable,
       cleanup,
     };
   } finally {

--- a/apps/web/e2e/helpers/exams.ts
+++ b/apps/web/e2e/helpers/exams.ts
@@ -88,10 +88,11 @@ export interface CreatedExam {
 export async function createExamViaAPI(
   request: APIRequestContext,
   input: CreateExamInput,
+  schoolId: string = EXAMS_SCHOOL_ID,
 ): Promise<CreatedExam> {
   const token = await getAdminToken(request);
   const res = await request.post(
-    `${EXAMS_API}/schools/${EXAMS_SCHOOL_ID}/exams`,
+    `${EXAMS_API}/schools/${schoolId}/exams`,
     {
       headers: {
         Authorization: `Bearer ${token}`,

--- a/apps/web/e2e/helpers/homework.ts
+++ b/apps/web/e2e/helpers/homework.ts
@@ -72,10 +72,11 @@ export interface CreatedHomework {
 export async function createHomeworkViaAPI(
   request: APIRequestContext,
   input: CreateHomeworkInput,
+  schoolId: string = HOMEWORK_SCHOOL_ID,
 ): Promise<CreatedHomework> {
   const token = await getAdminToken(request);
   const res = await request.post(
-    `${HOMEWORK_API}/schools/${HOMEWORK_SCHOOL_ID}/homework`,
+    `${HOMEWORK_API}/schools/${schoolId}/homework`,
     {
       headers: {
         Authorization: `Bearer ${token}`,

--- a/apps/web/e2e/helpers/school-context.ts
+++ b/apps/web/e2e/helpers/school-context.ts
@@ -1,0 +1,77 @@
+/**
+ * Issue #137 — Browser-side helper for the throwaway-school pilot.
+ *
+ * Sets `useSchoolContext.currentSchoolId` from a Playwright spec by reaching
+ * into `window.__schoolContextStore` (exposed in dev/test bundles only —
+ * see `apps/web/src/stores/school-context-store.ts`).
+ *
+ * Why needed: with #133 (composite unique) + #135 (X-School-Id interceptor)
+ * + #136 (throwaway fixture) in place, the only remaining gap for a UI spec
+ * driving the throwaway school is making `apiFetch` send `X-School-Id: <throwaway>`.
+ * `apiFetch` reads from the Zustand store; calling `setCurrentSchool` on the
+ * store updates every subsequent request without touching production code
+ * paths.
+ *
+ * Call this AFTER `loginAsRole` (so `/users/me` has populated the store
+ * with the user's `availableSchools`) and BEFORE the first assertion that
+ * depends on throwaway-scoped data.
+ */
+import type { BrowserContext, Page } from '@playwright/test';
+
+interface SchoolContextStoreWindow {
+  __schoolContextStore?: {
+    getState: () => { setCurrentSchool: (id: string) => void };
+  };
+}
+
+/**
+ * Set `X-School-Id` on every `/api/**` request the browser context makes,
+ * INCLUDING the initial `/users/me` that hydrates `useSchoolContext`.
+ *
+ * Uses `context.route` (not `setExtraHTTPHeaders`) so the header is added
+ * ONLY to backend API calls — Keycloak's login redirects and CORS preflight
+ * stay untouched. Adding `X-School-Id` to KC POSTs trips its CORS allowlist
+ * and aborts the login flow with a closed-page error.
+ *
+ * The backend `CurrentSchoolInterceptor` reads the header, validates it
+ * against the user's Person memberships, and returns the requested school
+ * as `schoolId` from `/users/me`. The frontend store then persists that as
+ * `currentSchoolId`, so subsequent `apiFetch` calls also send the same
+ * header — without any in-page Zustand manipulation.
+ *
+ * Survives `page.goto` and `page.reload` because the route handler lives
+ * on the BrowserContext, not in the page's JS heap.
+ *
+ * Call BEFORE the first `loginAsRole` / `page.goto` of the test.
+ */
+export async function useThrowawaySchoolHeader(
+  context: BrowserContext,
+  schoolId: string,
+): Promise<void> {
+  await context.route('**/api/**', async (route) => {
+    const headers = { ...route.request().headers(), 'x-school-id': schoolId };
+    await route.continue({ headers });
+  });
+}
+
+/**
+ * In-page Zustand setter — for the rare case a spec needs to switch
+ * school context AFTER initial hydration (e.g., proving a hypothetical
+ * Schools-Switch UI works). For initial throwaway binding, prefer
+ * `useThrowawaySchoolHeader` which doesn't lose its setting across
+ * `page.goto` / `page.reload`.
+ */
+export async function setCurrentSchoolInBrowser(
+  page: Page,
+  schoolId: string,
+): Promise<void> {
+  await page.evaluate((id) => {
+    const w = window as unknown as SchoolContextStoreWindow;
+    if (!w.__schoolContextStore) {
+      throw new Error(
+        '__schoolContextStore not exposed on window — dev/test bundle expected (apps/web/src/stores/school-context-store.ts)',
+      );
+    }
+    w.__schoolContextStore.getState().setCurrentSchool(id);
+  }, schoolId);
+}

--- a/apps/web/e2e/timetable-cell-badges.spec.ts
+++ b/apps/web/e2e/timetable-cell-badges.spec.ts
@@ -1,107 +1,119 @@
 /**
  * Issue #82 — Timetable cell badges (Homework + Exam) regression-lock.
  *
- * Third sub-spec of the Hausaufgaben/Klausuren coverage gap (closes #82
- * alongside #99 + #100). Locks the cross-surface render contract that
- * homework and exam badges land on the right timetable cell when the
- * Lehrer opens /timetable:
+ * Migrated to the throwaway-school architecture in #137 (Phase 3 pilot):
+ *   - Per-spec School + active TimetableRun + Lesson + ClassSubject + Teacher
+ *     are provisioned via `createThrowawaySchool({ withTimetableStack: true })`,
+ *     so the chromium-only-skip race-defense ("Mutates Homework + Exam rows
+ *     on the shared seed class — chromium is the sole writer") is GONE.
+ *   - Cross-project parallel execution (chromium + firefox) is the success
+ *     criterion: every worker writes Homework + Exam rows on its OWN throwaway
+ *     classSubject, so race-on-shared-resource cannot recur.
+ *   - Frontend school-context switch via `setCurrentSchoolInBrowser` after
+ *     `loginAsRole(lehrer)` so `apiFetch` injects `X-School-Id: <throwaway>`
+ *     on every subsequent request (see ADR docs/adr/0001-current-school-context.md).
  *
- *   1. Seed a TimetableRun fixture (MONDAY/period-1 lesson for class 1A,
- *      teacher = kc-lehrer Maria Mueller).
- *   2. Seed ONE Homework and ONE Exam against the fixture's
- *      classSubjectId via API.
- *   3. kc-lehrer logs in → /timetable defaults to perspective=teacher
- *      for her own teacherId.
+ * Asserts (unchanged from the pre-migration regression intent):
+ *   1. Seeded TimetableLesson at MONDAY/period-1 (kc-lehrer Maria Mueller as
+ *      teacher in the throwaway school).
+ *   2. Seeded Homework + Exam against the throwaway classSubjectId via API.
+ *   3. kc-lehrer logs in → /timetable defaults to teacher perspective for
+ *      her throwaway-school teacherId.
  *   4. The seeded cell renders TimetableCellBadges with both icons —
- *      aria-label="Hausaufgabe: <title>" and "Pruefung: <title>"
- *      identify them deterministically.
+ *      aria-label="Hausaufgabe: <title>" and "Pruefung: <title>".
  *   5. Click each badge → Popover opens with the seeded title visible.
  *
- * Exercises the renderCellWithBadges path in /timetable/index.tsx, the
- * useHomework + useExams aggregation, and the badge Popover trigger.
- * Bug-class guard: if HomeworkBadge stops accepting its homework prop
- * or the badge container drops aria-label, this spec turns red loudly.
- *
- * Chromium-only-skip per the race-family precedent — every spec on
- * this surface writes Homework / Exam rows on the shared seed class.
+ * Cleanup: `fixture.cleanup()` does `prisma.school.delete()` which cascades
+ * through Homework + Exam + TimetableLesson + TimetableRun + ClassSubject +
+ * Teacher + Subject + Room + SchoolDay + TimeGrid + Person (post-#136
+ * cascade audit: 25/25 School FKs are CASCADE). No per-row sweeps needed.
  */
 import { test, expect } from '@playwright/test';
 import { loginAsRole } from './helpers/login';
 import {
   HOMEWORK_TITLE_PREFIX,
-  cleanupE2EHomework,
   createHomeworkViaAPI,
   isoDaysFromNow as homeworkDateInDays,
 } from './helpers/homework';
 import {
   EXAMS_TITLE_PREFIX,
-  cleanupE2EExams,
   createExamViaAPI,
   isoDaysFromNow as examDateInDays,
 } from './helpers/exams';
 import {
-  cleanupTimetableRun,
-  seedTimetableRun,
-  type TimetableRunFixture,
-} from './fixtures/timetable-run';
-import { SEED_SCHOOL_UUID } from './fixtures/seed-uuids';
+  createThrowawaySchool,
+  type ThrowawaySchoolFixture,
+} from './fixtures/throwaway-school';
+import { useThrowawaySchoolHeader } from './helpers/school-context';
 
-const SEED_CLASS_1A_ID = 'seed-class-1a';
-
-test.describe('Issue #82 — Timetable cell badges (desktop)', () => {
+test.describe('Issue #82 — Timetable cell badges (desktop, throwaway-school)', () => {
   test.skip(
     ({ isMobile }) => isMobile,
     'Cell-badge contract is identical across viewports — desktop only for the first lock.',
   );
-  test.skip(
-    ({ browserName }) => browserName !== 'chromium',
-    'Mutates Homework + Exam rows on the shared seed class — chromium is the sole writer.',
-  );
+  // No chromium-only-skip: #137 migration to throwaway-school eliminates the
+  // shared-seed-class race that made the original spec a sole-writer.
 
-  let fixture: TimetableRunFixture | undefined;
+  let fixture: ThrowawaySchoolFixture | undefined;
   let homeworkTitle: string;
   let examTitle: string;
 
-  test.beforeEach(async ({ page, request }) => {
-    fixture = await seedTimetableRun(SEED_SCHOOL_UUID);
+  test.beforeEach(async ({ request }) => {
+    fixture = await createThrowawaySchool({
+      roles: { lehrer: true },
+      withClasses: 1,
+      withTimetableStack: true,
+      namePrefix: 'E2E-CB',
+    });
+    const stack = fixture.timetable!;
 
     const ts = Date.now();
     homeworkTitle = `${HOMEWORK_TITLE_PREFIX}BADGE-${ts} — Kapitel 5 lesen`;
     examTitle = `${EXAMS_TITLE_PREFIX}BADGE-${ts} — Schularbeit 1`;
 
-    await createHomeworkViaAPI(request, {
-      title: homeworkTitle,
-      description: 'Aufgaben 1–12 auf Seite 47',
-      dueDate: homeworkDateInDays(2),
-      classSubjectId: fixture.classSubjectId,
-    });
-    await createExamViaAPI(request, {
-      title: examTitle,
-      date: examDateInDays(7),
-      classSubjectId: fixture.classSubjectId,
-      classId: SEED_CLASS_1A_ID,
-    });
-
-    await loginAsRole(page, 'lehrer');
+    await createHomeworkViaAPI(
+      request,
+      {
+        title: homeworkTitle,
+        description: 'Aufgaben 1-12 auf Seite 47',
+        dueDate: homeworkDateInDays(2),
+        classSubjectId: stack.classSubjectId,
+      },
+      fixture.schoolId,
+    );
+    await createExamViaAPI(
+      request,
+      {
+        title: examTitle,
+        date: examDateInDays(7),
+        classSubjectId: stack.classSubjectId,
+        classId: stack.classId,
+      },
+      fixture.schoolId,
+    );
   });
 
-  test.afterEach(async ({ request }) => {
-    // Sweep by BADGE- sub-prefix so parallel specs (classbook-homework,
-    // classbook-exams) only delete their own rows. Pattern lifted from
-    // the recent excuses cross-spec cleanup-race fix.
-    await cleanupE2EHomework(request, `${HOMEWORK_TITLE_PREFIX}BADGE-`);
-    await cleanupE2EExams(request, `${EXAMS_TITLE_PREFIX}BADGE-`);
+  test.afterEach(async () => {
     if (fixture) {
-      await cleanupTimetableRun(fixture);
+      await fixture.cleanup();
       fixture = undefined;
     }
   });
 
   test('CB-BADGE-01: Lehrer sees Homework + Exam badges on the seeded cell, popovers open with seeded content', async ({
     page,
+    context,
   }) => {
     if (!fixture) throw new Error('fixture not seeded');
 
+    // ── Issue #137 — Bind every HTTP request from this BrowserContext to
+    // the throwaway school via the X-School-Id header. Includes the very
+    // first /users/me that hydrates useSchoolContext, so the frontend
+    // store starts (and stays) on the throwaway — no Prisma-ordering
+    // race for the default membership.
+    await useThrowawaySchoolHeader(context, fixture.schoolId);
+
+    await loginAsRole(page, 'lehrer');
     await page.goto('/timetable');
 
     // Wait for the grid to mount. The kc-lehrer perspective lands on

--- a/apps/web/src/stores/school-context-store.ts
+++ b/apps/web/src/stores/school-context-store.ts
@@ -89,3 +89,12 @@ export const useSchoolContext = create<SchoolContextState>((set) => ({
 
   setCurrentSchool: (schoolId) => set({ currentSchoolId: schoolId }),
 }));
+
+// Issue #137 — Expose the store on `window` in non-production builds so
+// Playwright specs can call `setCurrentSchool` from `page.evaluate(...)`
+// without a UI switcher (which doesn't ship yet — separate sub-issue).
+// Production builds skip this so the store stays an implementation detail.
+if (typeof window !== 'undefined' && import.meta.env.MODE !== 'production') {
+  (window as unknown as { __schoolContextStore?: typeof useSchoolContext }).__schoolContextStore =
+    useSchoolContext;
+}


### PR DESCRIPTION
Closes #137. Refs #123, #136.

## Why

Phase 3 pilot migration: prove the throwaway-school architecture (#133 + #135 + #136) actually works on a real flake-prone UI spec by switching `timetable-cell-badges.spec.ts` off the shared seed-school race-defense (chromium-only-skip) and onto a per-spec throwaway. Demonstrated via **10/10 cross-project parallel runs (chromium + firefox on the same seed-lehrer KC user, zero flakes)**.

## What ships

### Spec migration (`timetable-cell-badges.spec.ts`)

| Before | After |
| --- | --- |
| `test.skip(({browserName}) => browserName !== 'chromium', 'Mutates Homework + Exam on shared seed class')` | NO chromium-only-skip |
| `seedTimetableRun(SEED_SCHOOL_UUID)` + advisory lock | `createThrowawaySchool({ withTimetableStack: true })` |
| Homework + Exam writes hit seed `class 1A` | Writes hit the throwaway `classSubjectId` |
| Per-spec sweep helpers + advisory-lock release | `fixture.cleanup()` (single school.delete cascade) |

The lehrer browser context is bound to the throwaway via `useThrowawaySchoolHeader(context, schoolId)` — `context.route` adds `X-School-Id` to every `/api/**` request, including the very first `/users/me` that hydrates `useSchoolContext`. Backend interceptor validates → returns throwaway as `schoolId` → frontend store sticks.

### Cascade audit follow-up (3 more FKs)

Throwaway cleanup discovered a diamond-cascade gap not covered by #136:

| FK | Pre | Post |
| --- | --- | --- |
| `exams.class_id` | RESTRICT | CASCADE |
| `exams.class_subject_id` | RESTRICT | CASCADE |
| `homework.class_subject_id` | RESTRICT | CASCADE |

Migration: `20260524191019_exam_homework_cascade_via_class_subject/migration.sql`.

`timetable_lessons.room_id` stays RESTRICT (admin Room deletes get a helpful 409 instead of a silent lesson nuke). Throwaway cleanup handles this by explicitly deleting `TimetableRun` first — its `run_id` CASCADE removes the lessons before the School cascade tries to drop the Room.

### Fixture extension (`createThrowawaySchool({ withTimetableStack: true })`)

Opts into a full classroom-ready setup: Teacher (for lehrer Person) + Subject + ClassSubject + Room + TimeGrid + SchoolDays MON-FRI + active TimetableRun + lesson at MONDAY/period-1. Returns `fixture.timetable.{ teacherId, classSubjectId, roomId, timetableRunId, timetableLessonId, classId, ... }`.

### Frontend + helpers

- `apps/web/src/stores/school-context-store.ts`: exposes `useSchoolContext` on `window.__schoolContextStore` in non-production builds (for in-page Zustand switching, useful for future Schools-Switch UI tests).
- `apps/web/e2e/helpers/school-context.ts`: ships two helpers.
  - `useThrowawaySchoolHeader(context, schoolId)` — canonical context.route binding (survives reload/goto, doesn't trip KC CORS).
  - `setCurrentSchoolInBrowser(page, schoolId)` — mid-session switch via Zustand setter.
- `createHomeworkViaAPI(request, input, schoolId?)` + `createExamViaAPI(request, input, schoolId?)` — additive `schoolId` param defaults to SEED for backwards compat.

### Cross-spec race fix in `auth-user-context.spec.ts`

`AUTH-CTX-01.{lehrer,eltern,schueler}` previously assumed each seed KC user has exactly one Person row. With throwaway fixtures in play, that's transiently false during parallel runs. Fix: AUTH-CTX-01 now sends `X-School-Id: SEED_SCHOOL_UUID` explicitly. Broader Phase 3 pattern: in a multi-membership world, "default to first membership" is non-deterministic — any test depending on a specific school MUST send the header.

## Why `context.route` (not `setExtraHTTPHeaders`)

`setExtraHTTPHeaders` applies the header to ALL outbound requests including Keycloak login POSTs. KC's CORS allowlist doesn't whitelist `X-School-Id` and aborts the login flow with a closed-page error. `context.route('**/api/**', ...)` scopes the header to backend API calls only.

## Verification

- [x] `pnpm exec tsc` clean on apps/api and apps/web
- [x] `pnpm exec nest build` clean (Prisma client regenerated for new cascade FKs)
- [x] apps/api vitest: 775 passed / 0 failed / 65 todo
- [x] Migration hygiene script green
- [x] **10/10 cross-project parallel runs of `timetable-cell-badges.spec.ts` (chromium + firefox, 2 workers, same seed-lehrer KC user) — zero flakes**
- [x] 24/24 cross-project run of all Phase 3 specs + the migrated spec (auth-user-context + current-school-context + throwaway-smoke + timetable-cell-badges, both projects)

## Unblocks

- **#138** — wide migration: apply this pilot's pattern to the remaining chromium-only-skip specs (statistics-absence, admin-timetable-history, timetable-generation-flow).
- Future CLAUDE.md D4 update: throwaway-school is now PRIMARY, not just permitted.

## Out of scope

- The other 3 chromium-only-skip specs — that's #138's job.
- A Schools-Switch UI in the app header — separate sub-issue once production multi-school users exist.

## Test plan

- [x] CI grün on first try (D3)
- [ ] Post-merge sanity: pull main, restart API (cascade migration applies via `migrate deploy`), Vite hot-reloads the store change automatically. Run `timetable-cell-badges.spec.ts --project=desktop --project=desktop-firefox` once locally to confirm.