### PR TITLE
feat(e2e): #138 wave 2 — migrate admin-timetable-history to throwaway + classNames + TimetableLessonEdit fixture extensions

### DIFF
--- a/apps/web/e2e/admin-timetable-history.spec.ts
+++ b/apps/web/e2e/admin-timetable-history.spec.ts
@@ -1,102 +1,76 @@
 /**
  * Issue #87 — Admin Aenderungsverlauf (Timetable Edit History) coverage.
  *
- * Surface: /admin/timetable-history (apps/web/src/routes/_authenticated/
- * admin/timetable-history.tsx, 104 LoC). Renders the EditHistoryPanel for
- * the active TimetableRun. Today only `roles-smoke.spec.ts` proves the
- * page rendert ohne Crash — there is no assertion that an actual edit
- * shows up with the right action badge + description + revert
- * confirmation copy.
+ * Migrated to the throwaway-school architecture in #138 wave 2: per-spec
+ * School + active TimetableRun + TimetableLesson + TimetableLessonEdit are
+ * provisioned via `createThrowawaySchool({ withTimetableStack: true,
+ * withTimetableEdit: { ... } })`, so the chromium-only-skip race-defense
+ * ("Mutates active TimetableRun on shared seed school — chromium is the
+ * sole writer") is GONE.
  *
- * Test-Strategie:
+ * Surface: /admin/timetable-history renders the EditHistoryPanel for the
+ * active TimetableRun. The fixture pins a single "move" edit row from
+ * MONDAY/1 → TUESDAY/2 so the page must render:
+ *   - heading "Aenderungsverlauf" + card title "Manuelle Aenderungen…"
+ *   - the seeded edit row with badge "Verschoben" + description
+ *     "MONDAY 1. Std. -> TUESDAY 2. Std." (per EditHistoryPanel.tsx:100)
+ *   - the "Rueckgaengig" button (revert dialog covered by TT-HIST-REVERT-DIALOG)
  *
- *   TT-HIST-RENDER: seed a TimetableRun + TimetableLesson + one
- *   TimetableLessonEdit row of action "move" (MONDAY/1 → TUESDAY/2),
- *   admin selects class 1A perspective on /timetable so the
- *   useTimetableStore has a perspective set, then navigates to
- *   /admin/timetable-history. The page must render:
- *     - heading "Aenderungsverlauf" + card title "Manuelle Aenderungen…"
- *     - the seeded edit row with badge "Verschoben", description
- *       "MONDAY 1. Std. -> TUESDAY 2. Std." (per EditHistoryPanel.tsx:100)
- *     - the "Rueckgaengig" button
+ * The throwaway class is explicitly named "1A" via the fixture's
+ * `classNames` option so the PerspectiveSelector assertion text stays
+ * byte-identical to the legacy seed-school path (minimal review diff).
  *
- *   TT-HIST-REVERT-DIALOG: clicking "Rueckgaengig" must open the
- *   confirmation dialog with title "Aenderung rueckgaengig machen" and
- *   the destructive-copy paragraph that references "spaeter vorgenommenen
- *   Aenderungen gehen verloren". "Abbrechen" closes the dialog without
- *   touching the edit row (cleanup must still find it).
- *
- * Why we don't actually revert: revert mutates the underlying
- * TimetableLesson back to the previousState (timetable-edit.service.ts:
- * revertToEdit), which would race the seedTimetableRun() lesson
- * coordinates with sibling specs. The confirmation-dialog open is the
- * regression we want to lock — the actual mutation path is covered by
- * the dnd / edit-perspective specs.
- *
- * Why Prisma-direct seeding: TimetableLessonEdit is an audit-log row
- * with no API for direct creation (only PATCH /move plants edit rows as
- * a side-effect, and driving a real move via UI would mutate the lesson
- * grid — much wider blast radius). The `seedTimetableEdit()` helper
- * uses the same `createRequire(Prisma client)` bridge as
- * `seedTimetableRun()`. See fixtures/timetable-run.ts:seedTimetableEdit
- * for the rationale.
- *
- * Race-Family-Achtung: chromium-only-skip + per-test seeding (same
- * precedent as the #86 non-admin-view specs). The TimetableLessonEdit
- * FK has no onDelete: Cascade on `run_id`, so cleanup MUST drop the
- * edit row before the run row — `cleanupTimetableEdit` first, then
- * `cleanupTimetableRun`. Reversed order leaks edit rows that subsequent
- * runs see as ghost history.
+ * Cleanup: `fixture.cleanup()` deletes the TimetableLessonEdit explicitly
+ * first (no FK cascade — schema audit in #138 wave 2 documented this gap),
+ * then the TimetableRun (CASCADE on runId frees the room FK), then the
+ * School (cascade does the rest).
  */
 import { test, expect } from '@playwright/test';
 import { loginAsRole } from './helpers/login';
 import {
-  cleanupTimetableEdit,
-  cleanupTimetableRun,
-  seedTimetableEdit,
-  seedTimetableRun,
-  type TimetableEditFixture,
-  type TimetableRunFixture,
-} from './fixtures/timetable-run';
-import { SEED_SCHOOL_UUID } from './fixtures/seed-uuids';
+  createThrowawaySchool,
+  type ThrowawaySchoolFixture,
+} from './fixtures/throwaway-school';
+import { useThrowawaySchoolHeader } from './helpers/school-context';
 
-test.describe('Issue #87 — Admin timetable-history (desktop)', () => {
+test.describe('Issue #87 — Admin timetable-history (desktop, throwaway-school)', () => {
   test.skip(
     ({ isMobile }) => isMobile,
     'Aenderungsverlauf is an admin-desktop surface. Mobile coverage of the EditHistoryPanel would belong to its own *.mobile.spec.ts.',
   );
-  test.skip(
-    ({ browserName }) => browserName !== 'chromium',
-    'Mutates active TimetableRun on shared seed school — chromium is the sole writer (race-family precedent).',
-  );
+  // No chromium-only-skip: #138 wave 2 migration to throwaway-school
+  // eliminates the active-TimetableRun-singleton race on the seed school.
 
-  let run: TimetableRunFixture | undefined;
-  let edit: TimetableEditFixture | undefined;
+  let fixture: ThrowawaySchoolFixture | undefined;
 
   test.beforeEach(async () => {
-    run = await seedTimetableRun(SEED_SCHOOL_UUID);
-    edit = await seedTimetableEdit(run.runId, run.lessonId);
+    fixture = await createThrowawaySchool({
+      roles: { admin: true },
+      withClasses: 1,
+      classNames: ['1A'],
+      withTimetableStack: true,
+      withTimetableEdit: {
+        previousState: { dayOfWeek: 'MONDAY', periodNumber: 1 },
+        newState: { dayOfWeek: 'TUESDAY', periodNumber: 2 },
+      },
+      namePrefix: 'E2E-TH',
+    });
   });
 
   test.afterEach(async () => {
-    // CRITICAL ORDER: TimetableLessonEdit.run_id has NO onDelete: Cascade
-    // (schema.prisma:799–808). Dropping the run first would leave the
-    // edit row dangling — Postgres allows it (no FK constraint), but the
-    // ghost row pollutes subsequent test fixtures' history-length
-    // assertions. Drop the edit FIRST, then the run.
-    if (edit) {
-      await cleanupTimetableEdit(edit);
-      edit = undefined;
-    }
-    if (run) {
-      await cleanupTimetableRun(run);
-      run = undefined;
+    if (fixture) {
+      await fixture.cleanup();
+      fixture = undefined;
     }
   });
 
   test('TT-HIST-RENDER: seeded "Verschoben" edit row + description show up on /admin/timetable-history', async ({
     page,
+    context,
   }) => {
+    if (!fixture) throw new Error('fixture not seeded');
+
+    await useThrowawaySchoolHeader(context, fixture.schoolId);
     await loginAsRole(page, 'admin');
 
     // ── Step 1: prime the timetable store with a perspective ────────────
@@ -104,7 +78,7 @@ test.describe('Issue #87 — Admin timetable-history (desktop)', () => {
     // the zustand timetable-store and is empty-state until they are set.
     // Admin auto-perspective is not auto-set; we mimic the same flow the
     // admin-timetable-edit-perspective spec uses to drive the
-    // PerspectiveSelector to class 1A.
+    // PerspectiveSelector to class 1A (the throwaway class name).
     await page.goto('/timetable');
     const perspectiveTrigger = page.getByRole('combobox').first();
     await expect(perspectiveTrigger).toBeVisible();
@@ -123,9 +97,7 @@ test.describe('Issue #87 — Admin timetable-history (desktop)', () => {
     // is disabled when perspectiveId is null. Clicking the sidebar link
     // routes via TanStack Router's history-API navigation — the store
     // survives, the view query runs with our seeded perspective, and
-    // the page renders the EditHistoryPanel. Observed 2026-05-18:
-    // page.goto produced the empty-state regardless of how /timetable
-    // primed the store.
+    // the page renders the EditHistoryPanel.
     await page.getByRole('link', { name: 'Aenderungsverlauf' }).click();
 
     await expect(
@@ -161,7 +133,11 @@ test.describe('Issue #87 — Admin timetable-history (desktop)', () => {
 
   test('TT-HIST-REVERT-DIALOG: "Rueckgaengig" opens the confirmation dialog with destructive copy and Abbrechen closes it', async ({
     page,
+    context,
   }) => {
+    if (!fixture) throw new Error('fixture not seeded');
+
+    await useThrowawaySchoolHeader(context, fixture.schoolId);
     await loginAsRole(page, 'admin');
     await page.goto('/timetable');
     const perspectiveTrigger = page.getByRole('combobox').first();
@@ -197,8 +173,8 @@ test.describe('Issue #87 — Admin timetable-history (desktop)', () => {
     ).toBeVisible();
 
     // "Abbrechen" closes the dialog without firing the revert mutation —
-    // the edit row therefore stays in the DB and cleanupTimetableEdit
-    // can still find it in afterEach.
+    // the edit row therefore stays in the DB and fixture.cleanup() can
+    // still find it in afterEach.
     await page.getByRole('button', { name: 'Abbrechen' }).click();
     await expect(page.getByRole('dialog')).toHaveCount(0);
     // Sanity: the row is still there.

--- a/apps/web/e2e/fixtures/throwaway-school.ts
+++ b/apps/web/e2e/fixtures/throwaway-school.ts
@@ -95,6 +95,10 @@ const { PrismaClient } = require('../../../api/dist/config/database/generated/cl
     timetableLesson: {
       create: (args: any) => Promise<{ id: string; dayOfWeek: string; periodNumber: number }>;
     };
+    timetableLessonEdit: {
+      create: (args: any) => Promise<{ id: string }>;
+      deleteMany: (args: any) => Promise<unknown>;
+    };
     $disconnect: () => Promise<void>;
   };
 };
@@ -129,7 +133,15 @@ export interface ThrowawaySchoolOptions {
   roles?: Partial<Record<SeedRole, boolean>>;
   /** Number of SchoolClasses to seed (default 1). */
   withClasses?: number;
-  /** Prefix for the school's name + class names — keeps cross-spec greps trivial. */
+  /**
+   * Issue #138 — explicit class names that override the default
+   * `${namePrefix}-K{i+1}` generation. Must match `withClasses` in length.
+   * Useful for UI specs that select a class by name (PerspectiveSelector
+   * shows the name not the id) — passing `['1A']` keeps assertions
+   * identical to pre-migration seed-school specs.
+   */
+  classNames?: string[];
+  /** Prefix for the school's name + (default) class names — keeps cross-spec greps trivial. */
   namePrefix?: string;
   /**
    * Issue #137 — opt-in timetable stack for UI specs that need a TimetableRun
@@ -166,6 +178,17 @@ export interface ThrowawaySchoolOptions {
       lateMinutes?: number;
     }>;
   };
+  /**
+   * Issue #138 wave 2 — opt-in TimetableLessonEdit audit-log row attached
+   * to the timetable stack's lesson. Single "move" edit row; EditHistoryPanel
+   * renders the description as
+   *   `${previousState.dayOfWeek} ${previousState.periodNumber}. Std. -> ${newState.dayOfWeek} ${newState.periodNumber}. Std.`
+   * Requires `withTimetableStack: true`.
+   */
+  withTimetableEdit?: {
+    previousState: { dayOfWeek: string; periodNumber: number };
+    newState: { dayOfWeek: string; periodNumber: number };
+  };
 }
 
 export interface ThrowawayTimetableStack {
@@ -200,6 +223,8 @@ export interface ThrowawaySchoolFixture {
   studentIds: string[];
   /** Issue #138 — Populated when `withClassbookEntry` was passed. */
   classBookEntryId?: string;
+  /** Issue #138 wave 2 — Populated when `withTimetableEdit` was passed. */
+  timetableEditId?: string;
   cleanup: () => Promise<void>;
 }
 
@@ -272,6 +297,16 @@ export async function createThrowawaySchool(
       'createThrowawaySchool: withClassbookEntry requires withStudents (need student rows to attach attendance to)',
     );
   }
+  if (options.classNames && options.classNames.length !== withClasses) {
+    throw new Error(
+      `createThrowawaySchool: classNames.length (${options.classNames.length}) must match withClasses (${withClasses})`,
+    );
+  }
+  if (options.withTimetableEdit && !withTimetableStack) {
+    throw new Error(
+      'createThrowawaySchool: withTimetableEdit requires withTimetableStack (no lesson to attach the edit to)',
+    );
+  }
 
   const prisma = buildPrisma();
   try {
@@ -302,7 +337,7 @@ export async function createThrowawaySchool(
       const klass = await prisma.schoolClass.create({
         data: {
           schoolId: school.id,
-          name: `${namePrefix}-K${i + 1}`,
+          name: options.classNames?.[i] ?? `${namePrefix}-K${i + 1}`,
           yearLevel: 5 + i,
           schoolYearId: schoolYear.id,
         },
@@ -536,10 +571,42 @@ export async function createThrowawaySchool(
       }
     }
 
+    // Issue #138 wave 2 — single TimetableLessonEdit audit-log row. No FK
+    // on runId/lessonId means we have to delete the row explicitly in
+    // cleanup (won't cascade from TimetableRun delete). The editedBy
+    // column is a free-form string — fixture uses a deterministic UUID-
+    // shaped placeholder so the row is visually distinguishable from
+    // production-edited rows in a debugger.
+    let timetableEditId: string | undefined;
+    if (options.withTimetableEdit) {
+      const stack = timetable!; // validated above
+      const edit = await prisma.timetableLessonEdit.create({
+        data: {
+          runId: stack.timetableRunId,
+          lessonId: stack.timetableLessonId,
+          editedBy: '00000000-0000-4000-8000-00000000e2e1',
+          editAction: 'move',
+          previousState: options.withTimetableEdit.previousState,
+          newState: options.withTimetableEdit.newState,
+        },
+      });
+      timetableEditId = edit.id;
+    }
+
     const capturedTimetable = timetable;
     const cleanup = async () => {
       const p = buildPrisma();
       try {
+        // Issue #138 wave 2 — TimetableLessonEdit has NO FK on runId or
+        // lessonId (Prisma schema omits @relation for both — schema audit
+        // confirmed). Cascade from School/Run does NOT reach edit rows;
+        // explicit deleteMany scoped to our run keeps them from ghosting
+        // future history-length assertions.
+        if (capturedTimetable) {
+          await p.timetableLessonEdit.deleteMany({
+            where: { runId: capturedTimetable.timetableRunId },
+          });
+        }
         // Issue #137 — `timetable_lessons.room_id` is still RESTRICT (#137
         // intentionally keeps it so admin Room deletes get a 409 instead
         // of silently nuking lessons). For the throwaway cleanup that
@@ -572,6 +639,7 @@ export async function createThrowawaySchool(
       timetable,
       studentIds,
       classBookEntryId,
+      timetableEditId,
       cleanup,
     };
   } finally {


### PR DESCRIPTION
Refs #138, #123. **Wave 2 of 3 — does NOT close #138.**

## Why

Second of three waves migrating the remaining chromium-only-skip specs to the throwaway-school architecture. Wave 2 unlocks admin-driven UI specs that need a TimetableRun + TimetableLessonEdit on a per-spec-isolated school.

## What ships

### Fixture extensions (`createThrowawaySchool`)

| New option | Behavior |
| --- | --- |
| `classNames: string[]` | Overrides default `${namePrefix}-K{i+1}` class naming. UI specs that select a class by name can pass `['1A']` for byte-identical assertions vs the legacy seed-school path. |
| `withTimetableEdit: { previousState, newState }` | Provisions a single "move" TimetableLessonEdit row attached to the timetable stack's lesson. Requires `withTimetableStack: true`. |

Cleanup now also explicitly drops `timetableLessonEdit.deleteMany({ runId })` BEFORE the TimetableRun delete — schema audit confirmed `TimetableLessonEdit` has no Prisma `@relation` on `runId`/`lessonId` (and no DB-level FK), so cascade from School/Run does NOT reach edit rows. Without this, ghost edit rows would pollute future history-length assertions.

```ts
const fixture = await createThrowawaySchool({
  roles: { admin: true },
  classNames: ['1A'],
  withTimetableStack: true,
  withTimetableEdit: {
    previousState: { dayOfWeek: 'MONDAY', periodNumber: 1 },
    newState: { dayOfWeek: 'TUESDAY', periodNumber: 2 },
  },
});
// fixture.timetableEditId also populated.
```

### Spec migration (`admin-timetable-history.spec.ts`)

| Before | After |
| --- | --- |
| `test.skip(({browserName}) => browserName !== 'chromium', 'Mutates active TimetableRun on shared seed school')` | NO chromium-only-skip |
| `seedTimetableRun(SEED_SCHOOL_UUID)` + `seedTimetableEdit()` against seed class 1A | Throwaway school provisions class named "1A" via new `classNames` option (PerspectiveSelector assertion stays byte-identical) |
| Advisory-lock-protected active-TimetableRun-singleton race precedent | No lock needed — each spec has its own school |

`useThrowawaySchoolHeader(context, fixture.schoolId)` binds admin to the throwaway via `context.route` (X-School-Id on every /api/** request). SPA-link navigation (NOT `page.goto`) preserved — same Zustand-store-survival rationale as the pre-migration spec.

## Verification

- [x] `pnpm exec tsc -p tsconfig.app.json --noEmit` clean
- [x] **20/20 cross-project parallel runs of `admin-timetable-history.spec.ts` (chromium + firefox, 2 workers, both TT-HIST-RENDER + TT-HIST-REVERT-DIALOG) — zero flakes**
- [x] **30/30 combined run of all Phase 3 specs + all three migrated specs (`throwaway-school-smoke`, `auth-user-context`, `current-school-context`, `timetable-cell-badges` #137, `statistics-absence` #138 wave 1, `admin-timetable-history` #138 wave 2) on both desktop + desktop-firefox**

## Wave plan (#138)

- **Wave 1**: admin role + students/classbook fixture extensions + statistics-absence migration ✅ (#144, merged)
- **Wave 2 (this PR)**: classNames + TimetableLessonEdit fixture extensions + admin-timetable-history migration ✅
- **Wave 3 (final PR)**: timetable-generation-flow migration + remove redundant Phase 2/4 advisory locks + CLAUDE.md D4 update (throwaway-school = PRIMARY) + close #138 and #123

## Test plan

- [x] CI grün on first try (D3)
- [ ] Post-merge sanity: pull main, run `admin-timetable-history.spec.ts --project=desktop --project=desktop-firefox` once locally to confirm