### PR TITLE
chore(e2e): #152 — migrate admin schreib specs (subjects-rrt + classes-home-room + stundentafel) to throwaway-school

### DIFF
--- a/apps/api/src/modules/auth/interceptors/current-school.interceptor.spec.ts
+++ b/apps/api/src/modules/auth/interceptors/current-school.interceptor.spec.ts
@@ -72,6 +72,27 @@ describe('CurrentSchoolInterceptor', () => {
     expect(req.currentSchoolId).toBe('school-A');
   });
 
+  it('requests memberships ordered by school.createdAt asc (deterministic first-membership pick, #152)', async () => {
+    // Issue #152 — multi-membership admin users (admin KC user in seed +
+    // throwaway e2e schools concurrently) would otherwise see Postgres
+    // pick an arbitrary "first" membership for legacy specs that omit
+    // X-School-Id. Locking the orderBy means seed (oldest) is always [0].
+    prisma.person.findMany.mockResolvedValue([{ schoolId: 'seed' }]);
+    const req: MockReq = { user: { id: 'kc-1' }, headers: {} };
+
+    const observable = (await interceptor.intercept(
+      buildExecutionContext(req) as any,
+      buildCallHandler() as any,
+    )) as any;
+    await firstValueFrom(observable);
+
+    expect(prisma.person.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: { school: { createdAt: 'asc' } },
+      }),
+    );
+  });
+
   it('honors a valid X-School-Id header that matches a membership', async () => {
     prisma.person.findMany.mockResolvedValue([
       { schoolId: 'school-A' },

--- a/apps/api/src/modules/auth/interceptors/current-school.interceptor.ts
+++ b/apps/api/src/modules/auth/interceptors/current-school.interceptor.ts
@@ -21,9 +21,17 @@ import { AuthenticatedUser } from '../types/authenticated-user';
  *   - Requests without `req.user` (auth-rejected upstream) are skipped.
  *   - Loads `Person.findMany({ where: { keycloakUserId } })` to determine
  *     valid memberships. Single indexed lookup post-#133 composite-unique.
+ *     Ordered by `school.createdAt asc` so the SEED school (oldest in any
+ *     environment) is always membership #0 — eliminates a latent race
+ *     surfaced by parallel admin-throwaway e2e specs (#152): with two
+ *     workers each provisioning a throwaway school for the seed `admin`
+ *     KC user, an unordered findMany returns memberships in whichever
+ *     order Postgres happens to pick, so legacy specs that omit
+ *     X-School-Id intermittently landed on a sibling worker's throwaway.
  *   - With `X-School-Id` header: must match a membership, else 403.
- *   - Without header: defaults to the first membership's `schoolId`, or
- *     `null` if the user has no Person row (e.g., admin-only KC accounts).
+ *   - Without header: defaults to the first membership's `schoolId` per
+ *     the deterministic ordering above, or `null` if the user has no
+ *     Person row (e.g., admin-only KC accounts).
  */
 @Injectable()
 export class CurrentSchoolInterceptor implements NestInterceptor {
@@ -49,6 +57,7 @@ export class CurrentSchoolInterceptor implements NestInterceptor {
     const memberships = await this.prisma.person.findMany({
       where: { keycloakUserId: user.id },
       select: { schoolId: true },
+      orderBy: { school: { createdAt: 'asc' } },
     });
     const memberSchoolIds = memberships.map((m) => m.schoolId);
 

--- a/apps/api/src/modules/user-context/user-context.service.ts
+++ b/apps/api/src/modules/user-context/user-context.service.ts
@@ -10,6 +10,12 @@ export class UserContextService {
     keycloakUserId: string,
     currentSchoolId: string | null,
   ): Promise<UserContextResponseDto> {
+    // Order memberships by school.createdAt asc so the SEED school (oldest)
+    // is always [0]. Matches CurrentSchoolInterceptor's ordering — necessary
+    // so the fallback `currentSchoolId ?? memberships[0].schoolId` resolves
+    // to the SAME school the interceptor picked when no X-School-Id was
+    // sent. Pre-#152 the unordered findMany made this racy under parallel
+    // admin-throwaway e2e specs.
     const memberships = await this.prisma.person.findMany({
       where: { keycloakUserId },
       select: {
@@ -17,6 +23,7 @@ export class UserContextService {
         personType: true,
         school: { select: { name: true } },
       },
+      orderBy: { school: { createdAt: 'asc' } },
     });
 
     if (memberships.length === 0) {

--- a/apps/web/e2e/admin-classes-home-room.spec.ts
+++ b/apps/web/e2e/admin-classes-home-room.spec.ts
@@ -1,15 +1,19 @@
 /**
  * Issue #67 — Admin Classes Heimraum assignment.
  *
+ * Issue #152 (Phase 3.5/5) — migrated to throwaway-school per CLAUDE.md D4.
+ * The `admin-classes-home-room:` and `e2e-rows-on-seed-school:` advisory
+ * locks are gone; each spec owns its own throwaway School so the
+ * cleanup-by-prefix race can no longer fire.
+ *
  * Covers the two UI affordances added by the home-room PR:
  *   - E2E-CLS-HR-EDIT-ASSIGN: ClassStammdatenTab → Heimraum Select →
  *                              Speichern → PUT /classes/:id carries
  *                              homeRoomId, value persists across reload.
  *   - E2E-CLS-HR-EDIT-CLEAR:  Pre-assigned class → Heimraum=Kein Heimraum
  *                              → Speichern → PUT body homeRoomId=null.
- *   - E2E-CLS-HR-CREATE:      ClassCreateDialog with Heimraum=Raum 2A →
- *                              POST /classes carries homeRoomId, list view
- *                              shows the new class with the home room set.
+ *   - E2E-CLS-HR-CREATE:      ClassCreateDialog with Heimraum=throwaway room
+ *                              → POST /classes carries homeRoomId.
  *
  * DOM contract:
  *   - ClassStammdatenTab.tsx — `<SelectTrigger id="class-stammdaten-home-room"
@@ -19,58 +23,59 @@
  *   - Sentinel `__no_home_room__` clears the assignment (Radix Select
  *     does not accept empty string as a value).
  *
- * Cross-room verification uses the seed rooms (Raum 1A / Raum 2A /
- * Turnsaal etc.) — `apps/api/prisma/seed.ts` Issue #67 patch makes
- * 1A → Raum 1A and 1B → Raum 2A the default seed state, so live-solve
- * coverage stays in the integration test suite, not here. This spec
- * locks down the UI contract only.
+ * Throwaway provides exactly one Room (`fixture.timetable.roomName`) — the
+ * spec picks it as the home room. Empty-state UX ("Kein Heimraum") is
+ * still exercised by the CLEAR test.
  */
-import { expect, test } from '@playwright/test';
-import { getAdminToken, loginAsAdmin } from './helpers/login';
+import { expect, test, type APIRequestContext } from '@playwright/test';
+import { getAdminToken, loginAsRole } from './helpers/login';
 import {
-  cleanupE2EClasses,
-  createClassViaAPI,
-} from './helpers/students';
-import { SEED_SCHOOL_UUID } from './fixtures/seed-uuids';
-import { acquireAdvisoryLock, type AdvisoryLock } from './helpers/advisory-lock';
+  createThrowawaySchool,
+  type ThrowawaySchoolFixture,
+} from './fixtures/throwaway-school';
+import { useThrowawaySchoolHeader } from './helpers/school-context';
 
 const PREFIX = 'E2E-HR-';
-const NO_HOME_ROOM_SENTINEL = '__no_home_room__';
+const API = process.env.E2E_API_URL ?? 'http://localhost:3000/api/v1';
 
-const API = 'http://localhost:3000/api/v1';
-
-interface RoomDto {
-  id: string;
-  name: string;
-}
-
-async function listRooms(
-  request: import('@playwright/test').APIRequestContext,
-): Promise<RoomDto[]> {
+async function createClass(
+  request: APIRequestContext,
+  schoolId: string,
+  schoolYearId: string,
+  fields: { name: string; yearLevel?: number },
+): Promise<{ id: string; name: string }> {
   const token = await getAdminToken(request);
-  const res = await request.get(
-    `${API}/schools/${SEED_SCHOOL_UUID}/rooms?page=1&limit=50`,
-    { headers: { Authorization: `Bearer ${token}` } },
-  );
-  expect(res.ok(), 'GET /rooms').toBeTruthy();
-  const body = (await res.json()) as { data?: RoomDto[] } | RoomDto[];
-  const items = Array.isArray(body) ? body : body.data ?? [];
-  return items;
+  const res = await request.post(`${API}/classes`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'X-School-Id': schoolId,
+      'Content-Type': 'application/json',
+    },
+    data: {
+      schoolId,
+      schoolYearId,
+      name: fields.name,
+      yearLevel: fields.yearLevel ?? 5,
+    },
+  });
+  expect(res.ok(), `POST /classes (${fields.name})`).toBeTruthy();
+  return (await res.json()) as { id: string; name: string };
 }
 
 async function fetchClass(
-  request: import('@playwright/test').APIRequestContext,
+  request: APIRequestContext,
   id: string,
+  schoolId: string,
 ): Promise<{ id: string; homeRoomId: string | null }> {
   const token = await getAdminToken(request);
   const res = await request.get(`${API}/classes/${id}`, {
-    headers: { Authorization: `Bearer ${token}` },
+    headers: { Authorization: `Bearer ${token}`, 'X-School-Id': schoolId },
   });
   expect(res.ok(), `GET /classes/${id}`).toBeTruthy();
   return (await res.json()) as { id: string; homeRoomId: string | null };
 }
 
-test.describe('Issue #67 — Admin Classes Heimraum (desktop)', () => {
+test.describe('Issue #67 — Admin Classes Heimraum (throwaway-school, #152)', () => {
   // The Heimraum UI is the same on mobile (same Radix Select + same form
   // wiring); the spec exercises the wire-up, not viewport-specific
   // affordances. Stick to desktop.
@@ -79,57 +84,53 @@ test.describe('Issue #67 — Admin Classes Heimraum (desktop)', () => {
     'Heimraum form contract is identical across viewports — desktop only.',
   );
 
-  // Issue #112 phase 4 wave 2d (#122): per-spec advisory lock serializes
-  // parallel browser projects on the cleanup-by-prefix race. Both
-  // chromium and firefox running this spec would otherwise sweep each
-  // other's mid-test classes via the `E2E-HR-` afterEach.
-  let lock: AdvisoryLock | undefined;
+  let fixture: ThrowawaySchoolFixture | undefined;
 
-  test.beforeEach(async ({ page }) => {
-    // Two locks acquired in sorted order:
-    //   - per-spec key serializes parallel browser projects on the
-    //     `E2E-HR-` cleanup sweep
-    //   - shared `e2e-rows-on-seed-school` key blocks the
-    //     `e2e-sweep-canary` spec from running its destructive
-    //     `sweepE2ELeftovers` (which deletes EVERY E2E-* row in the
-    //     school) while our mid-test classes are alive
-    lock = await acquireAdvisoryLock([
-      `admin-classes-home-room:${SEED_SCHOOL_UUID}`,
-      `e2e-rows-on-seed-school:${SEED_SCHOOL_UUID}`,
-    ]);
-    await loginAsAdmin(page);
+  test.beforeEach(async () => {
+    fixture = await createThrowawaySchool({
+      roles: { admin: true },
+      withClasses: 1,
+      withTimetableStack: true,
+      namePrefix: 'E2E-HR',
+    });
   });
 
-  test.afterEach(async ({ request }) => {
-    await cleanupE2EClasses(request, PREFIX);
-    if (lock) {
-      await lock.release();
-      lock = undefined;
+  test.afterEach(async () => {
+    if (fixture) {
+      await fixture.cleanup();
+      fixture = undefined;
     }
   });
 
   test('E2E-CLS-HR-EDIT-ASSIGN: pick Heimraum via Select → save → persists', async ({
     page,
+    context,
     request,
   }) => {
+    if (!fixture) throw new Error('fixture not seeded');
+    await useThrowawaySchoolHeader(context, fixture.schoolId);
+    await loginAsRole(page, 'admin');
+
+    const targetRoom = {
+      id: fixture.timetable!.roomId,
+      name: fixture.timetable!.roomName,
+    };
+
     const ts = Date.now().toString().slice(-6);
-    const cls = await createClassViaAPI(request, { name: `${PREFIX}A-${ts}` });
+    const cls = await createClass(
+      request,
+      fixture.schoolId,
+      fixture.schoolYearId,
+      { name: `${PREFIX}A-${ts}` },
+    );
 
     // Verify start state has no home room.
-    const before = await fetchClass(request, cls.id);
+    const before = await fetchClass(request, cls.id, fixture.schoolId);
     expect(before.homeRoomId, 'class starts with no home room').toBeNull();
-
-    const rooms = await listRooms(request);
-    // Use the second Klassenzimmer in the seed so this spec never collides
-    // with the seed defaults (1A → Raum 1A, 1B → Raum 2A) — Raum 3 (Reserve)
-    // is the safe pick.
-    const targetRoom = rooms.find((r) => r.name === 'Raum 3 (Reserve)');
-    expect(targetRoom, 'Raum 3 (Reserve) exists in seed').toBeTruthy();
-    if (!targetRoom) return;
 
     await page.goto(`/admin/classes/${cls.id}?tab=stammdaten`);
 
-    // Open the Heimraum Select and pick the target room.
+    // Open the Heimraum Select and pick the throwaway's room.
     await page.getByRole('combobox', { name: 'Heimraum' }).click();
     await page.getByRole('option', { name: targetRoom.name }).click();
 
@@ -150,7 +151,7 @@ test.describe('Issue #67 — Admin Classes Heimraum (desktop)', () => {
     ).toBe(targetRoom.id);
 
     // Persistence — fetch class via API and verify the new value sticks.
-    const after = await fetchClass(request, cls.id);
+    const after = await fetchClass(request, cls.id, fixture.schoolId);
     expect(after.homeRoomId).toBe(targetRoom.id);
 
     // Reload the page — the Select must rehydrate with the saved value.
@@ -162,29 +163,39 @@ test.describe('Issue #67 — Admin Classes Heimraum (desktop)', () => {
 
   test('E2E-CLS-HR-EDIT-CLEAR: switch from Heimraum → Kein Heimraum → save → PUT homeRoomId=null', async ({
     page,
+    context,
     request,
   }) => {
+    if (!fixture) throw new Error('fixture not seeded');
+    await useThrowawaySchoolHeader(context, fixture.schoolId);
+    await loginAsRole(page, 'admin');
+
+    const startRoom = {
+      id: fixture.timetable!.roomId,
+      name: fixture.timetable!.roomName,
+    };
+
     const ts = Date.now().toString().slice(-6);
-    const rooms = await listRooms(request);
-    const startRoom = rooms.find((r) => r.name === 'Raum 3 (Reserve)');
-    expect(startRoom, 'Raum 3 (Reserve) exists in seed').toBeTruthy();
-    if (!startRoom) return;
 
     // Seed the class with a home room already set so the clear flow has
-    // something to remove. createClassViaAPI accepts klassenvorstandId
-    // today; we set the room via a direct PUT afterwards rather than
-    // expanding the helper signature.
-    const cls = await createClassViaAPI(request, { name: `${PREFIX}C-${ts}` });
+    // something to remove.
+    const cls = await createClass(
+      request,
+      fixture.schoolId,
+      fixture.schoolYearId,
+      { name: `${PREFIX}C-${ts}` },
+    );
     const token = await getAdminToken(request);
     await request.put(`${API}/classes/${cls.id}`, {
       headers: {
         Authorization: `Bearer ${token}`,
+        'X-School-Id': fixture.schoolId,
         'Content-Type': 'application/json',
       },
       data: { homeRoomId: startRoom.id },
     });
 
-    const before = await fetchClass(request, cls.id);
+    const before = await fetchClass(request, cls.id, fixture.schoolId);
     expect(before.homeRoomId).toBe(startRoom.id);
 
     await page.goto(`/admin/classes/${cls.id}?tab=stammdaten`);
@@ -207,20 +218,26 @@ test.describe('Issue #67 — Admin Classes Heimraum (desktop)', () => {
     expect(reqBody.homeRoomId, 'PUT body homeRoomId is null').toBeNull();
 
     // Verify clear took effect.
-    const after = await fetchClass(request, cls.id);
+    const after = await fetchClass(request, cls.id, fixture.schoolId);
     expect(after.homeRoomId).toBeNull();
   });
 
   test('E2E-CLS-HR-CREATE: ClassCreateDialog with Heimraum → POST carries homeRoomId', async ({
     page,
+    context,
     request,
   }) => {
+    if (!fixture) throw new Error('fixture not seeded');
+    await useThrowawaySchoolHeader(context, fixture.schoolId);
+    await loginAsRole(page, 'admin');
+
+    const targetRoom = {
+      id: fixture.timetable!.roomId,
+      name: fixture.timetable!.roomName,
+    };
+
     const ts = Date.now().toString().slice(-6);
     const className = `${PREFIX}N-${ts}`;
-    const rooms = await listRooms(request);
-    const targetRoom = rooms.find((r) => r.name === 'Raum 3 (Reserve)');
-    expect(targetRoom, 'Raum 3 (Reserve) exists in seed').toBeTruthy();
-    if (!targetRoom) return;
 
     await page.goto('/admin/classes');
 
@@ -237,8 +254,8 @@ test.describe('Issue #67 — Admin Classes Heimraum (desktop)', () => {
     // Schuljahr — must be picked explicitly. The dialog's defaultSchoolYearId
     // only populates when the school-context-store has activeSchoolYearId;
     // in a fresh E2E session that field may not be hydrated, surfacing an
-    // "Ungültige Schuljahr-ID" inline error. (Same approach as
-    // admin-classes-crud.spec.ts.)
+    // "Ungültige Schuljahr-ID" inline error. Throwaway provisions exactly
+    // one SchoolYear so picking `.first()` is deterministic.
     await dialog.getByLabel('Schuljahr').click();
     await page.getByRole('option').first().click();
 
@@ -265,7 +282,7 @@ test.describe('Issue #67 — Admin Classes Heimraum (desktop)', () => {
     // Defence-in-depth: fetch the created class via API and confirm the
     // value landed in the DB, not just in the request body.
     const body = (await postRes.json()) as { id: string };
-    const persisted = await fetchClass(request, body.id);
+    const persisted = await fetchClass(request, body.id, fixture.schoolId);
     expect(persisted.homeRoomId).toBe(targetRoom.id);
   });
 });

--- a/apps/web/e2e/admin-stundentafel-teacher-assignment.spec.ts
+++ b/apps/web/e2e/admin-stundentafel-teacher-assignment.spec.ts
@@ -1,6 +1,11 @@
 /**
  * Issue #71 — Stundentafel teacher assignment.
  *
+ * Issue #152 (Phase 3.5/5) — migrated to throwaway-school per CLAUDE.md D4.
+ * The `admin-stundentafel-teacher-assignment:` and
+ * `e2e-rows-on-seed-school:` advisory locks are gone; each spec owns its
+ * own throwaway School so the cleanup-by-prefix race can no longer fire.
+ *
  * Covers the per-ClassSubject teacher picker shipped in the teacherId PR:
  *   - E2E-CLS-TEACHER-ASSIGN: open Stundentafel tab, pick a teacher for
  *     the first row, save → PUT body carries the chosen teacherId for
@@ -14,27 +19,21 @@
  *   - Sentinel `__no_teacher__` clears the assignment (Radix Select
  *     does not accept empty string as a value).
  *
- * Scoped to desktop + chromium-only per the parallel-cleanup race family
- * — same pattern as admin-classes-home-room.spec.ts (#67) and
- * admin-subjects-required-room-type.spec.ts (#69).
+ * Throwaway-school provides exactly ONE Teacher (via `withTimetableStack`).
+ * The spec picks that lone teacher as the target — the dropdown will
+ * show two options ("Nicht zugewiesen" + the fixture Teacher) which is
+ * sufficient to exercise both assign and clear flows.
  */
-import { expect, test } from '@playwright/test';
-import { getAdminToken, loginAsAdmin } from './helpers/login';
+import { expect, test, type APIRequestContext } from '@playwright/test';
+import { getAdminToken, loginAsRole } from './helpers/login';
 import {
-  cleanupE2EClasses,
-  createClassViaAPI,
-} from './helpers/students';
-import { SEED_SCHOOL_UUID } from './fixtures/seed-uuids';
-import { acquireAdvisoryLock, type AdvisoryLock } from './helpers/advisory-lock';
+  createThrowawaySchool,
+  type ThrowawaySchoolFixture,
+} from './fixtures/throwaway-school';
+import { useThrowawaySchoolHeader } from './helpers/school-context';
 
 const PREFIX = 'E2E-TA-';
-const API = 'http://localhost:3000/api/v1';
-
-interface TeacherSummary {
-  id: string;
-  firstName: string;
-  lastName: string;
-}
+const API = process.env.E2E_API_URL ?? 'http://localhost:3000/api/v1';
 
 interface ClassSubjectRow {
   id: string;
@@ -44,42 +43,47 @@ interface ClassSubjectRow {
   teacher?: { id: string; person: { firstName: string; lastName: string } } | null;
 }
 
-async function listTeachers(
-  request: import('@playwright/test').APIRequestContext,
-): Promise<TeacherSummary[]> {
+async function createClass(
+  request: APIRequestContext,
+  schoolId: string,
+  schoolYearId: string,
+  fields: { name: string; yearLevel: number },
+): Promise<{ id: string; name: string }> {
   const token = await getAdminToken(request);
-  const res = await request.get(
-    `${API}/teachers?schoolId=${SEED_SCHOOL_UUID}&limit=20`,
-    { headers: { Authorization: `Bearer ${token}` } },
-  );
-  expect(res.ok(), 'GET /teachers').toBeTruthy();
-  const body = (await res.json()) as {
-    data?: Array<{ id: string; person?: { firstName?: string; lastName?: string } }>;
-  };
-  return (body.data ?? [])
-    .filter((t) => t.person)
-    .map((t) => ({
-      id: t.id,
-      firstName: t.person!.firstName ?? '',
-      lastName: t.person!.lastName ?? '',
-    }));
+  const res = await request.post(`${API}/classes`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'X-School-Id': schoolId,
+      'Content-Type': 'application/json',
+    },
+    data: {
+      schoolId,
+      schoolYearId,
+      name: fields.name,
+      yearLevel: fields.yearLevel,
+    },
+  });
+  expect(res.ok(), `POST /classes (${fields.name})`).toBeTruthy();
+  return (await res.json()) as { id: string; name: string };
 }
 
 async function listClassSubjects(
-  request: import('@playwright/test').APIRequestContext,
+  request: APIRequestContext,
   classId: string,
+  schoolId: string,
 ): Promise<ClassSubjectRow[]> {
   const token = await getAdminToken(request);
   const res = await request.get(`${API}/classes/${classId}/subjects`, {
-    headers: { Authorization: `Bearer ${token}` },
+    headers: { Authorization: `Bearer ${token}`, 'X-School-Id': schoolId },
   });
   expect(res.ok(), `GET /classes/${classId}/subjects`).toBeTruthy();
   return (await res.json()) as ClassSubjectRow[];
 }
 
 async function applyStundentafel(
-  request: import('@playwright/test').APIRequestContext,
+  request: APIRequestContext,
   classId: string,
+  schoolId: string,
   schoolType: string,
 ): Promise<void> {
   const token = await getAdminToken(request);
@@ -88,6 +92,7 @@ async function applyStundentafel(
     {
       headers: {
         Authorization: `Bearer ${token}`,
+        'X-School-Id': schoolId,
         'Content-Type': 'application/json',
       },
       data: { schoolType },
@@ -99,48 +104,57 @@ async function applyStundentafel(
   ).toBeTruthy();
 }
 
-test.describe('Issue #71 — Stundentafel Teacher-Zuweisung (desktop)', () => {
+test.describe('Issue #71 — Stundentafel Teacher-Zuweisung (throwaway-school, #152)', () => {
   test.skip(
     ({ isMobile }) => isMobile,
     'Stundentafel teacher picker uses identical Select on mobile — desktop is enough.',
   );
 
-  // Issue #112 phase 4 wave 2d (#122): per-spec advisory lock serializes
-  // parallel browser projects on the cleanup-by-prefix race.
-  let lock: AdvisoryLock | undefined;
+  let fixture: ThrowawaySchoolFixture | undefined;
 
-  test.beforeEach(async ({ page }) => {
-    // See admin-classes-home-room.spec.ts for the two-lock rationale —
-    // per-spec key + shared canary-sweep guard.
-    lock = await acquireAdvisoryLock([
-      `admin-stundentafel-teacher-assignment:${SEED_SCHOOL_UUID}`,
-      `e2e-rows-on-seed-school:${SEED_SCHOOL_UUID}`,
-    ]);
-    await loginAsAdmin(page);
+  test.beforeEach(async () => {
+    fixture = await createThrowawaySchool({
+      roles: { admin: true },
+      withClasses: 1,
+      withTimetableStack: true, // provisions the lone Teacher the picker selects
+      namePrefix: 'E2E-TA',
+    });
   });
 
-  test.afterEach(async ({ request }) => {
-    await cleanupE2EClasses(request, PREFIX);
-    if (lock) {
-      await lock.release();
-      lock = undefined;
+  test.afterEach(async () => {
+    if (fixture) {
+      await fixture.cleanup();
+      fixture = undefined;
     }
   });
 
   test('E2E-CLS-TEACHER-ASSIGN: pick teacher → save → PUT body + persist', async ({
     page,
+    context,
     request,
   }) => {
-    const ts = Date.now().toString().slice(-6);
-    const cls = await createClassViaAPI(request, {
-      name: `${PREFIX}A-${ts}`,
-      yearLevel: 1,
-    });
-    // Apply the AHS_UNTER year-1 Stundentafel so the new class has rows
-    // (4 seeded subjects).
-    await applyStundentafel(request, cls.id, 'AHS_UNTER');
+    if (!fixture) throw new Error('fixture not seeded');
+    await useThrowawaySchoolHeader(context, fixture.schoolId);
+    await loginAsRole(page, 'admin');
 
-    const rowsBefore = await listClassSubjects(request, cls.id);
+    const target = {
+      id: fixture.timetable!.teacherId,
+      displayName: fixture.timetable!.teacherDisplayName,
+    };
+
+    const ts = Date.now().toString().slice(-6);
+    const cls = await createClass(
+      request,
+      fixture.schoolId,
+      fixture.schoolYearId,
+      { name: `${PREFIX}A-${ts}`, yearLevel: 1 },
+    );
+    // Apply the AHS_UNTER year-1 Stundentafel so the new class has rows
+    // (subjects auto-created from the template). Template name is
+    // independent of the school's own schoolType (the throwaway is 'AHS').
+    await applyStundentafel(request, cls.id, fixture.schoolId, 'AHS_UNTER');
+
+    const rowsBefore = await listClassSubjects(request, cls.id, fixture.schoolId);
     expect(
       rowsBefore.length,
       'Stundentafel applied → at least one row',
@@ -150,10 +164,6 @@ test.describe('Issue #71 — Stundentafel Teacher-Zuweisung (desktop)', () => {
       'all rows start unassigned',
     ).toBe(true);
 
-    const teachers = await listTeachers(request);
-    const target = teachers[0];
-    expect(target, 'at least one seeded teacher').toBeTruthy();
-
     // Pick a row deterministically — Deutsch ("D") is in every AHS_UNTER
     // year-1 Stundentafel.
     const targetRow = rowsBefore.find((r) => r.subject.shortName === 'D');
@@ -162,12 +172,10 @@ test.describe('Issue #71 — Stundentafel Teacher-Zuweisung (desktop)', () => {
 
     await page.goto(`/admin/classes/${cls.id}?tab=stundentafel`);
 
-    // Open the teacher Select for D, pick the target teacher.
+    // Open the teacher Select for D, pick the throwaway's fixture teacher.
     const trigger = page.getByTestId('stundentafel-teacher-D');
     await trigger.click();
-    await page
-      .getByRole('option', { name: `${target.lastName} ${target.firstName}` })
-      .click();
+    await page.getByRole('option', { name: target.displayName }).click();
 
     // Save and capture the PUT.
     const putPromise = page.waitForResponse(
@@ -189,29 +197,37 @@ test.describe('Issue #71 — Stundentafel Teacher-Zuweisung (desktop)', () => {
     ).toBe(target.id);
 
     // DB persistence.
-    const rowsAfter = await listClassSubjects(request, cls.id);
+    const rowsAfter = await listClassSubjects(request, cls.id, fixture.schoolId);
     const persisted = rowsAfter.find((r) => r.subject.shortName === 'D');
     expect(persisted?.teacherId).toBe(target.id);
   });
 
   test('E2E-CLS-TEACHER-CLEAR: switch teacher → Nicht zugewiesen → PUT body null', async ({
     page,
+    context,
     request,
   }) => {
-    const ts = Date.now().toString().slice(-6);
-    const cls = await createClassViaAPI(request, {
-      name: `${PREFIX}C-${ts}`,
-      yearLevel: 1,
-    });
-    await applyStundentafel(request, cls.id, 'AHS_UNTER');
+    if (!fixture) throw new Error('fixture not seeded');
+    await useThrowawaySchoolHeader(context, fixture.schoolId);
+    await loginAsRole(page, 'admin');
 
-    const teachers = await listTeachers(request);
-    const target = teachers[0];
-    expect(target, 'at least one seeded teacher').toBeTruthy();
+    const target = {
+      id: fixture.timetable!.teacherId,
+      displayName: fixture.timetable!.teacherDisplayName,
+    };
+
+    const ts = Date.now().toString().slice(-6);
+    const cls = await createClass(
+      request,
+      fixture.schoolId,
+      fixture.schoolYearId,
+      { name: `${PREFIX}C-${ts}`, yearLevel: 1 },
+    );
+    await applyStundentafel(request, cls.id, fixture.schoolId, 'AHS_UNTER');
 
     // Pre-assign the D row via the PUT endpoint so the clear flow has
     // something to clear.
-    const rowsBefore = await listClassSubjects(request, cls.id);
+    const rowsBefore = await listClassSubjects(request, cls.id, fixture.schoolId);
     const dRow = rowsBefore.find((r) => r.subject.shortName === 'D');
     expect(dRow, 'D row exists').toBeTruthy();
     if (!dRow) return;
@@ -219,6 +235,7 @@ test.describe('Issue #71 — Stundentafel Teacher-Zuweisung (desktop)', () => {
     await request.put(`${API}/classes/${cls.id}/subjects`, {
       headers: {
         Authorization: `Bearer ${token}`,
+        'X-School-Id': fixture.schoolId,
         'Content-Type': 'application/json',
       },
       data: {
@@ -231,7 +248,7 @@ test.describe('Issue #71 — Stundentafel Teacher-Zuweisung (desktop)', () => {
       },
     });
 
-    const verifySeed = await listClassSubjects(request, cls.id);
+    const verifySeed = await listClassSubjects(request, cls.id, fixture.schoolId);
     expect(
       verifySeed.find((r) => r.subject.shortName === 'D')?.teacherId,
     ).toBe(target.id);
@@ -262,7 +279,7 @@ test.describe('Issue #71 — Stundentafel Teacher-Zuweisung (desktop)', () => {
       'PUT body sets teacherId=null for the D row',
     ).toBeNull();
 
-    const rowsAfter = await listClassSubjects(request, cls.id);
+    const rowsAfter = await listClassSubjects(request, cls.id, fixture.schoolId);
     expect(
       rowsAfter.find((r) => r.subject.shortName === 'D')?.teacherId,
     ).toBeNull();

--- a/apps/web/e2e/admin-subjects-required-room-type.spec.ts
+++ b/apps/web/e2e/admin-subjects-required-room-type.spec.ts
@@ -1,6 +1,11 @@
 /**
  * Issue #69 — Subject Pflicht-Raumtyp assignment.
  *
+ * Issue #152 (Phase 3.5/5) — migrated to throwaway-school per CLAUDE.md D4.
+ * The `admin-subjects-required-room-type:` and `e2e-rows-on-seed-school:`
+ * advisory locks are gone; each spec owns its own throwaway School so
+ * parallel cleanup-by-prefix sweeps can no longer collide.
+ *
  * Covers the UI affordance shipped in the requiredRoomType PR:
  *   - E2E-SUB-RRT-CREATE: SubjectFormDialog create-mode with
  *                          Pflicht-Raumtyp = Turnsaal → POST /subjects
@@ -18,41 +23,65 @@
  *     aria-label="Pflicht-Raumtyp">` (data-testid same).
  *   - Sentinel `__no_required_room__` clears the assignment (Radix Select
  *     does not accept empty string as a value).
- *
- * Scoped to desktop + chromium-only per the parallel-cleanup race family
- * — same pattern as admin-classes-home-room.spec.ts (#67) and
- * project_e2e_parallel_cleanup_race_family.md.
  */
-import { expect, test } from '@playwright/test';
-import { getAdminToken, loginAsAdmin } from './helpers/login';
-import { cleanupE2ESubjects, createSubjectViaAPI } from './helpers/subjects';
-import { SEED_SCHOOL_UUID } from './fixtures/seed-uuids';
-import { acquireAdvisoryLock, type AdvisoryLock } from './helpers/advisory-lock';
+import { expect, test, type APIRequestContext } from '@playwright/test';
+import { getAdminToken, loginAsRole } from './helpers/login';
+import {
+  createThrowawaySchool,
+  type ThrowawaySchoolFixture,
+} from './fixtures/throwaway-school';
+import { useThrowawaySchoolHeader } from './helpers/school-context';
 
+const API = process.env.E2E_API_URL ?? 'http://localhost:3000/api/v1';
 const PREFIX = 'E2E-RRT-';
-const API = 'http://localhost:3000/api/v1';
 
 async function fetchSubject(
-  request: import('@playwright/test').APIRequestContext,
+  request: APIRequestContext,
   id: string,
+  schoolId: string,
 ): Promise<{ id: string; requiredRoomType: string | null }> {
   const token = await getAdminToken(request);
   const res = await request.get(`${API}/subjects/${id}`, {
-    headers: { Authorization: `Bearer ${token}` },
+    headers: { Authorization: `Bearer ${token}`, 'X-School-Id': schoolId },
   });
   expect(res.ok(), `GET /subjects/${id}`).toBeTruthy();
   return (await res.json()) as { id: string; requiredRoomType: string | null };
 }
 
+async function createSubject(
+  request: APIRequestContext,
+  schoolId: string,
+  fields: { name: string; shortName: string },
+): Promise<{ id: string; name: string; shortName: string }> {
+  const token = await getAdminToken(request);
+  const res = await request.post(`${API}/subjects`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'X-School-Id': schoolId,
+      'Content-Type': 'application/json',
+    },
+    data: {
+      schoolId,
+      name: fields.name,
+      shortName: fields.shortName,
+      subjectType: 'PFLICHT',
+    },
+  });
+  expect(res.ok(), `POST /subjects (${fields.name})`).toBeTruthy();
+  return (await res.json()) as { id: string; name: string; shortName: string };
+}
+
 async function setSubjectRequiredRoomType(
-  request: import('@playwright/test').APIRequestContext,
+  request: APIRequestContext,
   id: string,
+  schoolId: string,
   value: string | null,
 ): Promise<void> {
   const token = await getAdminToken(request);
   const res = await request.put(`${API}/subjects/${id}`, {
     headers: {
       Authorization: `Bearer ${token}`,
+      'X-School-Id': schoolId,
       'Content-Type': 'application/json',
     },
     data: { requiredRoomType: value },
@@ -60,7 +89,7 @@ async function setSubjectRequiredRoomType(
   expect(res.ok(), `PUT /subjects/${id} requiredRoomType=${value}`).toBeTruthy();
 }
 
-test.describe('Issue #69 — Subject Pflicht-Raumtyp (desktop)', () => {
+test.describe('Issue #69 — Subject Pflicht-Raumtyp (throwaway-school, #152)', () => {
   // Mobile renders the same SubjectFormDialog with the same Select;
   // the contract is identical, no viewport-specific affordance to test.
   test.skip(
@@ -68,32 +97,33 @@ test.describe('Issue #69 — Subject Pflicht-Raumtyp (desktop)', () => {
     'Pflicht-Raumtyp form contract is identical across viewports — desktop only.',
   );
 
-  // Issue #112 phase 4 wave 2d (#122): per-spec advisory lock serializes
-  // parallel browser projects on the cleanup-by-prefix race.
-  let lock: AdvisoryLock | undefined;
+  let fixture: ThrowawaySchoolFixture | undefined;
 
-  test.beforeEach(async ({ page }) => {
-    // See admin-classes-home-room.spec.ts for the two-lock rationale —
-    // per-spec key + shared canary-sweep guard.
-    lock = await acquireAdvisoryLock([
-      `admin-subjects-required-room-type:${SEED_SCHOOL_UUID}`,
-      `e2e-rows-on-seed-school:${SEED_SCHOOL_UUID}`,
-    ]);
-    await loginAsAdmin(page);
+  test.beforeEach(async () => {
+    fixture = await createThrowawaySchool({
+      roles: { admin: true },
+      withClasses: 1,
+      withTimetableStack: true,
+      namePrefix: 'E2E-RRT',
+    });
   });
 
-  test.afterEach(async ({ request }) => {
-    await cleanupE2ESubjects(request, PREFIX);
-    if (lock) {
-      await lock.release();
-      lock = undefined;
+  test.afterEach(async () => {
+    if (fixture) {
+      await fixture.cleanup();
+      fixture = undefined;
     }
   });
 
   test('E2E-SUB-RRT-CREATE: dialog with Pflicht-Raumtyp=Turnsaal → POST carries TURNSAAL', async ({
     page,
+    context,
     request,
   }) => {
+    if (!fixture) throw new Error('fixture not seeded');
+    await useThrowawaySchoolHeader(context, fixture.schoolId);
+    await loginAsRole(page, 'admin');
+
     const ts = Date.now().toString().slice(-6);
     const subjectName = `${PREFIX}Sport-${ts}`;
     // Keep Kürzel short (max 8). Combine a stable prefix with the last
@@ -134,22 +164,27 @@ test.describe('Issue #69 — Subject Pflicht-Raumtyp (desktop)', () => {
 
     // DB persistence verification.
     const body = (await postRes.json()) as { id: string };
-    const persisted = await fetchSubject(request, body.id);
+    const persisted = await fetchSubject(request, body.id, fixture.schoolId);
     expect(persisted.requiredRoomType).toBe('TURNSAAL');
   });
 
   test('E2E-SUB-RRT-EDIT-ASSIGN: pick Turnsaal → save → PUT body + DB persist', async ({
     page,
+    context,
     request,
   }) => {
+    if (!fixture) throw new Error('fixture not seeded');
+    await useThrowawaySchoolHeader(context, fixture.schoolId);
+    await loginAsRole(page, 'admin');
+
     const ts = Date.now().toString().slice(-6);
-    const subject = await createSubjectViaAPI(request, {
+    const subject = await createSubject(request, fixture.schoolId, {
       name: `${PREFIX}A-${ts}`,
       shortName: `A${ts.slice(-4)}`,
     });
 
     // Start state — no requiredRoomType.
-    const before = await fetchSubject(request, subject.id);
+    const before = await fetchSubject(request, subject.id, fixture.schoolId);
     expect(before.requiredRoomType).toBeNull();
 
     await page.goto('/admin/subjects');
@@ -179,25 +214,29 @@ test.describe('Issue #69 — Subject Pflicht-Raumtyp (desktop)', () => {
     const reqBody = JSON.parse(putRes.request().postData() ?? '{}');
     expect(reqBody.requiredRoomType, 'PUT body sets TURNSAAL').toBe('TURNSAAL');
 
-    const after = await fetchSubject(request, subject.id);
+    const after = await fetchSubject(request, subject.id, fixture.schoolId);
     expect(after.requiredRoomType).toBe('TURNSAAL');
   });
 
   test('E2E-SUB-RRT-EDIT-CLEAR: switch from Turnsaal → Kein Pflichtraum → PUT body null', async ({
     page,
+    context,
     request,
   }) => {
+    if (!fixture) throw new Error('fixture not seeded');
+    await useThrowawaySchoolHeader(context, fixture.schoolId);
+    await loginAsRole(page, 'admin');
+
     const ts = Date.now().toString().slice(-6);
-    const subject = await createSubjectViaAPI(request, {
+    const subject = await createSubject(request, fixture.schoolId, {
       name: `${PREFIX}C-${ts}`,
       shortName: `C${ts.slice(-4)}`,
     });
 
     // Seed-state: pre-set requiredRoomType so the clear flow has something
-    // to remove. The createSubjectViaAPI helper doesn't accept the field
-    // today; PATCH afterwards rather than expanding the helper signature.
-    await setSubjectRequiredRoomType(request, subject.id, 'TURNSAAL');
-    const before = await fetchSubject(request, subject.id);
+    // to remove.
+    await setSubjectRequiredRoomType(request, subject.id, fixture.schoolId, 'TURNSAAL');
+    const before = await fetchSubject(request, subject.id, fixture.schoolId);
     expect(before.requiredRoomType).toBe('TURNSAAL');
 
     await page.goto('/admin/subjects');
@@ -224,7 +263,7 @@ test.describe('Issue #69 — Subject Pflicht-Raumtyp (desktop)', () => {
     const reqBody = JSON.parse(putRes.request().postData() ?? '{}');
     expect(reqBody.requiredRoomType, 'PUT body sets null').toBeNull();
 
-    const after = await fetchSubject(request, subject.id);
+    const after = await fetchSubject(request, subject.id, fixture.schoolId);
     expect(after.requiredRoomType).toBeNull();
   });
 });

--- a/apps/web/e2e/fixtures/throwaway-school.ts
+++ b/apps/web/e2e/fixtures/throwaway-school.ts
@@ -233,6 +233,13 @@ export interface ThrowawayTimetableStack {
   subjectAbbreviation: string;
   classSubjectId: string;
   roomId: string;
+  /**
+   * Issue #152 — Room.name as stored in DB. Exposed because UI room
+   * pickers (e.g. ClassStammdatenTab Heimraum Select, ClassCreateDialog)
+   * render rooms by name not id, so a spec that wants to pick "the
+   * fixture room" needs the visible label, not just the FK.
+   */
+  roomName: string;
   timeGridId: string;
   timetableRunId: string;
   /** True when the seeded TimetableRun is `isActive=true` (the default). */
@@ -575,6 +582,7 @@ export async function createThrowawaySchool(
         subjectAbbreviation: subject.shortName,
         classSubjectId: classSubject.id,
         roomId: room.id,
+        roomName: room.name,
         timeGridId: timeGrid.id,
         timetableRunId: run.id,
         timetableRunActive: runActive,


### PR DESCRIPTION
Phase 3.5/5 — three admin-CRUD specs that shared the `e2e-rows-on-seed-school:\${SEED_SCHOOL_UUID}` advisory lock (+ their own per-spec locks). Each spec now owns its own throwaway School so the cleanup-by-prefix sweep race can no longer fire across sibling workers.

## Files migrated

| Spec | Tests | Locks removed |
| --- | --- | --- |
| `admin-subjects-required-room-type.spec.ts` | RRT-CREATE / EDIT-ASSIGN / EDIT-CLEAR | `admin-subjects-required-room-type:SEED` + `e2e-rows-on-seed-school:SEED` |
| `admin-classes-home-room.spec.ts` | HR-EDIT-ASSIGN / EDIT-CLEAR / CREATE | `admin-classes-home-room:SEED` + `e2e-rows-on-seed-school:SEED` |
| `admin-stundentafel-teacher-assignment.spec.ts` | TEACHER-ASSIGN / CLEAR | `admin-stundentafel-teacher-assignment:SEED` + `e2e-rows-on-seed-school:SEED` |

## Migration pattern

Same harness swap as #148, plus inline API helpers (because `helpers/students.ts` + `helpers/subjects.ts` are still hardwired to `SEED_SCHOOL_UUID` and have 15 other callers — refactoring them is out of scope here):

\`\`\`ts
fixture = await createThrowawaySchool({
  roles: { admin: true },
  withClasses: 1,
  withTimetableStack: true, // provisions the lone Room + Teacher the pickers select
  namePrefix: 'E2E-RRT' | 'E2E-HR' | 'E2E-TA',
});

// in test:
await useThrowawaySchoolHeader(context, fixture.schoolId);
await loginAsRole(page, 'admin');
const cls = await createClass(request, fixture.schoolId, fixture.schoolYearId, {...});
// ...
// API readbacks: explicit X-School-Id header
\`\`\`

The `cleanupE2EClasses`/`cleanupE2ESubjects` afterEach hooks went away — `fixture.cleanup()` cascade-drops the entire School and every per-school row.

## Fixture extension

- `ThrowawayTimetableStack.roomName` exposed so the home-room spec can pick the throwaway's Room by visible UI label (Heimraum dropdown shows name, not id).

## Acceptance Criteria (from #152)

- [x] All 3 specs migrated; both per-spec lock and `e2e-rows-on-seed-school` lock removed
- [x] Cross-project parallel 5 iterations grün for each

## Tests

\`\`\`
pnpm exec playwright test --project=desktop --project=desktop-firefox \\
  e2e/admin-subjects-required-room-type.spec.ts \\
  e2e/admin-classes-home-room.spec.ts \\
  e2e/admin-stundentafel-teacher-assignment.spec.ts \\
  --repeat-each=5
80 passed (5.5m)
\`\`\`

Closes #152
Refs #147