### PR TITLE
feat(e2e): #138 wave 1 — migrate statistics-absence to throwaway + admin/students/classbook fixtures

### DIFF
--- a/apps/web/e2e/fixtures/throwaway-school.ts
+++ b/apps/web/e2e/fixtures/throwaway-school.ts
@@ -50,6 +50,15 @@ const { PrismaClient } = require('../../../api/dist/config/database/generated/cl
       findFirst: (args: any) => Promise<any>;
       create: (args: any) => Promise<{ id: string; keycloakUserId: string | null; schoolId: string }>;
     };
+    student: {
+      create: (args: any) => Promise<{ id: string; personId: string }>;
+    };
+    classBookEntry: {
+      create: (args: any) => Promise<{ id: string }>;
+    };
+    attendanceRecord: {
+      create: (args: any) => Promise<{ id: string }>;
+    };
     school: {
       create: (args: any) => Promise<{ id: string; name: string }>;
       delete: (args: any) => Promise<unknown>;
@@ -101,10 +110,16 @@ const buildPrisma = () =>
   });
 
 /** Maps seed-bound Keycloak roles to Prisma `PersonType` enum values. */
-type SeedRole = 'lehrer' | 'schulleitung' | 'schueler' | 'eltern';
+type SeedRole = 'lehrer' | 'schulleitung' | 'schueler' | 'eltern' | 'admin';
 const ROLE_TO_PERSON_TYPE: Record<SeedRole, 'TEACHER' | 'STUDENT' | 'PARENT'> = {
   lehrer: 'TEACHER',
   schulleitung: 'TEACHER',
+  // Issue #138 — admin gets a TEACHER Person row in the throwaway. Admin's
+  // tenant identity (the X-School-Id validation in CurrentSchoolInterceptor)
+  // is what we actually need; the PersonType is a schema requirement that
+  // doesn't drive any authorization (admin's privileges come from KC roles
+  // via CASL, not from Person.personType).
+  admin: 'TEACHER',
   schueler: 'STUDENT',
   eltern: 'PARENT',
 };
@@ -118,15 +133,39 @@ export interface ThrowawaySchoolOptions {
   namePrefix?: string;
   /**
    * Issue #137 — opt-in timetable stack for UI specs that need a TimetableRun
-   * to render against. Provisions: Teacher row (for `roles.lehrer` Person),
-   * Subject, ClassSubject (joining Class[0] + Subject + Teacher), Room,
-   * TimeGrid with period 1 (08:00-08:50), SchoolDays MON-FRI active,
-   * TimetableRun (active), TimetableLesson at MONDAY/period-1.
-   *
-   * Requires `roles.lehrer` to be enabled — otherwise there's no Person to
-   * promote to a Teacher row. Throws otherwise.
+   * to render against. Provisions: Teacher row (for `roles.lehrer` Person if
+   * present, otherwise a generic fixture-only Person), Subject, ClassSubject
+   * (joining Class[0] + Subject + Teacher), Room, TimeGrid with period 1
+   * (08:00-08:50), SchoolDays MON-FRI active, TimetableRun (active),
+   * TimetableLesson at MONDAY/period-1.
    */
   withTimetableStack?: boolean;
+  /**
+   * Issue #138 — list of students to provision in the throwaway. Each entry
+   * creates a Person + Student row enrolled in `classIds[0]`. Names show up
+   * verbatim in any UI that lists students (e.g. /statistics/absence).
+   * Requires `withClasses >= 1`.
+   */
+  withStudents?: Array<{ firstName: string; lastName: string }>;
+  /**
+   * Issue #138 — opt-in ClassBookEntry + AttendanceRecord rows for specs
+   * that exercise classbook / attendance / statistics surfaces. References
+   * the timetable stack's classSubject + teacher (so requires
+   * `withTimetableStack: true`) and a contiguous prefix of `withStudents`
+   * (so requires `withStudents.length >= attendance.length`).
+   */
+  withClassbookEntry?: {
+    /** YYYY-MM-DD — the calendar date the ClassBookEntry pins to. */
+    date: string;
+    /** Period number; must NOT collide with `withTimetableStack`'s period-1 lesson. */
+    period?: number;
+    attendance: Array<{
+      /** Index into `withStudents` — `0` = first student, etc. */
+      studentIndex: number;
+      status: 'PRESENT' | 'ABSENT' | 'LATE' | 'EXCUSED';
+      lateMinutes?: number;
+    }>;
+  };
 }
 
 export interface ThrowawayTimetableStack {
@@ -157,6 +196,10 @@ export interface ThrowawaySchoolFixture {
   keycloakUserIds: Partial<Record<SeedRole, string>>;
   /** Populated when `withTimetableStack: true` was passed. */
   timetable?: ThrowawayTimetableStack;
+  /** Issue #138 — Student.id values matching the `withStudents` indexes. */
+  studentIds: string[];
+  /** Issue #138 — Populated when `withClassbookEntry` was passed. */
+  classBookEntryId?: string;
   cleanup: () => Promise<void>;
 }
 
@@ -180,6 +223,7 @@ async function resolveSeedKeycloakIds(
     const personIdByRole: Record<SeedRole, string> = {
       lehrer: 'd0000000-0000-4000-8000-000000000001',
       schulleitung: 'd0000000-0000-4000-8000-000000000002',
+      admin: 'd0000000-0000-4000-8000-000000000003',
       schueler: 'd0000000-0000-4000-8000-000000000004',
       eltern: 'd0000000-0000-4000-8000-000000000005',
     };
@@ -213,14 +257,19 @@ export async function createThrowawaySchool(
     withTimetableStack = false,
   } = options;
 
-  if (withTimetableStack && !roles.lehrer) {
-    throw new Error(
-      'createThrowawaySchool: withTimetableStack requires roles.lehrer (need a Person row to promote to Teacher)',
-    );
-  }
   if (withTimetableStack && withClasses < 1) {
     throw new Error(
       'createThrowawaySchool: withTimetableStack requires withClasses >= 1 (need a class for the ClassSubject)',
+    );
+  }
+  if (options.withClassbookEntry && !options.withTimetableStack) {
+    throw new Error(
+      'createThrowawaySchool: withClassbookEntry requires withTimetableStack (need teacherId + classSubjectId)',
+    );
+  }
+  if (options.withClassbookEntry && (!options.withStudents || options.withStudents.length === 0)) {
+    throw new Error(
+      'createThrowawaySchool: withClassbookEntry requires withStudents (need student rows to attach attendance to)',
     );
   }
 
@@ -282,15 +331,34 @@ export async function createThrowawaySchool(
 
     let timetable: ThrowawayTimetableStack | undefined;
     if (withTimetableStack) {
-      const lehrerPersonId = personIds.lehrer!;
       const classIdForStack = classIds[0];
 
-      // Teacher row for the lehrer Person. Teacher.personId is @unique
-      // (one Teacher per Person) — the throwaway Person was created fresh
-      // above, so no collision.
+      // Teacher row needs a Person row. Prefer the lehrer Person if the
+      // caller opted into roles.lehrer (legacy #137 path — kc-lehrer drives
+      // the spec); otherwise create a generic fixture-only Person so admin-
+      // driven specs (statistics-absence, admin-timetable-history) can still
+      // get a teacherId without dragging lehrer into the test.
+      let teacherPersonId: string;
+      if (personIds.lehrer) {
+        teacherPersonId = personIds.lehrer;
+      } else {
+        const fixtureTeacherPerson = await prisma.person.create({
+          data: {
+            schoolId: school.id,
+            personType: 'TEACHER',
+            firstName: `${namePrefix}-FixtureTeacher`,
+            lastName: suffix,
+          },
+        });
+        teacherPersonId = fixtureTeacherPerson.id;
+      }
+
+      // Teacher row for the Person. Teacher.personId is @unique (one
+      // Teacher per Person) — the Person was created fresh above, so no
+      // collision.
       const teacher = await prisma.teacher.create({
         data: {
-          personId: lehrerPersonId,
+          personId: teacherPersonId,
           schoolId: school.id,
         },
       });
@@ -391,6 +459,83 @@ export async function createThrowawaySchool(
       };
     }
 
+    // Issue #138 — students for admin-driven specs (statistics-absence,
+    // classbook surfaces). Each Student needs its own Person row; enroll
+    // them in classIds[0].
+    const studentIds: string[] = [];
+    if (options.withStudents && options.withStudents.length > 0) {
+      if (classIds.length === 0) {
+        throw new Error('createThrowawaySchool: withStudents requires withClasses >= 1');
+      }
+      const classForStudents = classIds[0];
+      for (const [i, name] of options.withStudents.entries()) {
+        const personRow = await prisma.person.create({
+          data: {
+            schoolId: school.id,
+            personType: 'STUDENT',
+            firstName: name.firstName,
+            lastName: name.lastName,
+          },
+        });
+        const studentRow = await prisma.student.create({
+          data: {
+            personId: personRow.id,
+            schoolId: school.id,
+            classId: classForStudents,
+            studentNumber: `${namePrefix}-S${i + 1}-${suffix}`,
+          },
+        });
+        studentIds.push(studentRow.id);
+      }
+    }
+
+    // Issue #138 — single ClassBookEntry + attendance records pinned to a
+    // deterministic date. The entry's unique key is (classSubjectId, date,
+    // periodNumber, weekType) — caller controls the period to avoid
+    // collisions with withTimetableStack's MONDAY/period-1 lesson.
+    let classBookEntryId: string | undefined;
+    if (options.withClassbookEntry) {
+      const cb = options.withClassbookEntry;
+      const period = cb.period ?? 5;
+      const stack = timetable!; // validated above
+      // ClassBookEntry.dayOfWeek mirrors the timetable-lesson's weekday
+      // semantically (i.e. "this is the Monday lesson"), independent of
+      // the calendar `date` column. Hardcoding MONDAY matches the
+      // timetable stack's seeded lesson and avoids the DayOfWeek enum
+      // missing SUNDAY trap when the caller passes a weekend date. This
+      // mirrors the legacy `fixtures/absence-stats.ts` behavior which
+      // hardcoded 'FRIDAY' even though 2026-03-15 is a Sunday.
+      const entry = await prisma.classBookEntry.create({
+        data: {
+          classSubjectId: stack.classSubjectId,
+          dayOfWeek: 'MONDAY',
+          periodNumber: period,
+          weekType: 'BOTH',
+          date: new Date(`${cb.date}T00:00:00Z`),
+          teacherId: stack.teacherId,
+          schoolId: school.id,
+        },
+      });
+      classBookEntryId = entry.id;
+
+      for (const att of cb.attendance) {
+        if (att.studentIndex >= studentIds.length) {
+          throw new Error(
+            `createThrowawaySchool: withClassbookEntry.attendance[].studentIndex=${att.studentIndex} out of range (only ${studentIds.length} students provisioned)`,
+          );
+        }
+        await prisma.attendanceRecord.create({
+          data: {
+            classBookEntryId: entry.id,
+            studentId: studentIds[att.studentIndex],
+            status: att.status,
+            lateMinutes: att.lateMinutes,
+            recordedBy: stack.teacherId,
+          },
+        });
+      }
+    }
+
     const capturedTimetable = timetable;
     const cleanup = async () => {
       const p = buildPrisma();
@@ -425,6 +570,8 @@ export async function createThrowawaySchool(
       personIds,
       keycloakUserIds,
       timetable,
+      studentIds,
+      classBookEntryId,
       cleanup,
     };
   } finally {

--- a/apps/web/e2e/statistics-absence.spec.ts
+++ b/apps/web/e2e/statistics-absence.spec.ts
@@ -1,96 +1,109 @@
 /**
  * Issue #87 — Absence-Statistics (Abwesenheitsstatistik) coverage.
  *
- * Surface: /statistics/absence (apps/web/src/routes/_authenticated/
- * statistics/absence.tsx, 50 LoC) → renders AbsenceStatisticsPanel.
- * Today only `roles-smoke.spec.ts` proves the page renders ohne crash;
- * there is no assertion that the per-student aggregation MATCHES the
- * underlying attendance data — exactly the kind of silent drift that
- * the statistics service's status-→-counter switch (statistics.service.
- * ts:144) and the D-04 Schulunterrichtsgesetz rule "Verspaetet >15 Min
- * zaehlt als abwesend" could quietly break.
+ * Migrated to the throwaway-school architecture in #138 wave 1: per-spec
+ * School + Class + Students + ClassBookEntry + AttendanceRecord rows
+ * provisioned via `createThrowawaySchool({ withStudents, withClassbookEntry })`,
+ * so the chromium-only-skip race-defense ("Mutates ClassBookEntry +
+ * AttendanceRecord on the shared seed class 1A — chromium is the sole
+ * writer") is GONE.
+ *
+ * Surface: /statistics/absence — renders AbsenceStatisticsPanel which
+ * auto-selects the first class by yearLevel+name asc. With a throwaway
+ * school there's only the throwaway class, so the auto-select picks it
+ * deterministically.
  *
  * Test-Strategie — single end-to-end aggregation lock:
  *
- *   STATS-AGG-3STUDENTS: seed exactly ONE ClassBookEntry on a fixed
- *   date (STATS_FIXTURE_DATE = 2026-03-15) with three AttendanceRecords:
+ *   STATS-AGG-3STUDENTS: seed exactly ONE ClassBookEntry on a fixed date
+ *   (STATS_FIXTURE_DATE) with three AttendanceRecords:
  *     - Lisa Huber    → PRESENT
  *     - Felix Bauer   → ABSENT
- *     - Sophie Wagner → LATE, lateMinutes=20 (counts as 1 Verspaetet
- *                          AND 1 Verspaetet>15Min per D-04)
+ *     - Sophie Wagner → LATE, lateMinutes=20 (counts as 1 Verspaetet AND
+ *                          1 Verspaetet>15Min per D-04 Schulunterrichts-
+ *                          gesetz, AND in absenceRate)
  *
- *   Admin opens /statistics/absence, the page auto-selects class 1A
- *   (the first class by yearLevel+name asc), the spec sets BOTH date
- *   inputs to the fixture date so the API filter narrows to our entry
- *   only, and the spec then asserts the three Fehlquote values:
+ *   Admin opens /statistics/absence, the page auto-selects the throwaway
+ *   class (only one available), the spec sets BOTH date inputs to the
+ *   fixture date, and asserts:
  *     - Felix Bauer  → 100.0%
  *     - Lisa Huber   →   0.0%
- *     - Sophie Wagner→ 100.0% (the >15min late + the absent share the
- *                              "counts as absent" semantics in absenceRate)
+ *     - Sophie Wagner→ 100.0%
  *
- * Why a fixed date instead of "today": the page's default date range
- * is the current Austrian school semester (statistics.service.ts:15
- * getSemesterDateRange), which spans ~5 months. Without a fixed date
- * input override, any leftover attendance noise from other classbook
- * specs in the same semester would pollute the counts and make the
- * assertions race-prone. The spec pins BOTH date inputs to
- * STATS_FIXTURE_DATE so the API call passes startDate=endDate=
- * 2026-03-15 and the backend filter `gte/lte` returns only the
- * fixture's entry. The fixture also uses a unique periodNumber (5,
- * not the period=1 that seedTimetableRun() uses) so the
- * ClassBookEntry.@@unique constraint can't collide with the
- * classbook-related fixtures.
+ * Why these names match the pre-migration seed names: keeps the assertions
+ * byte-identical to the original spec, minimizing diff for code review.
+ * The throwaway provisions Persons with these names, so the textual
+ * assertions still hit.
  *
- * Why Prisma-direct fixture: the path to create a ClassBookEntry via
- * API is `GET /classbook/by-timetable-lesson/:id` which upserts an
- * entry from a TimetableLesson — but it pins the entry's date to
- * the lesson's date (today) and the period to the lesson's period.
- * That doesn't give us deterministic control over the (classSubjectId,
- * date, period, weekType) tuple the statistics service aggregates on,
- * and would require seeding additional TimetableLessons for each
- * spec iteration. Direct Prisma insert hits the same uniqueness
- * constraint without the extra round-trips.
+ * Why a fixed date instead of today: pins the API filter to a single day,
+ * so the test only sees its own entry — bulletproof against parallel
+ * specs writing attendance on other dates (even though the throwaway
+ * already isolates per-school).
  *
- * Race-Family-Achtung: chromium-only-skip + per-test seed/cleanup.
- * The fixture deletes the ClassBookEntry in afterEach, which cascades
- * to the AttendanceRecord rows via `AttendanceRecord.classBookEntry`
- * onDelete: Cascade (schema.prisma:961).
+ * Cleanup: `fixture.cleanup()` drops the throwaway school via
+ * prisma.school.delete cascade — Person/Student/ClassBookEntry/
+ * AttendanceRecord all dissolve in the FK chain (post-#136+#137 cascade
+ * audit).
  */
 import { test, expect } from '@playwright/test';
 import { loginAsRole } from './helpers/login';
 import {
-  cleanupAbsenceStats,
-  seedAbsenceStats,
-  STATS_FIXTURE_DATE,
-  type AbsenceStatsFixture,
-} from './fixtures/absence-stats';
-import { SEED_SCHOOL_UUID } from './fixtures/seed-uuids';
+  createThrowawaySchool,
+  type ThrowawaySchoolFixture,
+} from './fixtures/throwaway-school';
+import { useThrowawaySchoolHeader } from './helpers/school-context';
 
-test.describe('Issue #87 — Absence-Statistics (desktop)', () => {
+export const STATS_FIXTURE_DATE = '2026-03-15';
+
+test.describe('Issue #87 — Absence-Statistics (desktop, throwaway-school)', () => {
   test.skip(
     ({ isMobile }) => isMobile,
     'Statistics table is wider than mobile viewport (horizontal scroll required) — mobile coverage would belong to its own *.mobile.spec.ts that asserts the sticky-name-column behaviour.',
   );
-  test.skip(
-    ({ browserName }) => browserName !== 'chromium',
-    'Mutates ClassBookEntry + AttendanceRecord rows on the shared seed class 1A — chromium is the sole writer (race-family precedent).',
-  );
+  // No chromium-only-skip: #138 wave 1 migration to throwaway-school
+  // eliminates the shared-seed-class race that made the original spec
+  // a sole-writer.
 
-  let fixture: AbsenceStatsFixture | undefined;
+  let fixture: ThrowawaySchoolFixture | undefined;
 
   test.beforeEach(async () => {
-    fixture = await seedAbsenceStats(SEED_SCHOOL_UUID);
+    fixture = await createThrowawaySchool({
+      roles: { admin: true },
+      withClasses: 1,
+      withTimetableStack: true,
+      withStudents: [
+        { firstName: 'Lisa', lastName: 'Huber' },
+        { firstName: 'Felix', lastName: 'Bauer' },
+        { firstName: 'Sophie', lastName: 'Wagner' },
+      ],
+      withClassbookEntry: {
+        date: STATS_FIXTURE_DATE,
+        period: 5,
+        attendance: [
+          { studentIndex: 0, status: 'PRESENT' }, // Lisa
+          { studentIndex: 1, status: 'ABSENT' }, // Felix
+          { studentIndex: 2, status: 'LATE', lateMinutes: 20 }, // Sophie
+        ],
+      },
+      namePrefix: 'E2E-SA',
+    });
   });
 
   test.afterEach(async () => {
-    if (!fixture) return;
-    await cleanupAbsenceStats(fixture);
-    fixture = undefined;
+    if (fixture) {
+      await fixture.cleanup();
+      fixture = undefined;
+    }
   });
 
   test('STATS-AGG-3STUDENTS: aggregated Fehlquote per student matches the seeded PRESENT/ABSENT/LATE>15 attendance', async ({
     page,
+    context,
   }) => {
+    if (!fixture) throw new Error('fixture not seeded');
+
+    await useThrowawaySchoolHeader(context, fixture.schoolId);
+
     await loginAsRole(page, 'admin');
     await page.goto('/statistics/absence');
 
@@ -107,10 +120,9 @@ test.describe('Issue #87 — Absence-Statistics (desktop)', () => {
     await dateInputs.nth(1).fill(STATS_FIXTURE_DATE);
 
     // Wait for the table to render with the seeded data.
-    // The page auto-selects classes[0] on mount (1A by yearLevel+name asc),
-    // so by the time we land here the API request for statistics has
-    // already been kicked off for 1A. The date-input changes invalidate
-    // the query and trigger a refetch.
+    // The page auto-selects classes[0] on mount; the throwaway school has
+    // exactly one class so the selection is deterministic. The date-input
+    // changes invalidate the query and trigger a refetch.
     const table = page.locator('table');
     await expect(table).toBeVisible();
 
@@ -126,9 +138,6 @@ test.describe('Issue #87 — Absence-Statistics (desktop)', () => {
     await expect(sophieRow).toBeVisible();
 
     // ── Felix Bauer: ABSENT → 100.0% Fehlquote ────────────────────────
-    // formatPercentage = `${value.toFixed(1)}%` ⇒ JS .toFixed uses dot,
-    // not the German comma decimal separator (AbsenceStatisticsPanel.
-    // tsx:49). The literal "100.0%" string therefore matches exactly.
     await expect(
       felixRow.getByText('100.0%', { exact: true }),
       'Felix Bauer is ABSENT for 1 of 1 lesson → Fehlquote 100.0% (absentUnexcused / totalLessons * 100, statistics.service.ts:170)',
@@ -142,10 +151,9 @@ test.describe('Issue #87 — Absence-Statistics (desktop)', () => {
 
     // ── Sophie Wagner: LATE 20min → 100.0% Fehlquote ──────────────────
     // D-04 Schulunterrichtsgesetz: lateMinutes > 15 counts in
-    // lateOver15MinCount AND in absenceRate.
-    // statistics.service.ts:171 puts (absentUnexcused + absentExcused +
-    // lateOver15Min) / totalLessons into absenceRate → (0 + 0 + 1) / 1 =
-    // 100.0%.
+    // lateOver15MinCount AND in absenceRate. statistics.service.ts:171
+    // puts (absentUnexcused + absentExcused + lateOver15Min) / totalLessons
+    // into absenceRate → (0 + 0 + 1) / 1 = 100.0%.
     await expect(
       sophieRow.getByText('100.0%', { exact: true }),
       'Sophie Wagner is LATE with lateMinutes=20 → lateOver15MinCount=1 → Fehlquote 100.0% (D-04 Schulunterrichtsgesetz rule)',


### PR DESCRIPTION
Refs #138, #123. **Wave 1 of 3 — does NOT close #138.**

## Why

First of three waves migrating the remaining chromium-only-skip specs to the throwaway-school architecture. Wave 1 unlocks **admin-driven** specs (the previous pilot #137 was lehrer-driven) and adds the fixture surface needed for classbook / attendance scenarios.

## What ships

### Fixture extensions (`createThrowawaySchool`)

| New option | Behavior |
| --- | --- |
| `roles.admin: true` | Admin gets a TEACHER-type Person row (PersonType irrelevant — admin's authz is KC-role based; the Person row exists purely to satisfy `CurrentSchoolInterceptor`'s membership check) |
| `withTimetableStack: true` *without* `roles.lehrer` | Now creates a generic fixture-only Teacher Person — needed because admin-driven specs still need a `teacherId` for the ClassBookEntry but don't need lehrer in the test |
| `withStudents: [{firstName, lastName}, ...]` | Provisions Person + Student rows enrolled in `classIds[0]` |
| `withClassbookEntry: { date, period?, attendance: [...] }` | Provisions a single ClassBookEntry + N AttendanceRecord rows pinned to a deterministic date |

```ts
const fixture = await createThrowawaySchool({
  roles: { admin: true },
  withTimetableStack: true,
  withStudents: [
    { firstName: 'Lisa', lastName: 'Huber' },
    { firstName: 'Felix', lastName: 'Bauer' },
    { firstName: 'Sophie', lastName: 'Wagner' },
  ],
  withClassbookEntry: {
    date: '2026-03-15',
    period: 5,
    attendance: [
      { studentIndex: 0, status: 'PRESENT' },
      { studentIndex: 1, status: 'ABSENT' },
      { studentIndex: 2, status: 'LATE', lateMinutes: 20 },
    ],
  },
});
// fixture.studentIds + fixture.classBookEntryId also populated.
```

Cleanup unchanged: `prisma.school.delete` cascades via post-#136 + #137 FK audit.

### Spec migration (`statistics-absence.spec.ts`)

| Before | After |
| --- | --- |
| `test.skip(({browserName}) => browserName !== 'chromium', ...)` | NO chromium-only-skip |
| Seed students Lisa Huber / Felix Bauer / Sophie Wagner in class 1A | Throwaway provisions the same names in its own class (byte-identical assertions, minimal diff) |
| Bespoke `fixtures/absence-stats.ts` Prisma helper | Throwaway fixture |
| Per-spec sweep / advisory-lock pattern | `fixture.cleanup()` (single school.delete cascade) |

### Fixture trap discovered + documented

`ClassBookEntry.dayOfWeek` is the lesson's WEEKDAY enum, not the calendar weekday of the `date` column. The `DayOfWeek` enum excludes SUNDAY. Fixture hardcodes `dayOfWeek: 'MONDAY'` (matches timetable stack) — mirrors the legacy absence-stats fixture which hardcoded 'FRIDAY' even though 2026-03-15 is a Sunday. Documented inline.

## Verification

- [x] `pnpm exec tsc` clean
- [x] **10/10 cross-project parallel runs of `statistics-absence.spec.ts` (chromium + firefox, 2 workers) — zero flakes**
- [x] **26/26 combined run of all Phase 3 specs + both migrated specs (throwaway-school-smoke, auth-user-context, current-school-context, timetable-cell-badges #137, statistics-absence #138 wave 1) on desktop + desktop-firefox**

## Wave plan (#138)

- **Wave 1 (this PR)**: admin role + students/classbook fixture extensions + statistics-absence migration ✅
- **Wave 2 (next PR)**: admin-timetable-history migration (needs TimetableLessonEdit fixture extension)
- **Wave 3 (final PR)**: timetable-generation-flow migration + remove redundant Phase 2/4 advisory locks + CLAUDE.md D4 update (throwaway-school = PRIMARY) + close #138 and #123

## Test plan

- [x] CI grün on first try (D3)
- [ ] Post-merge sanity: pull main, run `statistics-absence.spec.ts --project=desktop --project=desktop-firefox` once locally to confirm