### PR TITLE
chore(e2e): #154 — migrate calendar-token specs to throwaway + reduce helper

### DIFF
--- a/apps/web/e2e/helpers/calendar-tokens.ts
+++ b/apps/web/e2e/helpers/calendar-tokens.ts
@@ -1,99 +1,20 @@
 /**
  * Calendar-Token E2E helpers — Issue #88.
  *
- * Three responsibilities:
- *  1. Map test-persona role names → SchoolFlow Person UUIDs (fixed
- *     seed constants from `fixtures/seed-uuids.ts`). The CalendarToken
- *     row uses `userId = Person.keycloakUserId`, but the Keycloak
- *     user UUIDs are GENERATED at realm-import time and differ across
- *     environments. We resolve them at runtime via the Person table
- *     (Person.keycloakUserId column) so the helper is portable
- *     across dev / CI / fresh-import scenarios.
- *  2. A Prisma-direct purge of `calendar_tokens` rows for the test
- *     personas. The CalendarToken table allows MULTIPLE rows per
- *     (userId, schoolId) — there is no @@unique constraint on that
- *     tuple, only on `token` (calendar.service.ts:32 does an
- *     unconditional INSERT and the schema declares only a unique
- *     index on `token`). A leftover token from a prior failed test
- *     therefore both (a) prevents the empty-state assertion AND (b)
- *     leaks into the next spec's "URL must differ" assertion (the
- *     newly-generated URL is fine but the GET returns the OLDEST
- *     row via findFirst). Specs MUST purge in beforeEach AND
- *     afterEach to be deterministic.
- *  3. An `apiBaseFromE2eEnv()` helper that resolves the bare API
- *     host (e.g. http://localhost:3000) from the existing
- *     `E2E_API_URL` convention (which points to .../api/v1 by
- *     default). Specs that fetch the public ICS endpoint need just
- *     the host because `calendarUrl` already includes the
- *     /api/v1/calendar/<token>.ics suffix.
+ * Issue #154 (Phase 3.5/7) reduction — the lock-bound seed/cleanup
+ * functions (`seedCalendarTokenContext`, `cleanupCalendarTokenContext`)
+ * + the persona-uuid map + the Prisma-direct purge were removed when
+ * the three caller specs (settings-ical-generate / revoke / rbac)
+ * migrated to throwaway-school. Each spec now owns its own School with
+ * its own CalendarToken rows; `fixture.cleanup()` cascade-drops the
+ * school + token rows via FK, so the global-state purge is obsolete.
  *
- * Why Prisma-direct cleanup (not API DELETE): the API DELETE
- * endpoint is `revokeAndRegenerate` — it deletes AND immediately
- * creates a new token (calendar.controller.ts:99). That's not
- * cleanup, that's churn. The Prisma-direct deleteMany leaves the
- * user in the "no token yet" state which is what beforeEach
- * needs.
+ * What stays: `apiBaseFromE2eEnv()` — a thin URL-host helper still used
+ * by the migrated specs to fetch the public ICS endpoint
+ * (`/api/v1/calendar/<token>.ics`) without prepending `/api/v1` twice.
+ * Could live in a more generic `helpers/api-url.ts` long-term, but
+ * keeping it here for now to minimize churn in this PR.
  */
-import 'dotenv/config';
-import { config as dotenvConfig } from 'dotenv';
-import { createRequire } from 'node:module';
-import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-import {
-  SEED_PERSON_KC_ADMIN_UUID,
-  SEED_PERSON_KC_ELTERN_UUID,
-  SEED_PERSON_KC_LEHRER_UUID,
-  SEED_PERSON_KC_SCHUELER_UUID,
-  SEED_PERSON_KC_SCHULLEITUNG_UUID,
-} from '../fixtures/seed-uuids';
-import { acquireAdvisoryLock, type AdvisoryLock } from './advisory-lock';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-dotenvConfig({ path: path.resolve(__dirname, '../../../../.env') });
-
-const require = createRequire(import.meta.url);
-
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const { PrismaClient } = require('../../../api/dist/config/database/generated/client.js') as {
-  PrismaClient: new (opts?: { adapter?: unknown }) => {
-    person: {
-      findMany: (args: {
-        where: Record<string, unknown>;
-        select: Record<string, unknown>;
-      }) => Promise<Array<{ id: string; keycloakUserId: string | null }>>;
-    };
-    calendarToken: {
-      deleteMany: (args: { where: Record<string, unknown> }) => Promise<{ count: number }>;
-    };
-    $disconnect: () => Promise<void>;
-  };
-};
-
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const { PrismaPg } = require('../../../api/node_modules/@prisma/adapter-pg') as {
-  PrismaPg: new (opts: { connectionString: string }) => unknown;
-};
-
-/**
- * Role → Person UUID lookup. The Person row links a SchoolFlow domain
- * record to a Keycloak user via `keycloakUserId`. We start from the
- * fixed Person UUIDs (defined in apps/api/prisma/seed.ts) because the
- * Keycloak user UUIDs are NON-fixed: they're generated at realm-import
- * time and differ across environments (observed locally: lehrer-user =
- * `230711d2-...`, not the `00000000-0000-0000-0000-000000000002` that
- * docker/keycloak/realm-export.json declares).
- */
-const PERSON_UUID_BY_ROLE = {
-  admin: SEED_PERSON_KC_ADMIN_UUID,
-  lehrer: SEED_PERSON_KC_LEHRER_UUID,
-  eltern: SEED_PERSON_KC_ELTERN_UUID,
-  schueler: SEED_PERSON_KC_SCHUELER_UUID,
-  schulleitung: SEED_PERSON_KC_SCHULLEITUNG_UUID,
-} as const;
-
-export type CalendarTestRole = keyof typeof PERSON_UUID_BY_ROLE;
 
 /**
  * Resolve the bare API host (e.g. http://localhost:3000) for use by
@@ -102,143 +23,12 @@ export type CalendarTestRole = keyof typeof PERSON_UUID_BY_ROLE;
  * strip the trailing `/api/v1` to get the host.
  *
  * The public ICS endpoint is mounted at `/api/v1/calendar/:token.ics`
- * (calendar.controller.ts after the #88 fix) and `calendarUrl` in
- * the React settings component is the relative path
- * `/api/v1/calendar/...ics` (calendar.controller.ts:87).
- * Prepending the host produces the absolute URL the iCal
- * subscription client would use.
+ * and `calendarUrl` in the React settings component is the relative
+ * path `/api/v1/calendar/...ics` (calendar.controller.ts:87).
+ * Prepending the host produces the absolute URL the iCal subscription
+ * client (Apple Kalender / Google Calendar / Outlook) would use.
  */
 export function apiBaseFromE2eEnv(): string {
   const apiUrl = process.env.E2E_API_URL ?? 'http://localhost:3000/api/v1';
   return apiUrl.replace(/\/api\/v1\/?$/, '');
-}
-
-
-// ---------------------------------------------------------------------------
-// Lock-bound CalendarToken context (Issue #112 Phase 2.5a / #117)
-// ---------------------------------------------------------------------------
-
-/**
- * Handle returned by `seedCalendarTokenContext` — carries the held
- * advisory lock so cleanup can release it and the seed-school + roles
- * so afterEach can re-purge on the SAME locked session.
- */
-export interface CalendarTokenContext {
-  schoolId: string;
-  roles: ReadonlyArray<CalendarTestRole>;
-  /** Held advisory lock(s) — released in `cleanupCalendarTokenContext`. */
-  _lock: AdvisoryLock;
-}
-
-/**
- * Resource-key namespace for CalendarToken locks. Distinct namespace
- * prefix per resource type so a 32-bit FNV-1a hash collision with the
- * `active-timetable-run:` keys (or any future namespace) is impossible
- * by construction — they live in orthogonal namespaces by string
- * prefix, hash collision only matters within the same namespace.
- *
- * One lock per (schoolId, role) — that's the row-identity the
- * @@unique-less CalendarToken table effectively keys by (the service
- * does `findFirst({ schoolId, userId })` and unconditionally INSERTs
- * a new row when missing). Specs sharing a role serialize; specs on
- * disjoint roles run in parallel without blocking each other.
- */
-function calendarTokenLockKeys(
-  schoolId: string,
-  roles: ReadonlyArray<CalendarTestRole>,
-): string[] {
-  return roles.map((r) => `calendar-token:${schoolId}:${r}`);
-}
-
-/**
- * Acquire the per-(schoolId, role) advisory lock(s) for the given
- * personas + purge any leftover CalendarToken rows on the locked
- * session. The returned context MUST be passed to
- * `cleanupCalendarTokenContext` in `afterEach` so the lock is
- * released — leaking it would block parallel specs forever.
- *
- * Why purge here AND in afterEach: parallel specs that share a role
- * (e.g. generate-lehrer and rbac-lehrer-eltern) serialize on the
- * `calendar-token:<schoolId>:lehrer` lock, but each STILL needs to
- * see a clean empty state at the start of its test body — the
- * previous holder may have left rows in the table (the test body
- * itself creates rows; only afterEach + this function clean them up).
- * Purge inside the locked window so no parallel writer can squeeze
- * a row in between.
- */
-export async function seedCalendarTokenContext(
-  schoolId: string,
-  roles: CalendarTestRole | ReadonlyArray<CalendarTestRole>,
-): Promise<CalendarTokenContext> {
-  const roleList = Array.isArray(roles)
-    ? (roles as ReadonlyArray<CalendarTestRole>)
-    : [roles as CalendarTestRole];
-
-  const lock = await acquireAdvisoryLock(calendarTokenLockKeys(schoolId, roleList));
-  try {
-    await purgeCalendarTokensOnSession(lock, schoolId, roleList);
-    return { schoolId, roles: roleList, _lock: lock };
-  } catch (err) {
-    // Acquisition succeeded but purge failed — release the lock so
-    // parallel specs aren't blocked and re-throw.
-    await lock.release();
-    throw err;
-  }
-}
-
-/**
- * Re-purge CalendarToken rows on the still-locked session, then
- * release the lock. Idempotent: callers can invoke this safely from
- * an `afterEach` even when the test failed early — the purge is
- * scoped to the seed school + specific roles, so it cannot interfere
- * with other specs (which hold their own locks on their own
- * roles).
- */
-export async function cleanupCalendarTokenContext(
-  ctx: CalendarTokenContext,
-): Promise<void> {
-  try {
-    await purgeCalendarTokensOnSession(ctx._lock, ctx.schoolId, ctx.roles);
-  } catch (err) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      `[calendar-tokens helper] cleanupCalendarTokenContext purge failed for roles=${ctx.roles.join(',')}:`,
-      err,
-    );
-  } finally {
-    await ctx._lock.release();
-  }
-}
-
-/**
- * INTERNAL — purge CalendarToken rows on the Prisma session that
- * holds the advisory lock. We resolve keycloakUserId on the SAME
- * session so the (already-running) Person.findMany participates in
- * the lock's session and we don't open + close a second connection
- * per call.
- */
-async function purgeCalendarTokensOnSession(
-  lock: AdvisoryLock,
-  schoolId: string,
-  roles: ReadonlyArray<CalendarTestRole>,
-): Promise<void> {
-  const personIds = roles.map((r) => PERSON_UUID_BY_ROLE[r]);
-  const prisma = lock._client as InstanceType<typeof PrismaClient>;
-  const rows = await prisma.person.findMany({
-    where: { id: { in: personIds } },
-    select: { id: true, keycloakUserId: true },
-  });
-  const userIds = rows
-    .map((p) => p.keycloakUserId)
-    .filter((id): id is string => id != null && id.length > 0);
-  if (userIds.length === 0) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      `[calendar-tokens helper] no Keycloak userId resolved for roles=${roles.join(',')} — nothing to purge`,
-    );
-    return;
-  }
-  await prisma.calendarToken.deleteMany({
-    where: { schoolId, userId: { in: userIds } },
-  });
 }

--- a/apps/web/e2e/settings-ical-generate.spec.ts
+++ b/apps/web/e2e/settings-ical-generate.spec.ts
@@ -1,19 +1,20 @@
 /**
  * Issue #88 — iCal calendar-token generate flow (Settings).
  *
+ * Issue #154 (Phase 3.5/7) — migrated to throwaway-school per CLAUDE.md D4.
+ * The per-`(schoolId, role)` advisory lock + Prisma-direct purge are gone;
+ * each spec owns its own throwaway School so CalendarToken rows live in
+ * tenant-isolated tables. `fixture.cleanup()` cascade-drops the school
+ * (and its calendar_tokens rows via FK) on afterEach.
+ *
  * Surface: /settings → ICalSettings card (apps/web/src/components/
- * calendar/ICalSettings.tsx). Today only `roles-smoke.spec.ts`
- * proves the page rendert ohne Crash — there is no end-to-end
- * regression-lock that the generated token URL actually serves a
- * valid iCal feed.
+ * calendar/ICalSettings.tsx).
  *
  * Test-Strategie — full POST → URL → public-GET round-trip:
  *
  *   ICAL-GEN-LEHRER:
- *     1. Purge any stale token row for lehrer-user on the seed
- *        school (defensive — a previous failed run could leave
- *        one and the page would land in "Token exists" state,
- *        not "Noch kein Kalender-Abonnement").
+ *     1. Throwaway-school fixture with `lehrer` role — fresh tenant,
+ *        no pre-existing CalendarToken rows.
  *     2. Lehrer logs in, navigates to /settings.
  *     3. Page shows the empty-state copy + the "Kalender-URL erstellen"
  *        CTA. Click it.
@@ -33,57 +34,55 @@
  * Bug-class this catches: any future commit that breaks the
  * full token-URL-roundtrip — e.g. renaming the controller
  * `@Public()` decorator, changing the URL shape, dropping the
- * UUID format, or serving the wrong Content-Type. These are
- * exactly the kind of silent regressions the iCal subscription
- * surface needs locked, because the user-visible failure mode is
- * "my calendar app silently stops syncing" — no toast, no error,
- * no log line on the user's side.
- *
- * Race-Family-Achtung: Issue #112 Phase 2.5a (#117) — a per-(schoolId,
- * role) Postgres advisory lock serializes the purge → seed → test
- * body → cleanup window across parallel specs that share the lehrer
- * persona. Cross-browser safe; previous chromium-only-skip removed.
+ * UUID format, or serving the wrong Content-Type.
  */
 import { test, expect } from '@playwright/test';
 import { loginAsRole } from './helpers/login';
+import { apiBaseFromE2eEnv } from './helpers/calendar-tokens';
 import {
-  apiBaseFromE2eEnv,
-  seedCalendarTokenContext,
-  cleanupCalendarTokenContext,
-  type CalendarTokenContext,
-} from './helpers/calendar-tokens';
-import { SEED_SCHOOL_UUID } from './fixtures/seed-uuids';
+  createThrowawaySchool,
+  type ThrowawaySchoolFixture,
+} from './fixtures/throwaway-school';
+import { useThrowawaySchoolHeader } from './helpers/school-context';
 
 const ROLE = 'lehrer' as const;
 
-test.describe('Issue #88 — iCal generate (desktop)', () => {
+test.describe('Issue #88 — iCal generate (throwaway-school, #154)', () => {
   test.skip(
     ({ isMobile }) => isMobile,
-    'iCal subscription is a desktop-anchored workflow (URL is copied into a desktop calendar app). Mobile coverage belongs to its own *.mobile.spec.ts that asserts the "URL kopieren" button surfaces below the URL field on base/sm.',
+    'iCal subscription is a desktop-anchored workflow (URL is copied into a desktop calendar app). Mobile coverage belongs to its own *.mobile.spec.ts.',
   );
 
-  let ctx: CalendarTokenContext | undefined;
+  let fixture: ThrowawaySchoolFixture | undefined;
 
   test.beforeEach(async () => {
-    ctx = await seedCalendarTokenContext(SEED_SCHOOL_UUID, [ROLE]);
+    fixture = await createThrowawaySchool({
+      roles: { [ROLE]: true },
+      withClasses: 1,
+      namePrefix: 'E2E-ICAL-GEN',
+    });
   });
 
   test.afterEach(async () => {
-    if (ctx) {
-      await cleanupCalendarTokenContext(ctx);
-      ctx = undefined;
+    if (fixture) {
+      await fixture.cleanup();
+      fixture = undefined;
     }
   });
 
   test('ICAL-GEN-LEHRER: "Kalender-URL erstellen" → toast + URL renders → public GET returns valid VCALENDAR', async ({
     page,
+    context,
     request,
   }) => {
+    if (!fixture) throw new Error('fixture not seeded');
+    await useThrowawaySchoolHeader(context, fixture.schoolId);
     await loginAsRole(page, ROLE);
     await page.goto('/settings');
 
-    // Empty-state lock — proves the purge took effect and the page is
-    // actually rendering the "no token yet" branch (ICalSettings.tsx:78).
+    // Empty-state lock — proves the fresh throwaway has no prior token
+    // and the page is rendering the "no token yet" branch
+    // (ICalSettings.tsx:78).
     //
     // Note: shadcn CardTitle renders as <div>, NOT <h*> (see
     // apps/web/src/components/ui/card.tsx:32 — `React.forwardRef<HTMLDivElement>`).
@@ -102,24 +101,20 @@ test.describe('Issue #88 — iCal generate (desktop)', () => {
     await createButton.click();
 
     // Success toast surfaces from useGenerateCalendarToken.onSuccess
-    // (useCalendarToken.ts:49). Sonner renders toasts inside a region
-    // with aria-label "Notifications" — getByText scoped to status role
-    // is the cleanest locator that doesn't trip on the card body's
-    // sibling text.
+    // (useCalendarToken.ts:49).
     await expect(
       page.getByText('Kalender-URL erstellt', { exact: false }),
     ).toBeVisible();
 
     // After the query invalidation refetches, the page swaps to the
-    // "token exists" branch which renders the monospace URL field. The
-    // <label> for that field is "Ihre persoenliche Kalender-URL".
+    // "token exists" branch which renders the monospace URL field.
     await expect(
       page.getByText('Ihre persoenliche Kalender-URL'),
     ).toBeVisible();
 
     // The URL element is `<div className="font-mono ...">` with the
-    // calendarUrl text. Grab the visible relative URL — `crypto.randomUUID()`
-    // produces a v4 UUID so the format is fixed.
+    // calendarUrl text. `crypto.randomUUID()` produces a v4 UUID so
+    // the format is fixed.
     const urlElement = page
       .locator('div.font-mono')
       .filter({ hasText: /^\/api\/v1\/calendar\/[0-9a-f-]{36}\.ics$/i })
@@ -128,18 +123,16 @@ test.describe('Issue #88 — iCal generate (desktop)', () => {
     const relativeUrl = (await urlElement.textContent())?.trim() ?? '';
     expect(
       relativeUrl,
-      'Generated URL must match /api/v1/calendar/<uuid>.ics shape (token is crypto.randomUUID() per calendar.service.ts:30)',
+      'Generated URL must match /api/v1/calendar/<uuid>.ics shape',
     ).toMatch(/^\/api\/v1\/calendar\/[0-9a-f-]{36}\.ics$/i);
 
     // ── Public ICS endpoint round-trip — no Authorization header ────────
     // calendar.controller.ts:34 marks getIcs() @Public() so this
-    // request bypasses the JWT guard. The iCal subscription client
-    // (Apple Kalender etc.) sends this exact request shape.
+    // request bypasses the JWT guard AND the CurrentSchoolInterceptor
+    // (no X-School-Id needed). The iCal subscription client sends
+    // this exact request shape — pure token-lookup, no tenant header.
     const absoluteUrl = `${apiBaseFromE2eEnv()}${relativeUrl}`;
     const icsResponse = await request.get(absoluteUrl, {
-      // Belt-and-braces: explicitly drop any auth header that might be
-      // sticky on the shared Playwright APIRequestContext from earlier
-      // logged-in fetches.
       headers: {},
     });
 
@@ -162,9 +155,7 @@ test.describe('Issue #88 — iCal generate (desktop)', () => {
       'ICS body must end with END:VCALENDAR — proves the ical-generator emitted a complete document, not a partial response',
     ).toBe(true);
     // PRODID line is mandatory in RFC 5545 and the service sets it to
-    // SchoolFlow explicitly (calendar.service.ts:70). This catches a
-    // future swap to a stub ical-generator that emits empty calendars.
+    // SchoolFlow explicitly (calendar.service.ts:70).
     expect(icsBody).toMatch(/PRODID:[^\r\n]*SchoolFlow/i);
-
   });
 });

--- a/apps/web/e2e/settings-ical-rbac.spec.ts
+++ b/apps/web/e2e/settings-ical-rbac.spec.ts
@@ -1,6 +1,11 @@
 /**
  * Issue #88 — iCal calendar-token per-user isolation (Settings).
  *
+ * Issue #154 (Phase 3.5/7) — migrated to throwaway-school per CLAUDE.md D4.
+ * The sorted-acquisition advisory lock for the eltern + lehrer persona
+ * pair is gone; the throwaway school owns its own CalendarToken rows for
+ * BOTH persons, so the two-context race is impossible by construction.
+ *
  * This is the "optional" third sub-spec in #88 ("eltern-user sieht nur
  * eigene Tokens, kann nicht andere widerrufen"). The CalendarToken
  * table is single-row-per-(userId, schoolId) and lookups derive the
@@ -12,19 +17,17 @@
  * Test-Strategie — two-context per-user isolation:
  *
  *   ICAL-RBAC-PER-USER:
- *     1. Two browser contexts so lehrer and eltern auth state
+ *     1. Throwaway-school with both `lehrer` + `eltern` roles.
+ *     2. Two browser contexts so lehrer and eltern auth state
  *        don't share — same pattern as messaging-broadcast/realtime
- *        specs.
- *     2. Lehrer generates a token in context A. Capture URL.
- *     3. Eltern generates a token in context B. Capture URL.
- *     4. Assert the two URLs differ — proves the backend keyed by
- *        the JWT subject, not by some shared key (e.g. schoolId
- *        alone, which would mean Lehrer + Eltern share one token
- *        = exposing Eltern's child's data to Lehrer and vice versa).
- *     5. Each token URL fetched unauthenticated → 200 + valid ICS.
- *        Proves the public endpoint resolves the FK back to the
- *        right user row for both — a regression that swapped the
- *        FK or hard-coded a single user would surface here.
+ *        specs. BOTH contexts pin to the throwaway via
+ *        `useThrowawaySchoolHeader` so `/users/me` and `/settings`
+ *        resolve to the throwaway tenant.
+ *     3. Lehrer generates a token in context A. Capture URL.
+ *     4. Eltern generates a token in context B. Capture URL.
+ *     5. Assert the two URLs differ — proves the backend keyed by
+ *        the JWT subject, not by some shared key.
+ *     6. Each token URL fetched unauthenticated → 200 + valid ICS.
  *
  * Bug-class this catches: any future change that breaks the
  * per-user partitioning of CalendarToken — e.g. a schema migration
@@ -32,45 +35,36 @@
  * resolves the user from a path param instead of the JWT, or a
  * findFirst that mis-orders the where clause and grabs an
  * arbitrary token.
- *
- * Race-Family-Achtung: Issue #112 Phase 2.5a (#117) — per-(schoolId,
- * role) Postgres advisory lock acquired on BOTH personas in sorted
- * order (eltern → lehrer). The sibling generate.spec (lehrer) and
- * revoke.spec (eltern) acquire their single lock and block on this
- * spec's set; the sorted acquisition order makes ABBA deadlock
- * impossible. Cross-browser safe; previous chromium-only-skip and
- * disjoint-personas workaround (schueler+admin) removed — this spec
- * is back on the originally-intended lehrer+eltern personas now that
- * the advisory lock eliminates the race.
  */
 import { test, expect } from '@playwright/test';
 import { loginAsRole } from './helpers/login';
+import { apiBaseFromE2eEnv } from './helpers/calendar-tokens';
 import {
-  apiBaseFromE2eEnv,
-  seedCalendarTokenContext,
-  cleanupCalendarTokenContext,
-  type CalendarTokenContext,
-} from './helpers/calendar-tokens';
-import { SEED_SCHOOL_UUID } from './fixtures/seed-uuids';
+  createThrowawaySchool,
+  type ThrowawaySchoolFixture,
+} from './fixtures/throwaway-school';
+import { useThrowawaySchoolHeader } from './helpers/school-context';
 
-const ROLES = ['lehrer', 'eltern'] as const;
-
-test.describe('Issue #88 — iCal RBAC / per-user isolation (desktop)', () => {
+test.describe('Issue #88 — iCal RBAC / per-user isolation (throwaway-school, #154)', () => {
   test.skip(
     ({ isMobile }) => isMobile,
     'iCal subscription is a desktop-anchored workflow.',
   );
 
-  let ctx: CalendarTokenContext | undefined;
+  let fixture: ThrowawaySchoolFixture | undefined;
 
   test.beforeEach(async () => {
-    ctx = await seedCalendarTokenContext(SEED_SCHOOL_UUID, ROLES);
+    fixture = await createThrowawaySchool({
+      roles: { lehrer: true, eltern: true },
+      withClasses: 1,
+      namePrefix: 'E2E-ICAL-RBAC',
+    });
   });
 
   test.afterEach(async () => {
-    if (ctx) {
-      await cleanupCalendarTokenContext(ctx);
-      ctx = undefined;
+    if (fixture) {
+      await fixture.cleanup();
+      fixture = undefined;
     }
   });
 
@@ -78,11 +72,18 @@ test.describe('Issue #88 — iCal RBAC / per-user isolation (desktop)', () => {
     browser,
     request,
   }) => {
-    // Two contexts so each persona has its own JWT — same pattern as
-    // messaging-broadcast.spec.ts:77 / messaging-realtime.spec.ts:91.
+    if (!fixture) throw new Error('fixture not seeded');
+    const schoolId = fixture.schoolId;
+
+    // Two contexts so each persona has its own JWT. The throwaway header
+    // is installed on each context BEFORE login so `/users/me` resolves
+    // the throwaway as the active school for both personas.
     const ctxA = await browser.newContext();
     const ctxB = await browser.newContext();
     try {
+      await useThrowawaySchoolHeader(ctxA, schoolId);
+      await useThrowawaySchoolHeader(ctxB, schoolId);
+
       const pageA = await ctxA.newPage();
       const pageB = await ctxB.newPage();
 
@@ -123,8 +124,7 @@ test.describe('Issue #88 — iCal RBAC / per-user isolation (desktop)', () => {
       // --- The core isolation lock ------------------------------------
       // The two UUIDs MUST differ. Same string would mean the backend
       // either keys CalendarToken on (schoolId) alone or returns a
-      // cached row from a different user — both are silent DSGVO leaks
-      // (one user would see the other's calendar feed).
+      // cached row from a different user — both are silent DSGVO leaks.
       expect(
         urlB,
         `Two distinct users MUST receive different tokens; got identical URLs (${urlA}) — backend has lost per-user partitioning`,

--- a/apps/web/e2e/settings-ical-revoke.spec.ts
+++ b/apps/web/e2e/settings-ical-revoke.spec.ts
@@ -1,95 +1,85 @@
 /**
  * Issue #88 — iCal calendar-token revoke flow (Settings).
  *
+ * Issue #154 (Phase 3.5/7) — migrated to throwaway-school per CLAUDE.md D4.
+ * The per-`(schoolId, role)` advisory lock is gone; each spec owns its own
+ * throwaway School + CalendarToken rows.
+ *
  * Surface: /settings → ICalSettings card → "Token erneuern" button +
  * confirmation Dialog → DELETE /api/v1/schools/:schoolId/calendar/token.
  *
  * The DELETE endpoint is misleadingly named — it actually calls
  * `revokeAndRegenerate` (calendar.service.ts:54), which HARD-deletes
  * the prior CalendarToken row (no `revoked_at` soft-delete column
- * exists in the schema, despite the issue text mentioning one) and
- * unconditionally creates a fresh one. The public ICS endpoint
- * looks up by token PK via `findUnique({ where: { token } })`
- * (calendar.service.ts:47), so a revoked (= deleted) token returns
- * null and throws NotFoundException → HTTP 404.
+ * exists in the schema) and unconditionally creates a fresh one. The
+ * public ICS endpoint looks up by token PK via `findUnique({ where: { token } })`
+ * so a revoked (= deleted) token returns null and throws
+ * NotFoundException → HTTP 404.
  *
  * Test-Strategie — end-to-end old-vs-new URL switch:
  *
  *   ICAL-REVOKE-ELTERN:
- *     1. Purge any stale token row (defensive — see generate spec).
+ *     1. Throwaway-school fixture with `eltern` role.
  *     2. Eltern logs in, navigates to /settings, generates a token.
  *        Capture the URL as `urlOld`.
  *     3. Verify `urlOld` returns 200 + valid VCALENDAR via the
  *        public unauthenticated GET.
  *     4. Click "Token erneuern" → confirmation Dialog opens with
- *        the destructive copy "Die aktuelle Kalender-URL wird
- *        ungueltig. Alle verbundenen Kalender-Apps muessen neu
- *        eingerichtet werden. Fortfahren?" (ICalSettings.tsx:154).
+ *        the destructive copy.
  *     5. Click the destructive-variant "Token erneuern" button
  *        inside the Dialog. The page swaps to a fresh URL — capture
  *        as `urlNew`. Assert `urlNew !== urlOld`.
  *     6. The DSGVO-critical leg:
  *        * `urlOld` MUST return 404 — proves the old token was
  *          hard-deleted, not soft-revoked-but-still-honoured.
- *        * `urlNew` MUST return 200 with valid VCALENDAR — proves
- *          the regenerate half of `revokeAndRegenerate` worked.
- *
- * Why eltern: the issue lists the spec as an Eltern flow ("eltern-
- * user sieht nur eigene Tokens, kann nicht andere widerrufen"). The
- * core revoke behaviour is role-agnostic — same endpoint, same
- * permissions for all three personas (apps/api/prisma/seed.ts:428
- * grants create/read/delete calendar-token to eltern). Using
- * eltern here keeps role coverage symmetric with the generate
- * spec (lehrer) and the rbac spec (lehrer + eltern).
+ *        * `urlNew` MUST return 200 with valid VCALENDAR.
  *
  * Bug-class this catches: a future commit that flips
  * `revokeAndRegenerate` to a soft-delete via a `revoked_at`
- * column-add without updating `findByToken` to honour it. That's
- * exactly the silent DSGVO-leak the issue text warns about: the
- * user clicks "Token erneuern" expecting the old URL to stop
- * working, but the public endpoint still serves their personal
- * timetable + Klausur dates to whoever cached the old URL.
- *
- * Race-Family-Achtung: Issue #112 Phase 2.5a (#117) — per-(schoolId,
- * role) Postgres advisory lock serializes parallel specs sharing the
- * eltern persona. Cross-browser safe; previous chromium-only-skip
- * removed.
+ * column-add without updating `findByToken` to honour it — the
+ * silent DSGVO-leak the issue text warns about.
  */
 import { test, expect } from '@playwright/test';
 import { loginAsRole } from './helpers/login';
+import { apiBaseFromE2eEnv } from './helpers/calendar-tokens';
 import {
-  apiBaseFromE2eEnv,
-  seedCalendarTokenContext,
-  cleanupCalendarTokenContext,
-  type CalendarTokenContext,
-} from './helpers/calendar-tokens';
-import { SEED_SCHOOL_UUID } from './fixtures/seed-uuids';
+  createThrowawaySchool,
+  type ThrowawaySchoolFixture,
+} from './fixtures/throwaway-school';
+import { useThrowawaySchoolHeader } from './helpers/school-context';
 
 const ROLE = 'eltern' as const;
 
-test.describe('Issue #88 — iCal revoke (desktop)', () => {
+test.describe('Issue #88 — iCal revoke (throwaway-school, #154)', () => {
   test.skip(
     ({ isMobile }) => isMobile,
     'iCal subscription is a desktop-anchored workflow (URL is copied into a desktop calendar app).',
   );
 
-  let ctx: CalendarTokenContext | undefined;
+  let fixture: ThrowawaySchoolFixture | undefined;
 
   test.beforeEach(async () => {
-    ctx = await seedCalendarTokenContext(SEED_SCHOOL_UUID, [ROLE]);
+    fixture = await createThrowawaySchool({
+      roles: { [ROLE]: true },
+      withClasses: 1,
+      namePrefix: 'E2E-ICAL-REV',
+    });
   });
 
   test.afterEach(async () => {
-    if (ctx) {
-      await cleanupCalendarTokenContext(ctx);
-      ctx = undefined;
+    if (fixture) {
+      await fixture.cleanup();
+      fixture = undefined;
     }
   });
 
   test('ICAL-REVOKE-ELTERN: "Token erneuern" hard-deletes the old token (old URL → 404, new URL → 200)', async ({
     page,
+    context,
     request,
   }) => {
+    if (!fixture) throw new Error('fixture not seeded');
+    await useThrowawaySchoolHeader(context, fixture.schoolId);
     await loginAsRole(page, ROLE);
     await page.goto('/settings');
 
@@ -118,8 +108,7 @@ test.describe('Issue #88 — iCal revoke (desktop)', () => {
     // Step 2 — open the revoke confirmation dialog.
     // Note: there are TWO "Token erneuern" labelled affordances on this
     // page once the dialog opens — the card button and the destructive
-    // dialog-footer button (both literally `Token erneuern` per
-    // ICalSettings.tsx:144 + 167). Use the card button first.
+    // dialog-footer button. Use the card button first.
     await page.getByRole('button', { name: 'Token erneuern' }).first().click();
 
     // Dialog content + destructive copy.
@@ -139,13 +128,7 @@ test.describe('Issue #88 — iCal revoke (desktop)', () => {
       .getByRole('button', { name: 'Token erneuern' })
       .click();
 
-    // Step 4 — wait for the URL to swap. The Dialog auto-closes via
-    // useRevokeCalendarToken.onSuccess (ICalSettings.tsx:65).
-    // The mutation invalidates calendarTokenKeys.all(schoolId) and the
-    // useCalendarToken query refetches the NEW token. Poll the visible
-    // URL element until it differs from urlOld — the polled equality
-    // check guards against the race where the old URL is still
-    // visible on the first sample but flips a beat later.
+    // Step 4 — wait for the URL to swap.
     await expect.poll(
       async () => (await urlSelector.textContent())?.trim() ?? '',
       {
@@ -159,14 +142,7 @@ test.describe('Issue #88 — iCal revoke (desktop)', () => {
     expect(urlNew, 'New URL must differ from the old URL').not.toBe(urlOld);
 
     // ── DSGVO-critical lock ─────────────────────────────────────────────
-    // Old URL must now return 404 (token row is gone). If the backend
-    // ever switches to soft-delete WITHOUT updating findByToken to
-    // honour `revoked_at`, this assertion goes red loudly. This is the
-    // EXACT bug class the issue text calls out:
-    //
-    //   "wenn die Generate/Revoke-Logik bricht, kann ein revoked Token
-    //    weiter funktionieren = stiller Datenleak (Stundenplan +
-    //    Klausuren in fremde Hände)"
+    // Old URL must now return 404 (token row is gone).
     const oldResponse = await request.get(`${apiBase}${urlOld}`, { headers: {} });
     expect(
       oldResponse.status(),


### PR DESCRIPTION
Phase 3.5/7 — three iCal specs migrated to throwaway-school; advisory locks + Prisma-direct purge gone.

## What changes

| Spec | Role(s) | Lock removed |
| --- | --- | --- |
| `settings-ical-generate.spec.ts` | lehrer | `calendar-token:SEED:lehrer` |
| `settings-ical-revoke.spec.ts` | eltern | `calendar-token:SEED:eltern` |
| `settings-ical-rbac.spec.ts` | lehrer + eltern | `calendar-token:SEED:lehrer` + `:eltern` (sorted-acquisition) |

Each spec now owns its own School + CalendarToken rows; `fixture.cleanup()` cascade-drops both via FK. The two-context RBAC spec installs the throwaway header on BOTH contexts BEFORE login so each persona's `/users/me` resolves the throwaway tenant.

## Helper reduction

`helpers/calendar-tokens.ts` shrunk **245 → 33 lines**:

- Dropped: `seedCalendarTokenContext`, `cleanupCalendarTokenContext`, `CalendarTokenContext`, `CalendarTestRole`, `PERSON_UUID_BY_ROLE`, Prisma + advisory-lock plumbing.
- Kept: `apiBaseFromE2eEnv()` — still used by all 3 specs to fetch `/api/v1/calendar/<token>.ics` without prepending /api/v1 twice.

Net diff: **+131 / −374**.

## Public ICS endpoint behavior

Untouched. `calendar.controller.ts:34` `getIcs()` is still `@Public()` + token-PK lookup (`findUnique({ where: { token } })`), so the public endpoint works regardless of tenant context — the iCal subscription client (Apple Kalender / Google Calendar / Outlook) sends no auth or tenant header.

## Acceptance Criteria (from #154)

- [x] All 3 specs migrated, no calendar-token helper imports left for the lock-bound APIs
- [x] `helpers/calendar-tokens.ts` reduced to lock-free helpers (only `apiBaseFromE2eEnv`)
- [x] Cross-project parallel 5 iterations grün for each

## Tests

\`\`\`
pnpm exec playwright test --project=desktop --project=desktop-firefox \\
  e2e/settings-ical-generate.spec.ts e2e/settings-ical-revoke.spec.ts \\
  e2e/settings-ical-rbac.spec.ts --repeat-each=5
30 passed (2.7m)
\`\`\`

Closes #154
Refs #147