### PR TITLE
chore(e2e): #149 — throwaway-school gains withSecondTeacherLesson + subjectAbbreviation alias

### DIFF
--- a/apps/web/e2e/fixtures/throwaway-school.ts
+++ b/apps/web/e2e/fixtures/throwaway-school.ts
@@ -194,6 +194,20 @@ export interface ThrowawaySchoolOptions {
     previousState: { dayOfWeek: string; periodNumber: number };
     newState: { dayOfWeek: string; periodNumber: number };
   };
+  /**
+   * Issue #149 (Phase 3.5/1) — opt-in second TimetableLesson taught by a
+   * DIFFERENT Teacher at MONDAY/period-2, sharing the timetable stack's
+   * ClassSubject + Room + Run. Mirrors the legacy `seedSecondTeacherLesson`
+   * companion of `seedTimetableRun` — needed by substitution specs that
+   * exercise the assign-substitute flow (one teacher absent, a free second
+   * teacher available at a non-colliding period).
+   *
+   * Requires `withTimetableStack: true`. Cleanup piggy-backs on the run
+   * cascade — no extra plumbing required. The second Teacher's Person row
+   * is created fresh inside the throwaway school, so the School cascade
+   * deletes it on `fixture.cleanup()`.
+   */
+  withSecondTeacherLesson?: boolean;
 }
 
 export interface ThrowawayTimetableStack {
@@ -208,6 +222,15 @@ export interface ThrowawayTimetableStack {
   teacherDisplayName: string;
   subjectId: string;
   subjectShortName: string;
+  /**
+   * Issue #149 — alias of `subjectShortName` matching the legacy
+   * `TimetableRunFixture.subjectAbbreviation` field name. The timetable-view
+   * API exposes this verbatim as `TimetableViewLesson.subjectAbbreviation`
+   * (timetable.service.ts:447) and the visible cell label uses it; the
+   * alias smooths the consumer-spec migration in #153 (one fewer rename
+   * per spec).
+   */
+  subjectAbbreviation: string;
   classSubjectId: string;
   roomId: string;
   timeGridId: string;
@@ -223,6 +246,31 @@ export interface ThrowawayTimetableStack {
   lessonPeriodNumber: 1;
 }
 
+/**
+ * Issue #149 — return shape for the optional second TimetableLesson
+ * provisioned by `withSecondTeacherLesson: true`. Mirrors the field set
+ * of the legacy `SecondTeacherLessonFixture` so consumer migration in
+ * #153 is a flat rename rather than a redesign.
+ */
+export interface ThrowawaySecondTeacherLesson {
+  /** Teacher.id of the second teacher (NOT the timetable stack's primary). */
+  teacherId: string;
+  /**
+   * Display name in `${firstName} ${lastName}` order — matches the legacy
+   * `SecondTeacherLessonFixture.teacherFullName`. (Primary teacher exposes
+   * `teacherDisplayName` in `${lastName} ${firstName}` order; the two are
+   * intentionally different because they're consumed in different UI
+   * contexts.)
+   */
+  teacherFullName: string;
+  /** Always MONDAY — paired with the primary lesson at MONDAY/period-1. */
+  dayOfWeek: 'MONDAY';
+  /** Always 2 — non-colliding with the primary lesson's period-1. */
+  periodNumber: 2;
+  /** TimetableLesson.id of the second lesson. */
+  timetableLessonId: string;
+}
+
 export interface ThrowawaySchoolFixture {
   schoolId: string;
   schoolName: string;
@@ -234,6 +282,8 @@ export interface ThrowawaySchoolFixture {
   keycloakUserIds: Partial<Record<SeedRole, string>>;
   /** Populated when `withTimetableStack: true` was passed. */
   timetable?: ThrowawayTimetableStack;
+  /** Issue #149 — Populated when `withSecondTeacherLesson: true` was passed. */
+  secondTeacher?: ThrowawaySecondTeacherLesson;
   /** Issue #138 — Student.id values matching the `withStudents` indexes. */
   studentIds: string[];
   /** Issue #138 — Populated when `withClassbookEntry` was passed. */
@@ -327,6 +377,11 @@ export async function createThrowawaySchool(
   if (options.withTimetableEdit && !withTimetableStack) {
     throw new Error(
       'createThrowawaySchool: withTimetableEdit requires withTimetableStack (no lesson to attach the edit to)',
+    );
+  }
+  if (options.withSecondTeacherLesson && !withTimetableStack) {
+    throw new Error(
+      'createThrowawaySchool: withSecondTeacherLesson requires withTimetableStack (no run + classSubject + room to attach the second lesson to)',
     );
   }
 
@@ -517,6 +572,7 @@ export async function createThrowawaySchool(
         teacherDisplayName,
         subjectId: subject.id,
         subjectShortName: subject.shortName,
+        subjectAbbreviation: subject.shortName,
         classSubjectId: classSubject.id,
         roomId: room.id,
         timeGridId: timeGrid.id,
@@ -628,6 +684,50 @@ export async function createThrowawaySchool(
       timetableEditId = edit.id;
     }
 
+    // Issue #149 (Phase 3.5/1) — second TimetableLesson at MONDAY/period-2,
+    // taught by a fresh fixture-only Teacher. Mirrors the legacy
+    // `seedSecondTeacherLesson` companion: same Run + ClassSubject + Room,
+    // distinct teacher, non-colliding period. Cascade-clean via run delete
+    // (lesson) + school delete (teacher + person).
+    let secondTeacher: ThrowawaySecondTeacherLesson | undefined;
+    if (options.withSecondTeacherLesson) {
+      const stack = timetable!; // validated above
+      const secondFirstName = `${namePrefix}-Teacher2`;
+      const secondLastName = `${suffix}-T2`;
+      const secondPerson = await prisma.person.create({
+        data: {
+          schoolId: school.id,
+          personType: 'TEACHER',
+          firstName: secondFirstName,
+          lastName: secondLastName,
+        },
+      });
+      const secondTeacherRow = await prisma.teacher.create({
+        data: {
+          personId: secondPerson.id,
+          schoolId: school.id,
+        },
+      });
+      const secondLesson = await prisma.timetableLesson.create({
+        data: {
+          runId: stack.timetableRunId,
+          classSubjectId: stack.classSubjectId,
+          teacherId: secondTeacherRow.id,
+          roomId: stack.roomId,
+          dayOfWeek: 'MONDAY',
+          periodNumber: 2,
+          weekType: 'BOTH',
+        },
+      });
+      secondTeacher = {
+        teacherId: secondTeacherRow.id,
+        teacherFullName: `${secondFirstName} ${secondLastName}`,
+        dayOfWeek: 'MONDAY',
+        periodNumber: 2,
+        timetableLessonId: secondLesson.id,
+      };
+    }
+
     const capturedTimetable = timetable;
     const cleanup = async () => {
       const p = buildPrisma();
@@ -672,6 +772,7 @@ export async function createThrowawaySchool(
       personIds,
       keycloakUserIds,
       timetable,
+      secondTeacher,
       studentIds,
       classBookEntryId,
       timetableEditId,

--- a/apps/web/e2e/fixtures/timetable-run.ts
+++ b/apps/web/e2e/fixtures/timetable-run.ts
@@ -1,4 +1,27 @@
 /**
+ * **LEGACY (Phase 3.5, Issue #149)** — this file ships the seed-school-bound
+ * `seedTimetableRun` / `seedSecondTeacherLesson` family that holds the
+ * `active-timetable-run:SEED_SCHOOL_UUID` advisory lock for its entire
+ * lifecycle. It exists in lock-protected form until #153 (Phase 3.5/6)
+ * migrates the 18 remaining consumer specs onto the throwaway-school
+ * fixture (`apps/web/e2e/fixtures/throwaway-school.ts`).
+ *
+ * **DO NOT add new consumers.** New specs MUST use
+ * `createThrowawaySchool({ withTimetableStack: true, withSecondTeacherLesson?: true })`
+ * per CLAUDE.md D4 (throwaway-school = PRIMARY since PR #146). The throwaway
+ * fixture exposes every field a `TimetableRunFixture` consumer reads
+ * (`teacherId`, `teacherDisplayName`, `classSubjectId`, `subjectAbbreviation`,
+ * `lessonId` → `timetable.timetableLessonId`, `runId` → `timetable.timetableRunId`),
+ * plus the optional second-teacher MONDAY/period-2 lesson via
+ * `withSecondTeacherLesson: true`.
+ *
+ * The legacy helpers below are unchanged in behavior — same advisory-lock
+ * mechanic, same seed-school dependency. When the final consumer migrates,
+ * Issue #155 (Phase 3.5/8) deletes this file and its companion
+ * `helpers/advisory-lock.ts`.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ *
  * Quick task 260425-u72 — fixture for the admin timetable-edit DnD regression spec.
  *
  * Seeds the MINIMUM data the timetable-edit page needs to render exactly one
@@ -233,6 +256,10 @@ export interface SeedTimetableRunOptions {
  *
  * Picks the FIRST classSubject for class 1A and the FIRST Teacher + FIRST
  * Room of the school. All lookups are deterministic via createdAt asc.
+ *
+ * @deprecated Issue #149 — new specs MUST use
+ *   `createThrowawaySchool({ withTimetableStack: true })`. This helper
+ *   stays only until Issue #153 migrates the 18 remaining consumers.
  */
 export async function seedTimetableRun(
   schoolId: string,
@@ -489,6 +516,11 @@ export interface SecondTeacherLessonFixture {
 /**
  * Add a SECOND TimetableLesson to an existing fixture's TimetableRun,
  * taught by Anna Lehrerin (`SEED_TEACHER_2_UUID`) at MONDAY/period-2.
+ *
+ * @deprecated Issue #149 — new specs MUST use
+ *   `createThrowawaySchool({ withTimetableStack: true, withSecondTeacherLesson: true })`.
+ *   This helper stays only until Issue #153 migrates the lone consumer
+ *   (`teacher-substitutions-incoming.spec.ts`).
  *
  * Why a second lesson rather than a second run: keeping a single
  * TimetableRun avoids the "multiple active runs" tie-breaker in

--- a/apps/web/e2e/throwaway-school-smoke.spec.ts
+++ b/apps/web/e2e/throwaway-school-smoke.spec.ts
@@ -114,6 +114,63 @@ test.describe('THROW — throwaway-school fixture smoke (#136)', () => {
     expect(meAfterBody.availableSchools.map((s) => s.schoolId)).toContain(SEED_SCHOOL_UUID);
   });
 
+  test('THROW-04 — withTimetableStack + withSecondTeacherLesson provisions two distinct lessons at MONDAY/period-1 and MONDAY/period-2 (#149)', async ({
+    request,
+  }) => {
+    const fixture = await createThrowawaySchool({
+      roles: { lehrer: true },
+      withClasses: 1,
+      classNames: ['1A'],
+      withTimetableStack: true,
+      withSecondTeacherLesson: true,
+    });
+    try {
+      expect(fixture.timetable, 'withTimetableStack populates timetable').toBeDefined();
+      expect(fixture.secondTeacher, 'withSecondTeacherLesson populates secondTeacher').toBeDefined();
+
+      const stack = fixture.timetable!;
+      const second = fixture.secondTeacher!;
+
+      // Primary teacher at MONDAY/period-1; second teacher at MONDAY/period-2.
+      // Same class + same room, distinct lessons + distinct teachers.
+      expect(stack.lessonDayOfWeek).toBe('MONDAY');
+      expect(stack.lessonPeriodNumber).toBe(1);
+      expect(second.dayOfWeek).toBe('MONDAY');
+      expect(second.periodNumber).toBe(2);
+      expect(second.teacherId).not.toBe(stack.teacherId);
+      expect(second.timetableLessonId).not.toBe(stack.timetableLessonId);
+      // subjectAbbreviation alias is populated (consumer-spec migration parity
+      // for the legacy `TimetableRunFixture.subjectAbbreviation` field name).
+      expect(stack.subjectAbbreviation).toBe(stack.subjectShortName);
+      // teacherFullName uses `${firstName} ${lastName}` order — matches the
+      // legacy `SecondTeacherLessonFixture.teacherFullName` contract.
+      expect(second.teacherFullName).toMatch(/^E2E-TS-Teacher2 \d+-T2$/);
+
+      // /timetable view via the teacher perspective shows the primary lesson.
+      // (The view endpoint requires perspective + perspectiveId; teacher
+      // perspective is the cheapest to assert because we already have a
+      // teacherId on hand.) Validates that the seeded run + active SchoolDays
+      // + period round-trip cleanly through the same surface the consumer
+      // specs read in #153.
+      const token = await getRoleToken(request, 'lehrer');
+      const view = await request.get(
+        `${API}/schools/${fixture.schoolId}/timetable/view?perspective=teacher&perspectiveId=${stack.teacherId}`,
+        { headers: { Authorization: `Bearer ${token}`, 'X-School-Id': fixture.schoolId } },
+      );
+      expect(view.status(), 'timetable view (teacher) 200').toBe(200);
+      const body = (await view.json()) as {
+        lessons?: Array<{ id: string; dayOfWeek: string; periodNumber: number; teacherId: string }>;
+      };
+      const lessonIds = new Set((body.lessons ?? []).map((l) => l.id));
+      expect(
+        lessonIds.has(stack.timetableLessonId),
+        'primary lesson visible under primary-teacher perspective',
+      ).toBeTruthy();
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
   test('THROW-03 — multiple roles in one fixture all show up in availableSchools', async ({
     request,
   }) => {


### PR DESCRIPTION
Phase 3.5/1 foundation for #147 (advisory-lock removal).

## Why first

`seedTimetableRun` + `seedSecondTeacherLesson` are the lone consumers of the `active-timetable-run:SEED_SCHOOL_UUID` advisory lock across 18 + 1 specs. Migrating them one-at-a-time would touch the fixture's API 18× over. Extending the throwaway fixture once means #153 (3.5/6) becomes a flat per-spec rename.

## What changes

### `fixtures/throwaway-school.ts`

- **`withSecondTeacherLesson?: boolean`** — provisions a SECOND Teacher + fixture-only Person + TimetableLesson at MONDAY/period-2 on the existing stack's Run + ClassSubject + Room. Cascade-cleaned via the run-then-school delete order already in place.
- **`secondTeacher` fixture sub-field** with `teacherId`, `teacherFullName` (`${firstName} ${lastName}` matching legacy `SecondTeacherLessonFixture`), `dayOfWeek: 'MONDAY'`, `periodNumber: 2`, `timetableLessonId`.
- **`ThrowawayTimetableStack.subjectAbbreviation`** — alias of `subjectShortName` to match the legacy `TimetableRunFixture.subjectAbbreviation` field name (one fewer rename per consumer when #153 lands).
- Validation: `withSecondTeacherLesson` requires `withTimetableStack`.

### `fixtures/timetable-run.ts`

- File-level legacy header + `@deprecated` on `seedTimetableRun` and `seedSecondTeacherLesson`. Behavior unchanged — helpers remain fully functional until #153 migrates the 18 + 1 consumers. #155 then deletes the file + `helpers/advisory-lock.ts`.

### `throwaway-school-smoke.spec.ts`

- `THROW-04` cross-project: asserts both lessons exist at distinct teacher+period, `subjectAbbreviation` alias populated, primary lesson visible under teacher-perspective `/timetable/view`.

## Tests

- `pnpm exec playwright test --project=desktop --project=desktop-firefox e2e/throwaway-school-smoke.spec.ts --repeat-each=5` → **40/40 green** locally.
- `pnpm exec playwright test --project=desktop e2e/admin-substitutions-list.spec.ts` → green (legacy consumer unaffected).

## Acceptance Criteria (from #149)

- [x] `seedTimetableRun` documented as legacy-only with explicit path to removal in #153
- [x] `createThrowawaySchool({ withTimetableStack: true })` covers every field of `TimetableRunFixture` that consumer specs actually read (audit summary in commit message; `lessonId` → `timetable.timetableLessonId`, `runId` → `timetable.timetableRunId`, `subjectAbbreviation` aliased verbatim, plus optional `withSecondTeacherLesson` for the lone `seedSecondTeacherLesson` consumer)
- [x] No new advisory-lock acquisitions in the helper
- [x] CI grün — existing 18 specs MUST still work (they continue to use the legacy `seedTimetableRun` until #147/6)
- [x] Cross-project parallel run of `throwaway-school-smoke.spec.ts` still grün (now 8/8 per project, 40/40 on 5x repeat)

## Migration path for #153

Per-spec rename (no logic change required):

```ts
// before
const fixture = await seedTimetableRun(SEED_SCHOOL_UUID);
// fixture.lessonId, fixture.teacherId, fixture.classSubjectId, fixture.subjectAbbreviation
// fixture.runId

// after
const fixture = await createThrowawaySchool({
  roles: { admin: true /* or lehrer */ },
  withClasses: 1,
  classNames: ['1A'],
  withTimetableStack: true,
  withSecondTeacherLesson: true, // only when the spec needs Anna's lesson
});
// fixture.timetable!.timetableLessonId, .teacherId, .classSubjectId, .subjectAbbreviation
// fixture.timetable!.timetableRunId
// fixture.secondTeacher!.teacherId / teacherFullName  (was second.teacherId / .teacherFullName)
```

Closes #149
Refs #147