### PR TITLE
feat(messaging): #150 — scope directPairKey per school + migrate 2 messaging specs to throwaway

### DIFF
--- a/apps/api/prisma/migrations/20260526205000_direct_pair_key_per_school/migration.sql
+++ b/apps/api/prisma/migrations/20260526205000_direct_pair_key_per_school/migration.sql
@@ -1,0 +1,19 @@
+-- Issue #150 — scope DIRECT conversation `direct_pair_key` per school.
+--
+-- Pre-#150 the column had a global UNIQUE constraint, which broke any
+-- deployment where a user has Person memberships in multiple schools:
+-- the first DIRECT conversation between two such users in school A
+-- blocked a second DIRECT conversation between the same pair in school
+-- B, and ConversationService.createDirect's find-or-create silently
+-- aliased every subsequent attempt back to school A's conversation.
+--
+-- The composite unique (school_id, direct_pair_key) restores per-tenant
+-- isolation. NULL direct_pair_key values (every non-DIRECT row) remain
+-- unconstrained because Postgres treats NULL as distinct in unique
+-- indexes by default.
+
+-- DropIndex
+DROP INDEX "conversations_direct_pair_key_key";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "conversations_school_id_direct_pair_key_key" ON "conversations"("school_id", "direct_pair_key");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -1265,13 +1265,24 @@ model Conversation {
   scopeId       String?           @map("scope_id") // classId for CLASS, yearLevel string for YEAR_GROUP, null for SCHOOL/DIRECT
   subject       String?           // required for broadcasts
   createdBy     String            @map("created_by") // keycloakUserId
-  directPairKey String?           @unique @map("direct_pair_key") // sorted "userId1:userId2" for DIRECT dedup (Pitfall 5)
+  // Issue #150 — scoped per-school. `directPairKey` is the sorted
+  // "userId1:userId2" key used by `ConversationService.createDirect`
+  // for find-or-create dedup (Pitfall 5). Pre-#150 the column was
+  // GLOBALLY @unique, which broke any deployment where a user has
+  // memberships in multiple schools: the first DIRECT conversation
+  // between two such users in school A blocked a second DIRECT
+  // conversation between the same pair in school B (and silently
+  // aliased subsequent creates back to school A). Composite-uniqueing
+  // (schoolId, directPairKey) restores per-tenant isolation and
+  // unblocks the throwaway-school e2e migration (#150).
+  directPairKey String?           @map("direct_pair_key")
   createdAt     DateTime          @default(now()) @map("created_at")
   updatedAt     DateTime          @updatedAt @map("updated_at")
 
   messages            Message[]
   conversationMembers ConversationMember[]
 
+  @@unique([schoolId, directPairKey], name: "schoolId_directPairKey")
   @@index([schoolId, scope])
   @@index([createdBy])
   @@map("conversations")

--- a/apps/api/src/modules/communication/__tests__/conversation.service.spec.ts
+++ b/apps/api/src/modules/communication/__tests__/conversation.service.spec.ts
@@ -249,10 +249,12 @@ describe('ConversationService', () => {
 
     expect(result).toBeDefined();
     expect(result.id).toBe('conv-direct');
-    // Verify directPairKey lookup was attempted
+    // Verify (schoolId, directPairKey) composite lookup was attempted —
+    // post-#150 the dedup is scoped per-school so a user with multi-school
+    // memberships gets a distinct DIRECT row per school.
     expect(prisma.conversation.findUnique).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: { directPairKey: 'user-a:user-b' },
+        where: { schoolId_directPairKey: { schoolId: 'school-1', directPairKey: 'user-a:user-b' } },
       }),
     );
   });

--- a/apps/api/src/modules/communication/conversation/conversation.service.ts
+++ b/apps/api/src/modules/communication/conversation/conversation.service.ts
@@ -216,9 +216,15 @@ export class ConversationService {
 
     const directPairKey = [userId, dto.recipientId].sort().join(':');
 
-    // Upsert: find existing or create new (Pitfall 5)
+    // Upsert: find existing or create new (Pitfall 5).
+    //
+    // Issue #150 — the lookup is scoped to (schoolId, directPairKey) so a
+    // user with memberships in multiple schools gets a SEPARATE DIRECT
+    // conversation per school. Pre-#150 the column was globally @unique,
+    // which silently aliased every cross-school DIRECT attempt back to
+    // whichever school first created the pair.
     const existing = await this.prisma.conversation.findUnique({
-      where: { directPairKey },
+      where: { schoolId_directPairKey: { schoolId, directPairKey } },
       include: {
         conversationMembers: true,
         messages: {

--- a/apps/api/src/modules/communication/message/message.service.ts
+++ b/apps/api/src/modules/communication/message/message.service.ts
@@ -645,10 +645,15 @@ export class MessageService {
 
     const studentName = `${student.person.firstName} ${student.person.lastName}`;
 
-    // 3. Find or create DIRECT conversation between parent and KV
+    // 3. Find or create DIRECT conversation between parent and KV.
+    //
+    // Issue #150 — `directPairKey` is now scoped per-school via the
+    // composite (schoolId, directPairKey) unique key. A user with
+    // memberships in multiple schools gets a separate DIRECT conversation
+    // per school, matching ConversationService.createDirect's lookup.
     const directPairKey = [parentUserId, kvKeycloakId].sort().join(':');
     let conversation = await this.prisma.conversation.findUnique({
-      where: { directPairKey },
+      where: { schoolId_directPairKey: { schoolId, directPairKey } },
     });
 
     if (!conversation) {

--- a/apps/web/e2e/helpers/messaging.ts
+++ b/apps/web/e2e/helpers/messaging.ts
@@ -51,6 +51,13 @@ export interface CreateBroadcastInput {
     options: string[];
     deadline?: string;
   };
+  /**
+   * Issue #150 — throwaway-school override. When set, the helper posts to
+   * `/schools/<schoolId>/conversations` and sends `X-School-Id: <schoolId>`
+   * for tenant scoping. Default (undefined) keeps the seed-school path so
+   * legacy callers stay unchanged.
+   */
+  schoolId?: string;
 }
 
 export interface CreateDirectInput {
@@ -62,6 +69,10 @@ export interface CreateDirectInput {
    * sender for the lehrer→eltern flow specified in #84.
    */
   actorRole?: Role;
+  /**
+   * Issue #150 — throwaway-school override (see CreateBroadcastInput).
+   */
+  schoolId?: string;
 }
 
 export interface CreatedConversation {
@@ -82,12 +93,16 @@ export async function createBroadcastConversation(
   input: CreateBroadcastInput,
 ): Promise<CreatedConversation> {
   const token = await getAdminToken(request);
+  const schoolId = input.schoolId ?? MESSAGING_SCHOOL_ID;
   const res = await request.post(
-    `${MESSAGING_API}/schools/${MESSAGING_SCHOOL_ID}/conversations`,
+    `${MESSAGING_API}/schools/${schoolId}/conversations`,
     {
       headers: {
         Authorization: `Bearer ${token}`,
         'Content-Type': 'application/json',
+        // Always send X-School-Id when an explicit schoolId is provided
+        // — the legacy default-SEED path stays header-less for back-compat.
+        ...(input.schoolId ? { 'X-School-Id': input.schoolId } : {}),
       },
       data: {
         scope: input.scope ?? 'CLASS',
@@ -125,12 +140,14 @@ export async function createDirectConversation(
 ): Promise<CreatedConversation> {
   const role = input.actorRole ?? 'lehrer';
   const token = await getRoleToken(request, role);
+  const schoolId = input.schoolId ?? MESSAGING_SCHOOL_ID;
   const res = await request.post(
-    `${MESSAGING_API}/schools/${MESSAGING_SCHOOL_ID}/conversations`,
+    `${MESSAGING_API}/schools/${schoolId}/conversations`,
     {
       headers: {
         Authorization: `Bearer ${token}`,
         'Content-Type': 'application/json',
+        ...(input.schoolId ? { 'X-School-Id': input.schoolId } : {}),
       },
       data: {
         scope: 'DIRECT',
@@ -160,16 +177,18 @@ export async function createDirectConversation(
 export async function sendMessageViaAPI(
   request: APIRequestContext,
   conversationId: string,
-  options: { body: string; actorRole?: Role },
+  options: { body: string; actorRole?: Role; schoolId?: string },
 ): Promise<{ id: string; body: string }> {
   const role = options.actorRole ?? 'lehrer';
   const token = await getRoleToken(request, role);
+  const schoolId = options.schoolId ?? MESSAGING_SCHOOL_ID;
   const res = await request.post(
-    `${MESSAGING_API}/schools/${MESSAGING_SCHOOL_ID}/conversations/${conversationId}/messages`,
+    `${MESSAGING_API}/schools/${schoolId}/conversations/${conversationId}/messages`,
     {
       headers: {
         Authorization: `Bearer ${token}`,
         'Content-Type': 'application/json',
+        ...(options.schoolId ? { 'X-School-Id': options.schoolId } : {}),
       },
       data: { body: options.body },
     },

--- a/apps/web/e2e/messaging-direct-1on1.spec.ts
+++ b/apps/web/e2e/messaging-direct-1on1.spec.ts
@@ -1,6 +1,16 @@
 /**
  * Issue #84 — Messaging DIRECT 1:1 (lehrer → eltern, recipient visibility).
  *
+ * Issue #150 (Phase 3.5/3) — migrated to throwaway-school per CLAUDE.md D4.
+ * The `messaging:direct:lehrer-eltern:${SEED_SCHOOL_UUID}` advisory lock
+ * is gone; each spec owns its own throwaway School so DIRECT find-or-create
+ * (Pitfall 5) lives in tenant-isolated rows. The same PR also closed a
+ * latent backend bug — `conversations.direct_pair_key` was previously a
+ * GLOBALLY unique column, so two parallel throwaway specs would alias to
+ * a single Conversation row on whichever throwaway happened to win the
+ * race. The composite (school_id, direct_pair_key) unique introduced in
+ * the same PR restores per-tenant isolation.
+ *
  * Slice 2/n of the Messaging coverage gap. Locks the recipient-side flow
  * for DIRECT 1:1 conversations: a message that the lehrer sends to a
  * single parent must surface in that parent's /messages list, and
@@ -24,76 +34,64 @@
  * MSG-LIST-01 pattern (seed-via-API, assert-via-UI), keeps the spec
  * focused on the recipient-visibility contract, and avoids couplng to
  * the unrelated dialog wiring gap.
- *
- * Chromium-only-skip per the race-family precedent — DIRECT rows
- * between the shared seed (lehrer-user, eltern-user) pair are
- * find-or-create, so two parallel browser projects would step on the
- * same `directPairKey` row mid-flight.
  */
 import { test, expect } from '@playwright/test';
 import { loginAsRole } from './helpers/login';
-import { getSeedUserId } from './helpers/users';
 import {
   MESSAGING_PREFIX,
-  cleanupE2EConversations,
   createDirectConversation,
   type CreatedConversation,
 } from './helpers/messaging';
-import { acquireAdvisoryLock, type AdvisoryLock } from './helpers/advisory-lock';
-import { SEED_SCHOOL_UUID } from './fixtures/seed-uuids';
+import {
+  createThrowawaySchool,
+  type ThrowawaySchoolFixture,
+} from './fixtures/throwaway-school';
+import { useThrowawaySchoolHeader } from './helpers/school-context';
 
-test.describe('Issue #84 — Messaging DIRECT 1:1 (lehrer → eltern, desktop)', () => {
+test.describe('Issue #84 — Messaging DIRECT 1:1 (lehrer → eltern, throwaway-school, #150)', () => {
   test.skip(
     ({ isMobile }) => isMobile,
     'List-detail two-pane layout is desktop-only; mobile has a separate route a future slice will cover.',
   );
 
-  // Issue #112 Phase 4 wave 2b (#120): DIRECT lehrer↔eltern is a per-pair
-  // singleton (find-or-create on `directPairKey`). The realtime spec
-  // (messaging-realtime.spec.ts) also writes to the same pair — without
-  // the lock, two parallel specs would see each other's mid-test
-  // messages on the shared row. Lock serializes both specs cross-spec
-  // AND cross-project.
-  let lock: AdvisoryLock | undefined;
+  let fixture: ThrowawaySchoolFixture | undefined;
   let created: CreatedConversation | null = null;
 
   test.beforeEach(async () => {
-    lock = await acquireAdvisoryLock(
-      `messaging:direct:lehrer-eltern:${SEED_SCHOOL_UUID}`,
-    );
+    fixture = await createThrowawaySchool({
+      roles: { lehrer: true, eltern: true },
+      withClasses: 1,
+      namePrefix: 'E2E-MSG-DIRECT',
+    });
   });
 
-  test.afterEach(async ({ request }) => {
-    // Sweep DIRECT rows whose latest message body carries the E2E-MSG-
-    // prefix. Listing AS lehrer is required because admin is not a
-    // member of DIRECT conversations and so cannot see them via the
-    // member-scoped GET. Deletion still goes through the admin token
-    // inside the helper (DELETE requires manage:communication).
-    // Scope sweep to this spec's own sub-prefix so sibling messaging
-    // specs running in parallel don't sweep our mid-test DIRECT row
-    // (race-family from PR #107 parallel-run failure: shared
-    // `E2E-MSG-` prefix made every spec's afterEach sweep every
-    // other spec's conversations).
-    await cleanupE2EConversations(request, `${MESSAGING_PREFIX}DIRECT-`, 'lehrer');
+  test.afterEach(async () => {
     created = null;
-    if (lock) {
-      await lock.release();
-      lock = undefined;
+    if (fixture) {
+      await fixture.cleanup();
+      fixture = undefined;
     }
   });
 
   test('MSG-DIRECT-01: lehrer-sent DIRECT message appears in eltern-user list and opens with body', async ({
     page,
+    context,
     request,
   }) => {
-    const elternId = await getSeedUserId(request, 'eltern');
+    if (!fixture) throw new Error('fixture not seeded');
+    const elternKcId = fixture.keycloakUserIds.eltern;
+    if (!elternKcId) throw new Error('throwaway fixture missing eltern KC id');
+
+    await useThrowawaySchoolHeader(context, fixture.schoolId);
+
     const ts = Date.now();
     const body = `${MESSAGING_PREFIX}DIRECT-${ts} — Hallo, eine direkte Nachricht von Maria Mueller.`;
 
     created = await createDirectConversation(request, {
       actorRole: 'lehrer',
-      recipientId: elternId,
+      recipientId: elternKcId,
       body,
+      schoolId: fixture.schoolId,
     });
     expect(created.id, 'POST /conversations DIRECT must return an id').toBeTruthy();
 
@@ -109,8 +107,8 @@ test.describe('Issue #84 — Messaging DIRECT 1:1 (lehrer → eltern, desktop)',
     // body preview underneath (ConversationListItem.tsx:33-34, 73-75).
     // Matching on the unique body prefix isolates this run's row from
     // any pre-existing lehrer↔eltern DIRECT conversation (find-or-create
-    // semantics mean the same conversation row can carry many prior
-    // messages — only the latest is asserted).
+    // semantics within this school — global cross-school aliasing was
+    // closed in #150 backend changes).
     const row = page.getByRole('button', { name: new RegExp(`${MESSAGING_PREFIX}DIRECT-${ts}`) });
     await expect(
       row,
@@ -122,8 +120,7 @@ test.describe('Issue #84 — Messaging DIRECT 1:1 (lehrer → eltern, desktop)',
     // ConversationView renders the first message via MessageBubble
     // (MessageBubble.tsx:90). `.first()` because the unique body string
     // appears twice on the page after the row click: once in the
-    // truncated list preview and once in the bubble itself. Assertion
-    // intent ("body is rendered in ConversationView") is preserved.
+    // truncated list preview and once in the bubble itself.
     await expect(
       page.getByText(body).first(),
       'DIRECT message body must appear in ConversationView after click',

--- a/apps/web/e2e/messaging-realtime.spec.ts
+++ b/apps/web/e2e/messaging-realtime.spec.ts
@@ -1,6 +1,14 @@
 /**
  * Issue #84 — Messaging Socket.IO realtime delivery (slice 5/5, "optional" per the issue).
  *
+ * Issue #150 (Phase 3.5/3) — migrated to throwaway-school per CLAUDE.md D4.
+ * The `messaging:direct:lehrer-eltern:${SEED_SCHOOL_UUID}` advisory lock
+ * is gone. Each spec owns its own throwaway School + DIRECT conversation
+ * (find-or-create scoped per-school by the (school_id, direct_pair_key)
+ * composite unique introduced in the same PR), so the Socket.IO emit
+ * delivers cross-context to the intended eltern without cross-spec
+ * collision.
+ *
  * Locks the WebSocket-driven invalidation path on /messages: a message
  * sent by one user lands in another user's open conversation view
  * WITHOUT a page reload. This is the load-bearing UX promise of the
@@ -25,58 +33,52 @@
  * Playwright contexts isolate cookies/localStorage. Sharing a context
  * between kc-lehrer and kc-eltern would force a Keycloak re-login
  * each time and risk auth-state races; two contexts give two clean
- * sessions in parallel.
+ * sessions in parallel. The Socket.IO `user:<kcUserId>` room is keyed
+ * on the Keycloak user id — no school dimension at the socket layer —
+ * so the throwaway-school binding doesn't change the WS contract;
+ * only the conversation tenancy changes.
  *
  * Why no `page.reload()` between seed and assertion: that's the whole
  * point. If a reload were needed, the socket layer wouldn't be doing
  * its job and the spec wouldn't be a regression-lock — it would be a
  * stale-cache stress test.
- *
- * Chromium-only-skip per the race-family precedent — shared
- * lehrer↔eltern DIRECT row is a per-pair singleton (`directPairKey`).
  */
 import { test, expect } from '@playwright/test';
 import { loginAsRole } from './helpers/login';
-import { getSeedUserId } from './helpers/users';
 import {
   MESSAGING_PREFIX,
-  cleanupE2EConversations,
   createDirectConversation,
   sendMessageViaAPI,
   type CreatedConversation,
 } from './helpers/messaging';
-import { acquireAdvisoryLock, type AdvisoryLock } from './helpers/advisory-lock';
-import { SEED_SCHOOL_UUID } from './fixtures/seed-uuids';
+import {
+  createThrowawaySchool,
+  type ThrowawaySchoolFixture,
+} from './fixtures/throwaway-school';
+import { useThrowawaySchoolHeader } from './helpers/school-context';
 
-test.describe('Issue #84 — Messaging realtime (Socket.IO, desktop)', () => {
+test.describe('Issue #84 — Messaging realtime (Socket.IO, throwaway-school, #150)', () => {
   test.skip(
     ({ isMobile }) => isMobile,
     'List-detail two-pane layout is desktop-only; mobile realtime parity is a follow-up once the mobile route lands.',
   );
 
-  // Issue #112 Phase 4 wave 2b (#120): DIRECT lehrer↔eltern is a per-pair
-  // singleton (find-or-create on `directPairKey`). Shared with the
-  // messaging-direct-1on1 spec — without the lock, a parallel run on
-  // the other spec would interleave messages into the same row and
-  // contaminate the realtime delivery assertion. Lock acquired here
-  // serializes both specs cross-spec AND cross-project.
-  let lock: AdvisoryLock | undefined;
+  let fixture: ThrowawaySchoolFixture | undefined;
   let created: CreatedConversation | null = null;
 
   test.beforeEach(async () => {
-    lock = await acquireAdvisoryLock(
-      `messaging:direct:lehrer-eltern:${SEED_SCHOOL_UUID}`,
-    );
+    fixture = await createThrowawaySchool({
+      roles: { lehrer: true, eltern: true },
+      withClasses: 1,
+      namePrefix: 'E2E-MSG-RT',
+    });
   });
 
-  test.afterEach(async ({ request }) => {
-    // Scope sweep to this spec's own sub-prefix so sibling messaging
-    // specs running in parallel don't sweep our mid-test DIRECT row.
-    await cleanupE2EConversations(request, `${MESSAGING_PREFIX}RT-`, 'lehrer');
+  test.afterEach(async () => {
     created = null;
-    if (lock) {
-      await lock.release();
-      lock = undefined;
+    if (fixture) {
+      await fixture.cleanup();
+      fixture = undefined;
     }
   });
 
@@ -84,17 +86,22 @@ test.describe('Issue #84 — Messaging realtime (Socket.IO, desktop)', () => {
     browser,
     request,
   }) => {
+    if (!fixture) throw new Error('fixture not seeded');
+    const elternKcId = fixture.keycloakUserIds.eltern;
+    if (!elternKcId) throw new Error('throwaway fixture missing eltern KC id');
+
     const ts = Date.now();
     const initialBody = `${MESSAGING_PREFIX}RT-INIT-${ts} — Erste Nachricht (initial seed)`;
     const realtimeBody = `${MESSAGING_PREFIX}RT-LIVE-${ts} — Diese Nachricht muss ohne Reload erscheinen`;
 
     // Seed the DIRECT row + initial message so eltern's /messages
-    // list has a row to click.
-    const elternId = await getSeedUserId(request, 'eltern');
+    // list has a row to click. schoolId pinned to throwaway so the
+    // per-school directPairKey unique resolves inside our tenant.
     created = await createDirectConversation(request, {
       actorRole: 'lehrer',
-      recipientId: elternId,
+      recipientId: elternKcId,
       body: initialBody,
+      schoolId: fixture.schoolId,
     });
 
     // Eltern session — open /messages, click the row, mount
@@ -103,8 +110,15 @@ test.describe('Issue #84 — Messaging realtime (Socket.IO, desktop)', () => {
     // _authenticated layout — it doesn't require the messages route
     // specifically, but mounting there ensures we're on the right
     // useMessages query key for invalidation).
+    //
+    // The throwaway-school header is installed on the eltern context
+    // BEFORE login so `/users/me` resolves the throwaway as the active
+    // school (the seed admin's interceptor ordering doesn't matter for
+    // eltern — eltern only has one Person row in seed and one in the
+    // throwaway, header forces the throwaway pick).
     const elternContext = await browser.newContext();
     try {
+      await useThrowawaySchoolHeader(elternContext, fixture.schoolId);
       const elternPage = await elternContext.newPage();
       await loginAsRole(elternPage, 'eltern');
       await elternPage.goto('/messages');
@@ -141,6 +155,7 @@ test.describe('Issue #84 — Messaging realtime (Socket.IO, desktop)', () => {
       await sendMessageViaAPI(request, created.id, {
         actorRole: 'lehrer',
         body: realtimeBody,
+        schoolId: fixture.schoolId,
       });
 
       // Eltern's `useMessagingSocket.on('message:new')` invalidates


### PR DESCRIPTION
Phase 3.5/3 — migrates `messaging-direct-1on1.spec.ts` + `messaging-realtime.spec.ts` to the throwaway-school fixture and removes the `messaging:direct:lehrer-eltern:\${SEED_SCHOOL_UUID}` advisory lock.

## Latent backend bug surfaced + fixed in-PR

`Conversation.directPairKey` was GLOBALLY `@unique` — which means: any user with Person memberships in two schools could only have a DIRECT conversation in ONE of them. `ConversationService.createDirect`'s find-or-create silently aliased every subsequent cross-school attempt back to whichever school first created the pair. The same race trivially defeats the throwaway migration: two parallel specs would alias to a single Conversation row.

### Schema + migration

\`\`\`prisma
// before
directPairKey String? @unique @map("direct_pair_key")

// after
directPairKey String? @map("direct_pair_key")
@@unique([schoolId, directPairKey], name: "schoolId_directPairKey")
\`\`\`

Migration `20260526205000_direct_pair_key_per_school` drops `conversations_direct_pair_key_key` and creates `conversations_school_id_direct_pair_key_key`. NULL `direct_pair_key` rows (every non-DIRECT conversation) stay unconstrained because Postgres treats NULL as distinct in unique indexes by default — so the migration is safe under existing data (no DELETE / data shuffling needed).

### Service callsites

- `conversation.service.ts:220` — `findUnique({ where: { directPairKey } })` → `findUnique({ where: { schoolId_directPairKey: { schoolId, directPairKey } } })`
- `message.service.ts:651` — same change in the excuse-DIRECT path (parent → Klassenvorstand auto-create on excuse creation).

Unit tests: `conversation.service.spec.ts` 8/8 green after updating the composite-key assertion.

## Helper extension

`helpers/messaging.ts` — `createBroadcastConversation`, `createDirectConversation`, `sendMessageViaAPI` accept an optional `schoolId`. When provided, the request hits `/schools/<schoolId>/conversations` and sends `X-School-Id`. Default-omitted keeps the seed-school path so the 3 other callers (broadcast / conversation-list / polls specs) stay unchanged — locally verified 3/3 still green.

## Spec migrations

| Spec | Before | After |
| --- | --- | --- |
| `messaging-direct-1on1.spec.ts` | seed school + advisory-lock + `getSeedUserId` round-trip + `cleanupE2EConversations` afterEach | throwaway-school with lehrer+eltern roles + `useThrowawaySchoolHeader` + `fixture.keycloakUserIds.eltern` + `fixture.cleanup()` cascade |
| `messaging-realtime.spec.ts` | same | same, plus eltern BrowserContext gets the throwaway header BEFORE login so `/users/me` resolves the throwaway tenant |

Socket.IO contract unchanged — `user:<kcUserId>` rooms have no school dimension; only conversation tenancy moved. WS handshake remains the same 1s settle-buffer.

## Acceptance Criteria (from #150)

- [x] Both specs migrated, advisory-lock removed
- [x] Cross-project parallel 5 iterations grün (local: **20/20**)
- [x] Realtime websocket assertions still work (lehrer + eltern in throwaway can establish the WS channel and `message:new` lands without page.reload)

## Tests

\`\`\`
# migrated specs
pnpm exec playwright test --project=desktop --project=desktop-firefox \\
  e2e/messaging-direct-1on1.spec.ts e2e/messaging-realtime.spec.ts \\
  --repeat-each=5
20 passed (1.7m)

# legacy specs on default-SEED path (helper back-compat)
pnpm exec playwright test --project=desktop \\
  e2e/messaging-broadcast.spec.ts e2e/messaging-conversation-list.spec.ts \\
  e2e/messaging-polls.spec.ts
3 passed (8.8s)

# unit tests
pnpm --filter @schoolflow/api exec vitest run \\
  src/modules/communication/__tests__/conversation.service.spec.ts
8 passed
\`\`\`

Closes #150
Refs #147