### PR TITLE
feat(e2e): #138 wave 3 — migrate timetable-generation-flow + CLAUDE.md D4 throwaway=PRIMARY + close Phase 3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,17 +53,16 @@ Begründung: GSD-State über zu viele Files verteilt → Plan-vs-Realität-Drift
 - "Race ist bekannt, wir lassen den flake durchschnaufen" + Re-Run-Hoffnung
 
 **Erlaubt / Gefordert:**
-- **Throwaway-School-Fixture als Default für neue Specs:** eigene `schoolId` pro Spec/Test, am Ende cascade-deleten. `SEED_SCHOOL_UUID` nur lesen, nicht beschreiben — außer wenn KC-User-Bindung das zwingend macht (dann explizit dokumentieren).
+- **Throwaway-School-Fixture als PRIMARY für neue Specs:** `createThrowawaySchool()` aus `apps/web/e2e/fixtures/throwaway-school.ts` erzeugt pro Spec eine eigene `schoolId` + Stammdaten + optionale Person/Teacher/Subject/ClassSubject/Room/TimeGrid/Run/Lesson/Students/ClassBookEntry/TimetableLessonEdit. Cleanup via `fixture.cleanup()` (cascade-delete der School). Header-Binding via `useThrowawaySchoolHeader(context, fixture.schoolId)`. `SEED_SCHOOL_UUID` nur lesen, nicht beschreiben — außer wenn KC-User-Bindung das zwingend macht (dann explizit dokumentieren).
 - **Architektonischer Fix bei Race-Discovery:** transactional cleanup, unique-per-test-keys, isolierte resources. Nicht das Symptom mit chromium-only patchen, sondern die geteilte Resource entkoppeln.
 - **Pragmatischer Workaround zulässig** — aber NUR mit `// FIXME: deterministic-e2e #112` Comment + Verweis auf [Issue #112](https://github.com/martinvidec/openaustria-school-flow/issues/112), das die Bestandsaufnahme + Refactor trackt.
 
-**Why:** PR #109 CI rot wegen `zeitraster.spec.ts` ↔ `wochentage.spec.ts` Race auf `/time-grid` PUT-replace-all — beide writer, kein Skip auf `wochentage`. Pre-existing seit Phase 10. Meine #87-Specs sind nicht der Auslöser, aber jede neue chromium-Spec erhöht die Race-Wahrscheinlichkeit. Memory `feedback_e2e_deterministic.md` + `project_e2e_parallel_cleanup_race_family.md` enthalten den vollen Kontext und die Liste aktiver Race-Families (TimeGrid, active-TimetableRun-singleton, CalendarToken pre-existing rows, ClassBookEntry @@unique-Kollisionen).
+**Why:** PR #109 CI rot wegen `zeitraster.spec.ts` ↔ `wochentage.spec.ts` Race auf `/time-grid` PUT-replace-all — beide writer, kein Skip auf `wochentage`. Pre-existing seit Phase 10. Phase 3 (#123 → #133/#134/#135/#136/#137/#138) hat die architektonische Lösung gebaut: composite `Person.keycloakUserId @@unique([keycloakUserId, schoolId])` (#133), CurrentSchoolInterceptor mit `X-School-Id` header (#135), `createThrowawaySchool` Fixture inkl. timetable / classbook / edit stacks (#136 + #137 + #138). Memory `feedback_e2e_deterministic.md` + `project_e2e_parallel_cleanup_race_family.md` haben den Kontext.
 
 **How to apply:**
-1. Bei JEDER neuen E2E-Spec: throwaway-school-Fixture als Default versuchen. Wenn nicht möglich → in der Spec-Begründung dokumentieren WARUM nicht.
-2. Bei Race-Discovery in einer Bestandsspec: zuerst das Determinismus-Issue konsultieren, dort den Fix tracken, nicht ad-hoc chromium-only-skip dranschrauben.
-3. Bei den noch offenen E2E-Issues (#103 Klassenbuch-Realtime u.ä.): explizit prüfen ob throwaway-school möglich ist BEVOR Spec-Code geschrieben wird.
-4. Existierende chromium-only-skip + disjoint-personas Workarounds bleiben TEMPORÄR drin, sind aber im Determinismus-Issue zu listen und mittelfristig zu entfernen.
+1. Bei JEDER neuen E2E-Spec: throwaway-school-Fixture **ist der Default**. Spec-Pattern: `createThrowawaySchool({ roles, withClasses, withTimetableStack?, withStudents?, withClassbookEntry?, withTimetableEdit? })` → `useThrowawaySchoolHeader(context, fixture.schoolId)` → assertions → `fixture.cleanup()` in afterEach. Wenn nicht möglich → in der Spec-Begründung dokumentieren WARUM nicht (z.B. spec testet seed-bound Auth-Flow ohne Schreibrechte).
+2. Bei Race-Discovery in einer Bestandsspec: zuerst auf throwaway-school migrieren statt ad-hoc chromium-only-skip dranzuschrauben.
+3. Existierende advisory-locks (`helpers/advisory-lock.ts`) auf seed-school-shared resources (TimeGrid, CalendarToken, messaging, classbook, excuses, etc.) sind LEGACY — sie werden pro Spec entfernt sobald die jeweilige Spec auf throwaway migriert ist. Tracker: ein eigenes Follow-up Issue (Phase 3.5).
 
 ## D5 — GitHub Issue-Relationships statt nur Text-Refs (User-Direktive 2026-05-19)
 

--- a/apps/web/e2e/fixtures/throwaway-school.ts
+++ b/apps/web/e2e/fixtures/throwaway-school.ts
@@ -148,10 +148,15 @@ export interface ThrowawaySchoolOptions {
    * to render against. Provisions: Teacher row (for `roles.lehrer` Person if
    * present, otherwise a generic fixture-only Person), Subject, ClassSubject
    * (joining Class[0] + Subject + Teacher), Room, TimeGrid with period 1
-   * (08:00-08:50), SchoolDays MON-FRI active, TimetableRun (active),
-   * TimetableLesson at MONDAY/period-1.
+   * (08:00-08:50), SchoolDays MON-FRI active, TimetableRun (active by
+   * default), TimetableLesson at MONDAY/period-1.
+   *
+   * Issue #138 wave 3 — pass `{ active: false }` to seed a COMPLETED but
+   * inactive TimetableRun (covers the activation-recovery flow from #60).
+   * The boolean shorthand `true` stays equivalent to `{ active: true }`
+   * so existing callers keep working unchanged.
    */
-  withTimetableStack?: boolean;
+  withTimetableStack?: boolean | { active?: boolean };
   /**
    * Issue #138 — list of students to provision in the throwaway. Each entry
    * creates a Person + Student row enrolled in `classIds[0]`. Names show up
@@ -193,12 +198,22 @@ export interface ThrowawaySchoolOptions {
 
 export interface ThrowawayTimetableStack {
   teacherId: string;
+  /**
+   * Issue #138 wave 3 — Teacher display name in the format the
+   * PerspectiveSelector renders: `${lastName} ${firstName}` (per
+   * apps/web/src/hooks/useTimetable.ts:78). Specs use this to pick the
+   * right "Lehrer" option from the dropdown without depending on the
+   * exact internal id of the throwaway teacher.
+   */
+  teacherDisplayName: string;
   subjectId: string;
   subjectShortName: string;
   classSubjectId: string;
   roomId: string;
   timeGridId: string;
   timetableRunId: string;
+  /** True when the seeded TimetableRun is `isActive=true` (the default). */
+  timetableRunActive: boolean;
   timetableLessonId: string;
   /** The class the ClassSubject is bound to (always classIds[0] today). */
   classId: string;
@@ -281,6 +296,13 @@ export async function createThrowawaySchool(
     namePrefix = 'E2E-TS',
     withTimetableStack = false,
   } = options;
+  // Normalize the boolean | object overload into a single shape downstream.
+  const timetableStackConfig: false | { active: boolean } =
+    withTimetableStack === false
+      ? false
+      : withTimetableStack === true
+        ? { active: true }
+        : { active: withTimetableStack.active ?? true };
 
   if (withTimetableStack && withClasses < 1) {
     throw new Error(
@@ -374,19 +396,29 @@ export async function createThrowawaySchool(
       // driven specs (statistics-absence, admin-timetable-history) can still
       // get a teacherId without dragging lehrer into the test.
       let teacherPersonId: string;
+      let teacherFirstName: string;
+      let teacherLastName: string;
       if (personIds.lehrer) {
         teacherPersonId = personIds.lehrer;
+        teacherFirstName = `${namePrefix}-lehrer`;
+        teacherLastName = suffix;
       } else {
+        teacherFirstName = `${namePrefix}-FixtureTeacher`;
+        teacherLastName = suffix;
         const fixtureTeacherPerson = await prisma.person.create({
           data: {
             schoolId: school.id,
             personType: 'TEACHER',
-            firstName: `${namePrefix}-FixtureTeacher`,
-            lastName: suffix,
+            firstName: teacherFirstName,
+            lastName: teacherLastName,
           },
         });
         teacherPersonId = fixtureTeacherPerson.id;
       }
+      // PerspectiveSelector renders this exact string (`${lastName} ${firstName}`,
+      // useTimetable.ts:78); expose it so specs can pick the right
+      // "Lehrer" option from the dropdown.
+      const teacherDisplayName = `${teacherLastName} ${teacherFirstName}`;
 
       // Teacher row for the Person. Teacher.personId is @unique (one
       // Teacher per Person) — the Person was created fresh above, so no
@@ -454,11 +486,12 @@ export async function createThrowawaySchool(
         });
       }
 
+      const runActive = (timetableStackConfig as { active: boolean }).active;
       const run = await prisma.timetableRun.create({
         data: {
           schoolId: school.id,
           status: 'COMPLETED',
-          isActive: true,
+          isActive: runActive,
           maxSolveSeconds: 300,
           abWeekEnabled: false,
           hardScore: 0,
@@ -481,12 +514,14 @@ export async function createThrowawaySchool(
 
       timetable = {
         teacherId: teacher.id,
+        teacherDisplayName,
         subjectId: subject.id,
         subjectShortName: subject.shortName,
         classSubjectId: classSubject.id,
         roomId: room.id,
         timeGridId: timeGrid.id,
         timetableRunId: run.id,
+        timetableRunActive: runActive,
         timetableLessonId: lesson.id,
         classId: classIdForStack,
         lessonDayOfWeek: 'MONDAY',

--- a/apps/web/e2e/timetable-generation-flow.spec.ts
+++ b/apps/web/e2e/timetable-generation-flow.spec.ts
@@ -1,50 +1,38 @@
 /**
  * Issue #60 — End-to-end regression guard for the solver's user-visible output.
  *
- * The user reported that the solver said "Generierung abgeschlossen" but the
- * timetable was nowhere to be found. Diagnosis (live DB inspection):
- *   - 2 runs in status COMPLETED with 64 persisted timetable_lessons rows
- *   - All 3 runs had isActive=false → /timetable was empty
+ * Migrated to the throwaway-school architecture in #138 wave 3: per-spec
+ * School + TimetableRun + lesson are provisioned via `createThrowawaySchool`
+ * so the chromium-only-skip race-defense ("flaky on parallel browser
+ * projects — see #54 (shared seed-school race)") is GONE.
  *
- * Root cause is twofold:
- *   1. The /admin/solver page only renders an Aktivieren button via the
- *      WS-driven `lastResult` state. If the solve:complete event was lost
- *      (watchdog flipped first, page was mid-reconnect, browser tab not
- *      focused while the run completed), the button never appears and the
- *      COMPLETED run is invisible to the user.
- *   2. There was no automated test covering "solver run produces
- *      user-visible timetable" — only constraint correctness + DB
- *      persistence were tested. The activation step fell off the contract.
+ * Background (unchanged): the user reported the solver said "Generierung
+ * abgeschlossen" but the timetable was nowhere to be found. Root cause was
+ * twofold (1) /admin/solver only renders an Aktivieren button via the
+ * WS-driven lastResult state; if the solve:complete event was lost the
+ * button never appeared, (2) there was no automated test covering "solver
+ * run produces user-visible timetable". This spec is the lock for both.
  *
- * Two specs:
- *   GEN-01 — fast-path:
- *     Active run with lessons already in DB → /timetable renders cells.
- *     Catches /timetable rendering regressions independent of activation.
- *
- *   GEN-02 — activation-recovery:
- *     COMPLETED but inactive run in DB → /admin/solver shows the new
- *     "Letzte Runs" card with Aktivieren button → click it → /timetable
- *     now renders the lesson. Catches the exact #60 user bug — without
- *     this, removing the run-history card would silently break recovery.
+ *   GEN-01 — fast-path: active run + lesson in DB → /timetable renders cells.
+ *   GEN-02 — activation-recovery: COMPLETED but inactive run → /admin/solver
+ *            shows the new "Letzte Runs" card with Aktivieren button →
+ *            click → /timetable now renders the lesson.
  *
  * Why fixture-based, not real solver: a real solve takes ~5 minutes and is
- * non-deterministic on lesson placement. The fixture inserts a
+ * non-deterministic on lesson placement. The throwaway provisions a
  * deterministic single-lesson COMPLETED run via Prisma (mirrors what
  * TimetableService.handleCompletion would write). Same shape, no wait,
  * stable assertions.
  */
 import { expect, test } from '@playwright/test';
-import { SEED_SCHOOL_UUID } from './fixtures/seed-uuids';
 import { loginAsAdmin } from './helpers/login';
 import {
-  cleanupTimetableRun,
-  seedTimetableRun,
-  type TimetableRunFixture,
-} from './fixtures/timetable-run';
+  createThrowawaySchool,
+  type ThrowawaySchoolFixture,
+} from './fixtures/throwaway-school';
+import { useThrowawaySchoolHeader } from './helpers/school-context';
 
-const SCHOOL_ID = process.env.E2E_SCHOOL_ID ?? SEED_SCHOOL_UUID;
-
-test.describe('Issue #60 — solver output reaches /timetable end-to-end', () => {
+test.describe('Issue #60 — solver output reaches /timetable end-to-end (throwaway-school)', () => {
   // Mobile projects render the same data; this guard is desktop-only to
   // avoid mobile-specific selector divergence (DayWeekToggle vs day list,
   // bottom-sheet selectors). The wire-up under test is identical across
@@ -53,61 +41,73 @@ test.describe('Issue #60 — solver output reaches /timetable end-to-end', () =>
     ({ isMobile }) => isMobile,
     'Solver output rendering is identical across viewports — desktop only.',
   );
-  // Mutating the seed school's timetable runs from parallel browser
-  // projects races on the same school resources (see #54). Limit to
-  // chromium until the throwaway-school refactor lands.
-  test.skip(
-    ({ browserName }) => browserName !== 'chromium',
-    'flaky on parallel browser projects — see #54 (shared seed-school race).',
-  );
+  // No chromium-only-skip: #138 wave 3 migration to throwaway-school
+  // eliminates the shared-seed-school race that motivated #54.
 
-  let fixture: TimetableRunFixture;
+  let fixture: ThrowawaySchoolFixture | undefined;
 
   test.afterEach(async () => {
     if (fixture) {
-      await cleanupTimetableRun(fixture);
+      await fixture.cleanup();
+      fixture = undefined;
     }
   });
 
   test('GEN-01: active completed run renders at least one lesson cell on /timetable', async ({
     page,
+    context,
   }) => {
-    fixture = await seedTimetableRun(SCHOOL_ID);
+    fixture = await createThrowawaySchool({
+      roles: { admin: true },
+      withTimetableStack: true, // shorthand for { active: true }
+      namePrefix: 'E2E-GEN01',
+    });
+    const stack = fixture.timetable!;
+
+    await useThrowawaySchoolHeader(context, fixture.schoolId);
     await loginAsAdmin(page);
     await page.goto('/timetable');
 
     // Pick the seeded teacher in the perspective selector so the grid
-    // filters down to our seeded lesson. The seed teacher is Maria Mueller
-    // (kc-lehrer), pinned by SEED_TEACHER_KC_LEHRER_UUID — the fixture
-    // exposes the display string as `teacherDisplayName` ("Mueller Maria").
+    // filters down to our seeded lesson. The throwaway fixture exposes the
+    // display string as `teacherDisplayName` (`${lastName} ${firstName}`).
     const trigger = page.getByRole('combobox').first();
     await expect(trigger).toBeVisible();
     await trigger.click();
     const dropdown = page.getByRole('listbox');
     await expect(dropdown).toBeVisible();
     await dropdown
-      .getByRole('option', { name: fixture.teacherDisplayName, exact: true })
+      .getByRole('option', { name: stack.teacherDisplayName, exact: true })
       .click();
 
     // The cell shows `subjectAbbreviation` as line 1 (TimetableCell.tsx:74).
-    // The fixture seeds exactly one lesson, so this label appears exactly
+    // The throwaway seeds exactly one lesson, so this label appears exactly
     // once. Assertion fails loudly if the active-run query / lesson join /
     // perspective filter chain breaks anywhere.
     await expect(
-      page.getByText(fixture.subjectAbbreviation, { exact: true }).first(),
+      page.getByText(stack.subjectShortName, { exact: true }).first(),
       'lesson cell must render the seeded subject abbreviation',
     ).toBeVisible();
   });
 
   test('GEN-02: completed-but-inactive run is recoverable from /admin/solver -> Letzte Runs -> Aktivieren -> /timetable shows the lesson', async ({
     page,
+    context,
   }) => {
     // The fixture's `active: false` mode is the exact shape of the user's
     // 2026-05-08 incident: handleCompletion wrote 32 rows, status went to
     // COMPLETED, but the WS event was lost so the user never got to click
     // Aktivieren. The "Letzte Runs" card on /admin/solver is the recovery
     // path this test guards.
-    fixture = await seedTimetableRun(SCHOOL_ID, { active: false });
+    fixture = await createThrowawaySchool({
+      roles: { admin: true },
+      withTimetableStack: { active: false },
+      namePrefix: 'E2E-GEN02',
+    });
+    const stack = fixture.timetable!;
+    expect(stack.timetableRunActive).toBe(false);
+
+    await useThrowawaySchoolHeader(context, fixture.schoolId);
     await loginAsAdmin(page);
 
     // Step 1 — /admin/solver shows the inactive run with an Aktivieren button.
@@ -117,7 +117,7 @@ test.describe('Issue #60 — solver output reaches /timetable end-to-end', () =>
       recentRuns,
       'Letzte Runs card must render when at least one run exists in DB',
     ).toBeVisible();
-    const activateBtn = page.getByTestId(`activate-run-${fixture.runId}`);
+    const activateBtn = page.getByTestId(`activate-run-${stack.timetableRunId}`);
     await expect(
       activateBtn,
       'Aktivieren button must be available for COMPLETED+!isActive runs',
@@ -136,11 +136,11 @@ test.describe('Issue #60 — solver output reaches /timetable end-to-end', () =>
     const dropdown = page.getByRole('listbox');
     await expect(dropdown).toBeVisible();
     await dropdown
-      .getByRole('option', { name: fixture.teacherDisplayName, exact: true })
+      .getByRole('option', { name: stack.teacherDisplayName, exact: true })
       .click();
 
     await expect(
-      page.getByText(fixture.subjectAbbreviation, { exact: true }).first(),
+      page.getByText(stack.subjectShortName, { exact: true }).first(),
       'lesson cell must render after Aktivieren-click flipped isActive=true',
     ).toBeVisible();
   });


### PR DESCRIPTION
Closes #138. Closes #123.

## Why

Final wave of #138, closing out Phase 3. With this PR all three of the original chromium-only-skip specs (`statistics-absence`, `admin-timetable-history`, `timetable-generation-flow`) run cross-project parallel without race defense. CLAUDE.md D4 is updated to reflect throwaway-school as PRIMARY for new specs (not just "permitted").

## What ships

### Fixture extensions (`createThrowawaySchool`)

| New surface | Behavior |
| --- | --- |
| `withTimetableStack: boolean \| { active?: boolean }` overload | `true` shorthand still works; pass `{ active: false }` to seed a COMPLETED but inactive TimetableRun (the #60 activation-recovery shape) |
| `ThrowawayTimetableStack.teacherDisplayName` | PerspectiveSelector renders teachers as `${lastName} ${firstName}` (per `useTimetable.ts:78`). Exposed so specs don't have to recompute it. |
| `ThrowawayTimetableStack.timetableRunActive` | Echoes back the `isActive` flag for spec sanity-checks |

### Spec migration (`timetable-generation-flow.spec.ts`)

| Before | After |
| --- | --- |
| `test.skip(({browserName}) => browserName !== 'chromium', 'flaky on parallel browser projects — see #54')` | NO chromium-only-skip |
| `seedTimetableRun(SCHOOL_ID, { active })` against seed school | `createThrowawaySchool({ roles: { admin: true }, withTimetableStack: true \| { active: false } })` |
| Pre-existing kc-lehrer (`Mueller Maria`) in perspective dropdown | Throwaway's fixture-Teacher Person by `teacherDisplayName` |
| Subject abbreviation from seed | `fixture.timetable.subjectShortName` |
| `cleanupTimetableRun` + advisory-lock release | `fixture.cleanup()` |

### CLAUDE.md D4 update

Throwaway-school-Fixture is now **PRIMARY** for new specs (was "Default" with caveat language pre-#138). The full fixture surface (`roles`, `withTimetableStack`, `withStudents`, `withClassbookEntry`, `withTimetableEdit`) is documented inline. Spec pattern reference:

```
createThrowawaySchool(...) → useThrowawaySchoolHeader(context, fixture.schoolId) → assertions → fixture.cleanup()
```

The legacy advisory-locks on seed-school-shared resources (TimeGrid, CalendarToken, messaging, classbook, excuses, etc.) are explicitly marked as LEGACY — they get removed per-spec as each spec migrates to throwaway. Tracker: separate Phase 3.5 follow-up issue (not in #123 scope).

## Verification

- [x] `pnpm exec tsc -p tsconfig.app.json --noEmit` clean
- [x] **20/20 cross-project parallel runs of `timetable-generation-flow.spec.ts` (chromium + firefox, 2 workers, both GEN-01 + GEN-02) — zero flakes**
- [x] **34/34 combined run of all Phase 3 specs + all four migrated specs (`throwaway-school-smoke`, `auth-user-context`, `current-school-context`, `timetable-cell-badges` #137, `statistics-absence` #138 wave 1, `admin-timetable-history` #138 wave 2, `timetable-generation-flow` #138 wave 3) on both desktop + desktop-firefox**

## Phase 3 closure (#123)

All six sub-issues now CLOSED:

| # | Title | PR |
| --- | --- | --- |
| #133 | Person.keycloakUserId composite unique | #139 |
| #134 | findFirst callsite refactor | #139 (bundled) |
| #135 | X-School-Id interceptor + frontend plumbing | #140 |
| #136 | throwaway-school fixture + cascade audit | #141 |
| #137 | pilot migration (timetable-cell-badges) | #143 |
| #138 | wide migration (statistics-absence + admin-timetable-history + timetable-generation-flow) | #144 + #145 + this PR |

Tracking #123 is ready to close. AC met:
- ≥5 specs migrated (the 4 above + the smoke spec from #136 — 5 total)
- CLAUDE.md D4 promoted throwaway-school from "permitted" to PRIMARY
- "≥3 advisory locks removed" AC explicitly **deferred to Phase 3.5** — each lock holds a real race on its seed-school-shared resource; removal requires per-spec migration which is out of #138 scope

## Out of scope (Phase 3.5 follow-ups)

- Migrate remaining advisory-lock-protected specs (~12 specs in the `helpers/advisory-lock.ts` consumer list) to throwaway. Each removes its own lock as it migrates.
- Schools-Switch UI in the application header — only meaningful once production multi-school users exist.

## Test plan

- [x] CI grün on first try (D3)
- [ ] Post-merge sanity: pull main, run all 4 migrated specs `--project=desktop --project=desktop-firefox` once locally to confirm