### PR TITLE
feat(excuses): #151 — scope Person lookups by schoolId + migrate 3 excuse specs to throwaway

### DIFF
--- a/apps/api/src/modules/classbook/excuse.controller.ts
+++ b/apps/api/src/modules/classbook/excuse.controller.ts
@@ -68,7 +68,7 @@ export class ExcuseController {
     const isTeacher = user.roles.includes('lehrer') || user.roles.includes('schulleitung') || user.roles.includes('admin');
 
     if (isParent) {
-      return this.excuseService.getExcusesForParent(user.id);
+      return this.excuseService.getExcusesForParent(user.id, schoolId);
     }
 
     if (isTeacher) {

--- a/apps/api/src/modules/classbook/excuse.service.ts
+++ b/apps/api/src/modules/classbook/excuse.service.ts
@@ -49,9 +49,15 @@ export class ExcuseService {
       throw new BadRequestException('Startdatum darf nicht mehr als 30 Tage in der Vergangenheit liegen');
     }
 
-    // Resolve parent from keycloakUserId
+    // Resolve parent from (keycloakUserId, schoolId). Issue #151 — the
+    // schoolId scope is load-bearing: a KC user with Person memberships
+    // in N schools (common under parallel e2e throwaway runs, real under
+    // multi-tenant families) without the scope would race on whichever
+    // Person Postgres returns first, and the downstream ParentStudent
+    // lookup would 403 because the sibling-school's `parentId` does not
+    // own a link to THIS school's student.
     const parentPerson = await this.prisma.person.findFirst({
-      where: { keycloakUserId: parentKeycloakId },
+      where: { keycloakUserId: parentKeycloakId, schoolId },
       include: { parent: true },
     });
     if (!parentPerson?.parent) {
@@ -251,11 +257,17 @@ export class ExcuseService {
   }
 
   /**
-   * List excuses submitted by a parent. Order by createdAt DESC.
+   * List excuses submitted by a parent within the current school. Order
+   * by createdAt DESC.
+   *
+   * Issue #151 — schoolId is now mandatory (passed from the controller's
+   * `:schoolId` path param). Without it the Person lookup would race on
+   * multi-school parents and the excuse list would leak rows from sibling
+   * tenants. Same root cause as the createExcuse 403 race fixed above.
    */
-  async getExcusesForParent(parentKeycloakId: string) {
+  async getExcusesForParent(parentKeycloakId: string, schoolId: string) {
     const parentPerson = await this.prisma.person.findFirst({
-      where: { keycloakUserId: parentKeycloakId },
+      where: { keycloakUserId: parentKeycloakId, schoolId },
       include: { parent: true },
     });
     if (!parentPerson?.parent) {
@@ -263,7 +275,7 @@ export class ExcuseService {
     }
 
     const excuses = await this.prisma.absenceExcuse.findMany({
-      where: { parentId: parentPerson.parent.id },
+      where: { parentId: parentPerson.parent.id, schoolId },
       include: { attachments: true },
       orderBy: { createdAt: 'desc' },
     });
@@ -303,9 +315,13 @@ export class ExcuseService {
    * then returns pending excuses for students in those classes.
    */
   async getPendingExcusesForKlassenvorstand(teacherKeycloakId: string, schoolId: string) {
-    // Resolve teacher
+    // Resolve teacher within the current school. Issue #151 — same
+    // multi-school race as createExcuse: a lehrer KC user with Persons
+    // in N schools would otherwise hit a sibling-school's Teacher row
+    // and the downstream Klassenvorstand-class lookup would return
+    // wrong-school data (or empty).
     const person = await this.prisma.person.findFirst({
-      where: { keycloakUserId: teacherKeycloakId },
+      where: { keycloakUserId: teacherKeycloakId, schoolId },
       include: { teacher: true },
     });
     if (!person?.teacher) {

--- a/apps/web/e2e/excuses-attachments.spec.ts
+++ b/apps/web/e2e/excuses-attachments.spec.ts
@@ -1,96 +1,95 @@
 /**
  * Issue #83 — Excuses PDF attachment flow (parent upload + teacher visibility).
  *
+ * Issue #151 (Phase 3.5/4) — migrated to throwaway-school per CLAUDE.md D4.
+ * The shared per-student advisory lock + the cleanup-by-prefix sweep are
+ * gone; each test owns its own throwaway School with its own Parent +
+ * Student + Klassenvorstand assignment. `fixture.cleanup()` cascade-drops
+ * every AbsenceExcuse AND its `excuse_attachments` rows (FK
+ * onDelete: Cascade) when the School is dropped.
+ *
  * Third (and final) sub-spec of the Entschuldigungen coverage gap,
  * closing the slice the issue calls out as "optional but DSGVO-
- * sensitive (Gesundheitsdaten in Attachments)". Two locks in one file
+ * sensitive (Gesundheitsdaten in Attachments)". Two tests in one file
  * because the two surfaces share the same ExcuseCard component (the
  * attachment chip rendering is identical on both sides — see
  * `ExcuseCard.tsx:97-114`):
  *
- *   EXC-ATT-PARENT-01 — Eltern submits an excuse with a PDF attachment
+ *   EXC-ATT-PARENT-01 — eltern submits an excuse with a PDF attachment
  *     through the UI (`FileUploadField` inside `ExcuseForm`). Toast
  *     fires after both the POST /excuses and the multipart POST
  *     /:id/attachment commit. After a reload the new ExcuseCard
- *     surfaces the attachment chip with the filename — this is what
- *     locks the upload contract end-to-end.
+ *     surfaces the attachment chip with the filename — this locks
+ *     the upload contract end-to-end against the throwaway tenant.
  *
  *   EXC-ATT-TEACHER-01 — A PENDING excuse + attachment is seeded
- *     direct-to-API as kc-eltern, then kc-lehrer (Klassenvorstand of
- *     1A) opens /excuses and sees the same attachment chip on the
- *     review-side ExcuseCard. The frontend renders attachments
- *     identically on both surfaces, but the back-end visibility check
- *     differs (parent vs Klassenvorstand scope), so this lock catches
- *     a regression where the GET /excuses payload omits attachments
- *     for the reviewer role.
+ *     direct-to-API as eltern, then kc-lehrer (Klassenvorstand of
+ *     throwaway class[0]) opens /excuses and sees the same attachment
+ *     chip on the review-side ExcuseCard.
  *
- * Why bundle both tests in one spec instead of two: the file-level
- * cleanup (note-prefix sweep with cascade through
- * `excuse_attachments`) is identical, and the issue treats this slice
- * as one unit. Splitting would duplicate scaffolding for marginal
- * coverage benefit.
+ * Why bundle both tests in one spec: the fixture setup (eltern + lehrer
+ * roles, Klassenvorstand, ParentStudent link, one Student) is identical
+ * and the issue treats this slice as one unit. Splitting would duplicate
+ * scaffolding for marginal coverage benefit.
  *
  * Why NOT exercise the actual download link click: the ExcuseCard
  * builds an href `/classbook/excuses/${excuseId}/attachment/${attId}`
  * but the API serves the file at `/classbook/excuses/attachments/:id`.
  * Clicking the link 404s today — that's a separate bug (frontend URL
  * builder drift from API) and out of scope for the coverage-gap fix.
- * The PR body flags it for a follow-up issue.
- *
- * Chromium-only-skip per the race-family precedent — every spec writes
- * AbsenceExcuse rows for the same kc-eltern parent and kc-lehrer is
- * the sole Klassenvorstand of 1A. Cleanup sweeps by note-prefix so
- * parallel specs only delete their own rows.
  */
 import { test, expect } from '@playwright/test';
 import { loginAsRole } from './helpers/login';
 import {
   EXCUSES_NOTE_PREFIX,
   STUB_PDF_ATTACHMENT,
-  cleanupE2EExcuses,
   createExcuseAsParentViaAPI,
   todayISODate,
   uploadExcuseAttachmentViaAPI,
   type CreatedExcuse,
 } from './helpers/excuses';
-import { acquireAdvisoryLock, type AdvisoryLock } from './helpers/advisory-lock';
+import {
+  createThrowawaySchool,
+  type ThrowawaySchoolFixture,
+} from './fixtures/throwaway-school';
+import { useThrowawaySchoolHeader } from './helpers/school-context';
 
-const SEED_STUDENT_LISA_HUBER_UUID = 'e0000000-0000-4000-8000-000000000001';
-// Per #112 phase 4 wave 2c (#121): shared with the other two excuses
-// specs so cross-spec AND cross-project parallel runs serialize on the
-// per-student row family.
-const EXCUSES_STUDENT_LOCK_KEY = `excuses:${SEED_STUDENT_LISA_HUBER_UUID}`;
+const ATT_PREFIX = `${EXCUSES_NOTE_PREFIX}ATT-`;
 
-test.describe('Issue #83 — Excuses attachments (desktop)', () => {
+test.describe('Issue #83 — Excuses attachments (throwaway-school, #151)', () => {
   test.skip(
     ({ isMobile }) => isMobile,
     'Attachment chip layout is identical across viewports — desktop only for the first lock.',
   );
 
-  // Sibling specs (excuses-parent-submit, excuses-teacher-review) use
-  // sub-prefixes E2E-EXC-PARENT- / E2E-EXC-REVIEW-. Use a distinct
-  // E2E-EXC-ATT- sub-prefix here so a sibling spec's afterEach cannot
-  // sweep our mid-test fixture (lesson from the parent-submit ↔
-  // teacher-review race recorded in `excuses-teacher-review.spec.ts:73`).
-  const ATT_PREFIX = `${EXCUSES_NOTE_PREFIX}ATT-`;
-
-  let lock: AdvisoryLock | undefined;
+  let fixture: ThrowawaySchoolFixture | undefined;
 
   test.beforeEach(async () => {
-    lock = await acquireAdvisoryLock(EXCUSES_STUDENT_LOCK_KEY);
+    fixture = await createThrowawaySchool({
+      roles: { lehrer: true, eltern: true },
+      withClasses: 1,
+      withTimetableStack: true,
+      withKlassenvorstand: 'lehrer',
+      withStudents: [{ firstName: 'Lisa', lastName: 'Huber' }],
+      withParentLinks: { eltern: { studentIndexes: [0] } },
+      namePrefix: 'E2E-EXC-ATT',
+    });
   });
 
   test.afterEach(async () => {
-    await cleanupE2EExcuses(ATT_PREFIX);
-    if (lock) {
-      await lock.release();
-      lock = undefined;
+    if (fixture) {
+      await fixture.cleanup();
+      fixture = undefined;
     }
   });
 
   test('EXC-ATT-PARENT-01: eltern submits an excuse with PDF attachment → toast → attachment chip visible after reload', async ({
     page,
+    context,
   }) => {
+    if (!fixture) throw new Error('fixture not seeded');
+    await useThrowawaySchoolHeader(context, fixture.schoolId);
+
     const note = `${ATT_PREFIX}PARENT-${Date.now()} — Lisa hat Arzttermin (Attest)`;
     const filename = `e2e-attest-parent-${Date.now()}.pdf`;
 
@@ -112,10 +111,9 @@ test.describe('Issue #83 — Excuses attachments (desktop)', () => {
     await page.getByLabel(/Anmerkung/).fill(note);
 
     // Attach the stub PDF via FileUploadField's hidden input. The
-    // FileUploadField wraps the input as `<input type="file" hidden>`
-    // (FileUploadField.tsx — same component the handover spec drives).
-    // Scope to the form so a parallel attachment input on the page
-    // (none today, defensive) is never mis-picked.
+    // FileUploadField wraps the input as `<input type="file" hidden>`.
+    // Scope to the form so a parallel attachment input on the page is
+    // never mis-picked.
     await page
       .locator('form input[type="file"]')
       .setInputFiles({
@@ -148,10 +146,7 @@ test.describe('Issue #83 — Excuses attachments (desktop)', () => {
     ).toBeVisible();
 
     // Attachment chip — the ExcuseCard renders attachments as <a>
-    // elements containing the filename text and a paperclip icon
-    // (ExcuseCard.tsx:99-113). Matching by filename keeps the
-    // assertion stable even with parallel-spec attachments on the
-    // same Lisa Huber.
+    // elements containing the filename text and a paperclip icon.
     await expect(
       page.getByRole('link', { name: new RegExp(filename) }),
       'attachment chip with the uploaded filename must render on the excuse card',
@@ -160,23 +155,28 @@ test.describe('Issue #83 — Excuses attachments (desktop)', () => {
 
   test('EXC-ATT-TEACHER-01: kc-lehrer (Klassenvorstand) sees the same PDF attachment on the review-side ExcuseCard', async ({
     page,
+    context,
     request,
   }) => {
+    if (!fixture) throw new Error('fixture not seeded');
+    await useThrowawaySchoolHeader(context, fixture.schoolId);
+
     const today = todayISODate();
     const note = `${ATT_PREFIX}TEACHER-${Date.now()} — Attest fuer Pollenallergie`;
     const filename = `e2e-attest-teacher-${Date.now()}.pdf`;
 
-    // Seed excuse + attachment direct-to-API as kc-eltern. The two
-    // halves are a single user-perceived action (the parent UI ships
-    // them as one submit), but the spec only needs the resulting DB
-    // state for the teacher-side assertion — UI-driving the upload is
-    // already locked by EXC-ATT-PARENT-01.
+    // Seed excuse + attachment direct-to-API as eltern on the throwaway
+    // schoolId. The two halves are a single user-perceived action (the
+    // parent UI ships them as one submit), but the spec only needs the
+    // resulting DB state for the teacher-side assertion — UI-driving
+    // the upload is already locked by EXC-ATT-PARENT-01.
     const excuse: CreatedExcuse = await createExcuseAsParentViaAPI(request, {
-      studentId: SEED_STUDENT_LISA_HUBER_UUID,
+      studentId: fixture.studentIds[0],
       startDate: today,
       endDate: today,
       reason: 'ARZTTERMIN',
       note,
+      schoolId: fixture.schoolId,
     });
     expect(
       excuse.status,
@@ -186,6 +186,7 @@ test.describe('Issue #83 — Excuses attachments (desktop)', () => {
       filename,
       mimeType: 'application/pdf',
       buffer: STUB_PDF_ATTACHMENT,
+      schoolId: fixture.schoolId,
     });
 
     await loginAsRole(page, 'lehrer');
@@ -203,7 +204,7 @@ test.describe('Issue #83 — Excuses attachments (desktop)', () => {
     // Our seeded excuse must surface (Klassenvorstand-scoped fetch).
     await expect(
       page.getByText(note),
-      'kc-lehrer (Klassenvorstand of 1A) must see the seeded excuse in the review list',
+      'kc-lehrer (Klassenvorstand of throwaway class[0]) must see the seeded excuse in the review list',
     ).toBeVisible();
 
     // Attachment chip must render with the uploaded filename. This is

--- a/apps/web/e2e/excuses-parent-submit.spec.ts
+++ b/apps/web/e2e/excuses-parent-submit.spec.ts
@@ -1,13 +1,19 @@
 /**
  * Issue #83 — Excuses parent-submit flow.
  *
+ * Issue #151 (Phase 3.5/4) — migrated to throwaway-school per CLAUDE.md D4.
+ * The shared per-student `excuses:${SEED_STUDENT_LISA_HUBER_UUID}` advisory
+ * lock is gone; each spec owns its own throwaway School with its own
+ * Parent + Student + ParentStudent rows. `fixture.cleanup()` cascade-drops
+ * every AbsenceExcuse via the School→Student→AbsenceExcuse FK chain.
+ *
  * First sub-spec of the Entschuldigungen coverage gap. Locks the
  * Eltern-side submission flow on /excuses:
- *   1. kc-eltern (Franz Huber, parent of Lisa Huber in 1A) logs in.
+ *   1. eltern (the throwaway's Franz-Huber-equivalent) logs in.
  *   2. Page mounts the ParentExcuseView with the ExcuseForm.
- *   3. Form auto-fills today as Von + Bis (default) and Lisa Huber as
- *      the only child (the Kind field renders as a text label, not a
- *      Select, when children.length === 1 — ExcuseForm.tsx:137).
+ *   3. Form auto-fills today as Von + Bis (default) and the single linked
+ *      child as the Kind field — rendered as a text label (not a Select)
+ *      when children.length === 1 (ExcuseForm.tsx:137).
  *   4. Pick "Krank" as Grund, type a timestamped note, submit.
  *   5. Wait for the "Entschuldigung eingereicht" toast (wire-confirmed
  *      signal; without it the list assertion races the mutation).
@@ -15,54 +21,51 @@
  *      timestamped note + a PENDING status badge.
  *
  * Exercises POST /classbook/excuses + useCreateExcuse invalidation +
- * GET /excuses refetch + ExcuseCard rendering. Teacher-review and
- * attachment upload are deferred to follow-up sub-specs.
- *
- * Chromium-only-skip per the race-family precedent — every spec writes
- * AbsenceExcuse rows for the same kc-eltern parent. The cleanup sweep
- * is scoped to a note-prefix so parallel specs only delete their own.
+ * GET /excuses refetch + ExcuseCard rendering.
  */
 import { test, expect } from '@playwright/test';
 import { loginAsRole } from './helpers/login';
-import { EXCUSES_NOTE_PREFIX, cleanupE2EExcuses } from './helpers/excuses';
-import { acquireAdvisoryLock, type AdvisoryLock } from './helpers/advisory-lock';
+import { EXCUSES_NOTE_PREFIX } from './helpers/excuses';
+import {
+  createThrowawaySchool,
+  type ThrowawaySchoolFixture,
+} from './fixtures/throwaway-school';
+import { useThrowawaySchoolHeader } from './helpers/school-context';
 
-// All three excuses specs target the same seed student (Lisa Huber,
-// kc-eltern's only child) and share `AbsenceExcuse` rows on that
-// student. Sub-prefix isolation prevents cross-spec data collisions,
-// but parallel runs of the SAME spec across browser projects would
-// still interleave list views + cleanup sweeps. The per-student lock
-// (shared by all three excuses specs) serializes them — both
-// intra-spec (chromium ↔ firefox) and inter-spec.
-const EXCUSES_STUDENT_LOCK_KEY = 'excuses:e0000000-0000-4000-8000-000000000001';
-
-test.describe('Issue #83 — Excuses parent submit (desktop)', () => {
+test.describe('Issue #83 — Excuses parent submit (throwaway-school, #151)', () => {
   test.skip(
     ({ isMobile }) => isMobile,
     'Form layout is identical across viewports — desktop only for the first lock.',
   );
 
-  let lock: AdvisoryLock | undefined;
+  let fixture: ThrowawaySchoolFixture | undefined;
 
   test.beforeEach(async () => {
-    lock = await acquireAdvisoryLock(EXCUSES_STUDENT_LOCK_KEY);
+    // Lisa Huber as the single child + Franz-Huber-equivalent eltern parent
+    // linked to her via ParentStudent. children.length === 1 keeps the
+    // ExcuseForm in its text-label branch (instead of Select).
+    fixture = await createThrowawaySchool({
+      roles: { eltern: true },
+      withClasses: 1,
+      withStudents: [{ firstName: 'Lisa', lastName: 'Huber' }],
+      withParentLinks: { eltern: { studentIndexes: [0] } },
+      namePrefix: 'E2E-EXC-PARENT',
+    });
   });
 
   test.afterEach(async () => {
-    // Sweep ALL E2E-EXC- excuses, not just the one created here. A
-    // killed previous run could leave parallel siblings behind, and
-    // those would clutter the list assertion below the next time the
-    // spec runs against an unclean DB.
-    await cleanupE2EExcuses(`${EXCUSES_NOTE_PREFIX}PARENT-`);
-    if (lock) {
-      await lock.release();
-      lock = undefined;
+    if (fixture) {
+      await fixture.cleanup();
+      fixture = undefined;
     }
   });
 
   test('EXC-PARENT-01: eltern submits an excuse → toast → row visible in submitted list with PENDING badge', async ({
     page,
+    context,
   }) => {
+    if (!fixture) throw new Error('fixture not seeded');
+    await useThrowawaySchoolHeader(context, fixture.schoolId);
     await loginAsRole(page, 'eltern');
     await page.goto('/excuses');
 
@@ -73,18 +76,13 @@ test.describe('Issue #83 — Excuses parent submit (desktop)', () => {
     ).toBeVisible();
 
     // Kind field renders as plain text when children.length === 1 —
-    // Lisa Huber is the only seed child of Franz Huber (kc-eltern).
-    // The cross-tenant assertion here is that Lisa's name appears, not
-    // a sibling-tenant child or an empty value.
-    //
-    // Scope by the form region — sibling spec excuses-teacher-review
-    // may seed an excuse for the same Lisa Huber and leak an
-    // ExcuseCard with the same name as a `<h3>` heading further down
-    // the page; the form-Kind paragraph is the assertion target.
+    // Lisa Huber is the only linked child of the throwaway eltern. The
+    // cross-tenant assertion here is that Lisa's name appears, not a
+    // sibling-tenant child or an empty value.
     const kindLabel = page.getByText('Kind', { exact: true });
     await expect(
       kindLabel.locator('..').getByText('Lisa Huber'),
-      'Kind field must render Lisa Huber for Franz Huber (kc-eltern) per the seed ParentStudent link',
+      'Kind field must render Lisa Huber for the throwaway-eltern per the seeded ParentStudent link',
     ).toBeVisible();
 
     // Grund select — pick "Krank" (KRANK enum). The form's submit is
@@ -93,10 +91,10 @@ test.describe('Issue #83 — Excuses parent submit (desktop)', () => {
     await page.getByRole('combobox', { name: 'Grund' }).click();
     await page.getByRole('option', { name: 'Krank', exact: true }).click();
 
-    // Timestamped note — keeps this run's row distinguishable from
-    // sibling specs' rows in the list assertion. EXCUSES_NOTE_PREFIX
-    // is what the cleanup sweep uses, so this stamp doubles as the
-    // cleanup discriminator.
+    // Timestamped note — keeps this run's row distinguishable in the list
+    // assertion. EXCUSES_NOTE_PREFIX keeps mid-test debugging via psql
+    // trivial; tenant isolation via the throwaway already prevents
+    // cross-spec collisions.
     const note = `${EXCUSES_NOTE_PREFIX}PARENT-${Date.now()} — Lisa hat Fieber`;
     await page.getByLabel(/Anmerkung/).fill(note);
 
@@ -111,10 +109,6 @@ test.describe('Issue #83 — Excuses parent submit (desktop)', () => {
 
     // After the toast, useCreateExcuse invalidates useExcuses → refetch
     // lands → the new excuse renders as an ExcuseCard below the form.
-    // The cross-cutting regression-lock is the timestamped note + the
-    // PENDING status — both are pulled from the API response, so a
-    // backend bug that drops the note or mis-defaults the status would
-    // be visible here.
     await expect(
       page.getByText(note),
       'newly-created excuse must surface in "Eingereichte Entschuldigungen" with the timestamped note',

--- a/apps/web/e2e/excuses-teacher-review.spec.ts
+++ b/apps/web/e2e/excuses-teacher-review.spec.ts
@@ -1,66 +1,70 @@
 /**
  * Issue #83 — Excuses Klassenvorstand review flow.
  *
- * Second sub-spec of the Entschuldigungen coverage gap (after
- * excuses-parent-submit). Locks the Klassenvorstand-side review flow:
- *   1. Seed a PENDING AbsenceExcuse via the parent API
- *      (kc-eltern → Lisa Huber, today, KRANK, timestamped note).
- *   2. kc-lehrer (Maria Mueller, Klassenvorstand of 1A per the seed)
- *      logs in and opens /excuses → ExcuseReviewList renders the seeded
- *      excuse as the only PENDING card for her classes.
+ * Issue #151 (Phase 3.5/4) — migrated to throwaway-school per CLAUDE.md D4.
+ * The shared per-student advisory lock is gone; each spec owns its own
+ * throwaway School with its own Student + ParentStudent + Klassenvorstand
+ * assignment.
+ *
+ * Locks the Klassenvorstand-side review flow:
+ *   1. Seed a PENDING AbsenceExcuse via the parent API (the throwaway-
+ *      eltern → its linked Student, today, KRANK, timestamped note).
+ *   2. The throwaway-lehrer (Klassenvorstand of class[0]) logs in and
+ *      opens /excuses → ExcuseReviewList renders the seeded excuse as
+ *      the only PENDING card for her class.
  *   3. Click "Akzeptieren" → review dialog opens with the ACCEPTED title.
  *   4. Click confirm (no review note required for ACCEPTED).
- *   5. Wait for "Entschuldigung akzeptiert" toast (wire-confirmed signal).
- *   6. The accepted card disappears from the PENDING list (useExcuses
- *      with filter=PENDING invalidates → refetch → empty state).
+ *   5. Wait for "Entschuldigung akzeptiert" toast.
+ *   6. The accepted card disappears from the PENDING list.
  *
  * Exercises PATCH /classbook/excuses/:id/review with status=ACCEPTED +
  * useReviewExcuse invalidation + ExcuseReviewList's PENDING filter +
- * the review-dialog Accept branch. The Reject branch (which requires a
- * non-empty review note) is deferred to a follow-up sub-spec.
- *
- * Chromium-only-skip per the race-family precedent — every spec writes
- * AbsenceExcuse rows for the same kc-eltern parent and kc-lehrer is the
- * sole Klassenvorstand of 1A. Cleanup sweeps by note-prefix so parallel
- * specs only delete their own rows.
+ * the review-dialog Accept branch.
  */
 import { test, expect } from '@playwright/test';
 import { loginAsRole } from './helpers/login';
 import {
   EXCUSES_NOTE_PREFIX,
-  cleanupE2EExcuses,
   createExcuseAsParentViaAPI,
   todayISODate,
   type CreatedExcuse,
 } from './helpers/excuses';
-import { acquireAdvisoryLock, type AdvisoryLock } from './helpers/advisory-lock';
+import {
+  createThrowawaySchool,
+  type ThrowawaySchoolFixture,
+} from './fixtures/throwaway-school';
+import { useThrowawaySchoolHeader } from './helpers/school-context';
 
-const SEED_STUDENT_LISA_HUBER_UUID = 'e0000000-0000-4000-8000-000000000001';
-// Per #112 phase 4 wave 2c (#121): shared with excuses-parent-submit
-// and excuses-attachments so cross-spec AND cross-project parallel
-// runs serialize on the per-student row family.
-const EXCUSES_STUDENT_LOCK_KEY = `excuses:${SEED_STUDENT_LISA_HUBER_UUID}`;
-
-test.describe('Issue #83 — Excuses teacher review (desktop)', () => {
+test.describe('Issue #83 — Excuses teacher review (throwaway-school, #151)', () => {
   test.skip(
     ({ isMobile }) => isMobile,
     'Review-list layout is identical across viewports — desktop only for the first lock.',
   );
 
-  let lock: AdvisoryLock | undefined;
+  let fixture: ThrowawaySchoolFixture | undefined;
   let excuse: CreatedExcuse | undefined;
   let noteText: string;
 
   test.beforeEach(async ({ request }) => {
-    lock = await acquireAdvisoryLock(EXCUSES_STUDENT_LOCK_KEY);
+    fixture = await createThrowawaySchool({
+      roles: { lehrer: true, eltern: true },
+      withClasses: 1,
+      withTimetableStack: true, // provisions the lehrer Teacher row
+      withKlassenvorstand: 'lehrer', // pins lehrer as KV of class[0]
+      withStudents: [{ firstName: 'Lisa', lastName: 'Huber' }],
+      withParentLinks: { eltern: { studentIndexes: [0] } },
+      namePrefix: 'E2E-EXC-REVIEW',
+    });
+
     const today = todayISODate();
     noteText = `${EXCUSES_NOTE_PREFIX}REVIEW-${Date.now()} — review-flow test`;
     excuse = await createExcuseAsParentViaAPI(request, {
-      studentId: SEED_STUDENT_LISA_HUBER_UUID,
+      studentId: fixture.studentIds[0],
       startDate: today,
       endDate: today,
       reason: 'KRANK',
       note: noteText,
+      schoolId: fixture.schoolId,
     });
     expect(
       excuse.status,
@@ -69,25 +73,21 @@ test.describe('Issue #83 — Excuses teacher review (desktop)', () => {
   });
 
   test.afterEach(async () => {
-    // Sweep only this spec's own E2E-EXC-REVIEW- rows. Sibling spec
-    // excuses-parent-submit uses a different sub-prefix (E2E-EXC-PARENT-)
-    // so the two cleanups don't deactivate each other's mid-test
-    // fixtures — earlier race where a parent-submit afterEach swept
-    // teacher-review's seeded excuse mid-flight and the PATCH /review
-    // then 404'd silently (success toast never fired).
-    await cleanupE2EExcuses(`${EXCUSES_NOTE_PREFIX}REVIEW-`);
     excuse = undefined;
-    if (lock) {
-      await lock.release();
-      lock = undefined;
+    if (fixture) {
+      await fixture.cleanup();
+      fixture = undefined;
     }
   });
 
   test('EXC-TEACHER-01: kc-lehrer accepts a PENDING excuse → toast → card disappears from PENDING list', async ({
     page,
+    context,
   }) => {
+    if (!fixture) throw new Error('fixture not seeded');
     if (!excuse) throw new Error('excuse not seeded');
 
+    await useThrowawaySchoolHeader(context, fixture.schoolId);
     await loginAsRole(page, 'lehrer');
     await page.goto('/excuses');
 
@@ -98,24 +98,19 @@ test.describe('Issue #83 — Excuses teacher review (desktop)', () => {
     ).toBeVisible();
 
     // Seeded excuse must be visible in the review list. The
-    // timestamped note is the discriminator — Maria Mueller is the
-    // Klassenvorstand of 1A and only sees PENDING excuses for her
-    // classes (excuse.controller.ts:75 + getPendingExcusesForKlassen
-    // vorstand). A backend bug that mis-scopes the query would either
-    // hide our row or leak rows from other classes — either way the
-    // discriminator catches it.
+    // timestamped note is the discriminator — kc-lehrer is the
+    // Klassenvorstand of class[0] (via withKlassenvorstand) and only
+    // sees PENDING excuses for her classes (excuse.controller.ts:75 +
+    // getPendingExcusesForKlassenvorstand).
     await expect(
       page.getByText(noteText),
-      'kc-lehrer (Klassenvorstand of 1A) must see the just-seeded PENDING excuse',
+      'kc-lehrer (Klassenvorstand of throwaway class[0]) must see the just-seeded PENDING excuse',
     ).toBeVisible();
 
-    // Scope by the card containing OUR timestamped note — parallel
-    // specs (excuses-parent-submit running concurrently on another
-    // chromium worker) can write their own PENDING excuses for the
-    // same Lisa-Huber student, surfacing extra Akzeptieren buttons on
-    // this page. The ExcuseCard renders a Radix Card with an
-    // aria-label "Entschuldigung fuer ..." (ExcuseCard.tsx:62) which
-    // is the only stable container element we can hook into.
+    // Scope by the card containing OUR timestamped note. With one
+    // student in the throwaway there is only one PENDING card on this
+    // page, but the locator stays robust for future fixtures that
+    // provision multiple students.
     const card = page
       .locator('[aria-label^="Entschuldigung fuer"]')
       .filter({ hasText: noteText });
@@ -126,8 +121,7 @@ test.describe('Issue #83 — Excuses teacher review (desktop)', () => {
     await card.getByRole('button', { name: 'Akzeptieren' }).click();
 
     // Review dialog opens with the ACCEPTED title (ExcuseReviewList
-    // .tsx:135). No review-note required for ACCEPTED, so we go
-    // straight to confirm.
+    // .tsx:135). No review-note required for ACCEPTED.
     await expect(
       page.getByRole('heading', { name: 'Entschuldigung akzeptieren' }),
     ).toBeVisible();
@@ -142,10 +136,7 @@ test.describe('Issue #83 — Excuses teacher review (desktop)', () => {
     ).toBeVisible({ timeout: 5_000 });
 
     // useReviewExcuse invalidates useExcuses → refetch with status=PENDING
-    // filter no longer includes our row → empty state appears OR the row
-    // disappears. The negative-presence check is the regression-lock for
-    // the invalidation: if `useExcuses` cache key drifts from the mutation's
-    // invalidation pattern, the card would stick around stale.
+    // filter no longer includes our row → card disappears.
     await expect(
       page.getByText(noteText),
       'accepted excuse must disappear from the PENDING review list after the toast',

--- a/apps/web/e2e/fixtures/throwaway-school.ts
+++ b/apps/web/e2e/fixtures/throwaway-school.ts
@@ -69,9 +69,16 @@ const { PrismaClient } = require('../../../api/dist/config/database/generated/cl
     };
     schoolClass: {
       create: (args: any) => Promise<{ id: string; name: string }>;
+      update: (args: any) => Promise<{ id: string; name: string; klassenvorstandId: string | null }>;
     };
     teacher: {
       create: (args: any) => Promise<{ id: string; personId: string }>;
+    };
+    parent: {
+      create: (args: any) => Promise<{ id: string; personId: string }>;
+    };
+    parentStudent: {
+      create: (args: any) => Promise<{ id: string; parentId: string; studentId: string }>;
     };
     subject: {
       create: (args: any) => Promise<{ id: string; shortName: string }>;
@@ -208,6 +215,34 @@ export interface ThrowawaySchoolOptions {
    * deletes it on `fixture.cleanup()`.
    */
   withSecondTeacherLesson?: boolean;
+  /**
+   * Issue #151 (Phase 3.5/4) — link the `eltern` Person to one or more
+   * students via `Parent` + `ParentStudent` rows. The eltern Person's
+   * `personId` becomes a `Parent.personId` (`@unique`); each
+   * `studentIndexes[i]` in `withStudents` is linked as a child via
+   * `ParentStudent`. Requires `roles.eltern === true` AND
+   * `withStudents.length >= max(studentIndexes) + 1`.
+   *
+   * The ExcuseForm renders a child as a plain text label when
+   * `children.length === 1` (ExcuseForm.tsx:137); passing a single
+   * index produces that branch, multiple indexes produce the Select.
+   * Cleanup is automatic via the School cascade (Parent + ParentStudent
+   * both have `onDelete: Cascade` on their FKs).
+   */
+  withParentLinks?: {
+    eltern?: { studentIndexes: number[] };
+  };
+  /**
+   * Issue #151 — assign the timetable stack's primary Teacher as
+   * `klassenvorstand` of `classIds[0]`. Required by the Excuses review
+   * spec, which queries PENDING excuses scoped to the Klassenvorstand
+   * (excuse.controller.ts `getPendingExcusesForKlassenvorstand`). Pass
+   * `'lehrer'` so the teacher whose Person is the seed-lehrer's Person
+   * becomes the KV — kc-lehrer (Maria Mueller) then sees the excuses
+   * for class[0]'s students. Requires `withTimetableStack: true`
+   * (otherwise there is no Teacher row to assign).
+   */
+  withKlassenvorstand?: 'lehrer';
 }
 
 export interface ThrowawayTimetableStack {
@@ -293,6 +328,12 @@ export interface ThrowawaySchoolFixture {
   secondTeacher?: ThrowawaySecondTeacherLesson;
   /** Issue #138 — Student.id values matching the `withStudents` indexes. */
   studentIds: string[];
+  /**
+   * Issue #151 — Parent.id values per linked role, populated when
+   * `withParentLinks` was passed. Only the keys for roles actually linked
+   * are present.
+   */
+  parentIds: Partial<Record<SeedRole, string>>;
   /** Issue #138 — Populated when `withClassbookEntry` was passed. */
   classBookEntryId?: string;
   /** Issue #138 wave 2 — Populated when `withTimetableEdit` was passed. */
@@ -389,6 +430,30 @@ export async function createThrowawaySchool(
   if (options.withSecondTeacherLesson && !withTimetableStack) {
     throw new Error(
       'createThrowawaySchool: withSecondTeacherLesson requires withTimetableStack (no run + classSubject + room to attach the second lesson to)',
+    );
+  }
+  if (options.withParentLinks?.eltern && !roles.eltern) {
+    throw new Error(
+      'createThrowawaySchool: withParentLinks.eltern requires roles.eltern (no eltern Person to attach Parent + ParentStudent rows to)',
+    );
+  }
+  if (options.withParentLinks?.eltern) {
+    const studentCount = options.withStudents?.length ?? 0;
+    const maxIdx = Math.max(...options.withParentLinks.eltern.studentIndexes);
+    if (maxIdx >= studentCount) {
+      throw new Error(
+        `createThrowawaySchool: withParentLinks.eltern.studentIndexes[max=${maxIdx}] is out of range (only ${studentCount} students provisioned)`,
+      );
+    }
+  }
+  if (options.withKlassenvorstand && !withTimetableStack) {
+    throw new Error(
+      'createThrowawaySchool: withKlassenvorstand requires withTimetableStack (no Teacher row exists to assign as Klassenvorstand)',
+    );
+  }
+  if (options.withKlassenvorstand === 'lehrer' && !roles.lehrer) {
+    throw new Error(
+      'createThrowawaySchool: withKlassenvorstand=lehrer requires roles.lehrer (otherwise the timetable stack picks a fixture-only Teacher whose Person is not the seed lehrer)',
     );
   }
 
@@ -736,6 +801,41 @@ export async function createThrowawaySchool(
       };
     }
 
+    // Issue #151 — Parent + ParentStudent rows. The eltern Person was
+    // created above (when roles.eltern); attach a Parent row to it and
+    // link the requested student indexes. Cascade-clean via School delete
+    // (Parent.schoolId FK + ParentStudent FKs both onDelete: Cascade).
+    const parentIds: Partial<Record<SeedRole, string>> = {};
+    if (options.withParentLinks?.eltern && personIds.eltern) {
+      const elternParent = await prisma.parent.create({
+        data: {
+          personId: personIds.eltern,
+          schoolId: school.id,
+        },
+      });
+      parentIds.eltern = elternParent.id;
+      for (const idx of options.withParentLinks.eltern.studentIndexes) {
+        await prisma.parentStudent.create({
+          data: {
+            parentId: elternParent.id,
+            studentId: studentIds[idx],
+          },
+        });
+      }
+    }
+
+    // Issue #151 — assign the timetable stack's primary Teacher as
+    // Klassenvorstand of class[0]. Required by the Excuses review surface
+    // which scopes PENDING excuses to the KV's classes. Only the 'lehrer'
+    // role variant is supported today (schulleitung KV is rare in DACH
+    // schools and out of scope for the current spec set).
+    if (options.withKlassenvorstand === 'lehrer' && timetable && classIds[0]) {
+      await prisma.schoolClass.update({
+        where: { id: classIds[0] },
+        data: { klassenvorstandId: timetable.teacherId },
+      });
+    }
+
     const capturedTimetable = timetable;
     const cleanup = async () => {
       const p = buildPrisma();
@@ -782,6 +882,7 @@ export async function createThrowawaySchool(
       timetable,
       secondTeacher,
       studentIds,
+      parentIds,
       classBookEntryId,
       timetableEditId,
       cleanup,

--- a/apps/web/e2e/helpers/excuses.ts
+++ b/apps/web/e2e/helpers/excuses.ts
@@ -1,61 +1,41 @@
 /**
  * Excuses E2E helpers — #83.
  *
+ * Issue #151 (Phase 3.5/4) reduction — the seed-school-bound prefix-sweep
+ * (`cleanupE2EExcuses`) + the Prisma + advisory-lock plumbing are gone
+ * because every consumer migrated to throwaway-school and
+ * `fixture.cleanup()` cascade-drops every AbsenceExcuse via the
+ * `student.schoolId` FK chain.
+ *
+ * What stays:
+ *   - `createExcuseAsParentViaAPI` — seeds a PENDING excuse as kc-eltern,
+ *     accepts an optional `schoolId` so a throwaway-bound spec can hit
+ *     `/schools/<throwawayId>/classbook/excuses` with `X-School-Id` set.
+ *   - `uploadExcuseAttachmentViaAPI` — multipart attachment upload, same
+ *     `schoolId` override.
+ *   - `STUB_PDF_ATTACHMENT` — in-memory minimal PDF (magic bytes only).
+ *   - `todayISODate` — date helper for the API contract.
+ *
  * Phase 6 AbsenceExcuse REST contract:
  *   - POST   /schools/:schoolId/classbook/excuses          — parent submits
  *   - GET    /schools/:schoolId/classbook/excuses          — list (role-scoped)
  *   - PATCH  /schools/:schoolId/classbook/excuses/:id/review — Klassenvorstand reviews
- *
- * There is NO DELETE endpoint on the excuses API (parents cannot withdraw
- * a submitted excuse; teachers can only review). For test cleanup we go
- * direct-to-Prisma, mirroring the `fixtures/timetable-run.ts` CommonJS-
- * bridge pattern. The sweep is scoped to a note-prefix every spec stamps
- * onto its excuse — that way two specs running in parallel can each
- * clean up only their own rows.
+ *   - POST   /schools/:schoolId/classbook/excuses/:id/attachment — multipart upload
  */
-import 'dotenv/config';
-import { config as dotenvConfig } from 'dotenv';
-import { createRequire } from 'node:module';
-import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
 import { expect, type APIRequestContext } from '@playwright/test';
-import { getRoleToken } from './login';
+import { getRoleToken, type Role } from './login';
 import { SEED_SCHOOL_UUID } from '../fixtures/seed-uuids';
 
 export const EXCUSES_API =
   process.env.E2E_API_URL ?? 'http://localhost:3000/api/v1';
-export const EXCUSES_SCHOOL_ID =
+const EXCUSES_DEFAULT_SCHOOL_ID =
   process.env.E2E_SCHOOL_ID ?? SEED_SCHOOL_UUID;
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-dotenvConfig({ path: path.resolve(__dirname, '../../../../.env') });
-
-const require = createRequire(import.meta.url);
-
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const { PrismaClient } = require('../../../api/dist/config/database/generated/client.js') as {
-  PrismaClient: new (opts?: { adapter?: unknown }) => {
-    absenceExcuse: {
-      deleteMany: (args: {
-        where: Record<string, unknown>;
-      }) => Promise<{ count: number }>;
-    };
-    $disconnect: () => Promise<void>;
-  };
-};
-
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const { PrismaPg } = require('../../../api/node_modules/@prisma/adapter-pg') as {
-  PrismaPg: new (opts: { connectionString: string }) => unknown;
-};
-
 /**
- * Prefix every E2E-generated excuse note with this string so the cleanup
- * sweep can find them. Two parallel specs CAN safely use the same
- * prefix — `deleteMany` is idempotent and the per-row write is the only
- * shared state.
+ * Prefix every E2E-generated excuse note with this string so any future
+ * legacy seed-bound consumer can locate them — throwaway-bound specs
+ * don't need this since `fixture.cleanup()` cascade-drops the rows, but
+ * keeping the prefix makes mid-test debugging via `psql` trivial.
  */
 export const EXCUSES_NOTE_PREFIX = 'E2E-EXC-';
 
@@ -65,6 +45,12 @@ export interface CreateExcuseInput {
   endDate: string; // YYYY-MM-DD
   reason: 'KRANK' | 'ARZTTERMIN' | 'FAMILIAER' | 'SONSTIG';
   note?: string;
+  /**
+   * Issue #151 — throwaway-school override. When set, the helper posts
+   * to `/schools/<schoolId>/classbook/excuses` and sends `X-School-Id`.
+   * Defaults to the seed-school constant.
+   */
+  schoolId?: string;
 }
 
 export interface CreatedExcuse {
@@ -81,13 +67,15 @@ export async function createExcuseAsParentViaAPI(
   request: APIRequestContext,
   input: CreateExcuseInput,
 ): Promise<CreatedExcuse> {
+  const schoolId = input.schoolId ?? EXCUSES_DEFAULT_SCHOOL_ID;
   const token = await getRoleToken(request, 'eltern');
   const res = await request.post(
-    `${EXCUSES_API}/schools/${EXCUSES_SCHOOL_ID}/classbook/excuses`,
+    `${EXCUSES_API}/schools/${schoolId}/classbook/excuses`,
     {
       headers: {
         Authorization: `Bearer ${token}`,
         'Content-Type': 'application/json',
+        ...(input.schoolId ? { 'X-School-Id': input.schoolId } : {}),
       },
       data: {
         studentId: input.studentId,
@@ -117,14 +105,8 @@ export const STUB_PDF_ATTACHMENT = Buffer.from('%PDF-1.4 test', 'utf-8');
 
 /**
  * Upload a PDF/JPG/PNG attachment to an existing excuse as the
- * supplied role (default 'eltern' — the only role that can submit
- * excuses and thus the canonical attachment author). Wraps the
- * multipart upload endpoint
+ * supplied role (default 'eltern'). Wraps the multipart upload endpoint
  * (`excuse.controller.ts:117` POST `/excuses/:id/attachment`).
- *
- * Uses the Playwright `request.post` `multipart` option which produces
- * the same wire format @fastify/multipart expects, including the
- * filename + mimeType headers.
  */
 export async function uploadExcuseAttachmentViaAPI(
   request: APIRequestContext,
@@ -133,15 +115,21 @@ export async function uploadExcuseAttachmentViaAPI(
     filename: string;
     mimeType?: string;
     buffer?: Buffer;
-    actorRole?: 'eltern' | 'lehrer' | 'admin' | 'schulleitung' | 'schueler';
+    actorRole?: Role;
+    /** Issue #151 — throwaway-school override (see CreateExcuseInput). */
+    schoolId?: string;
   },
 ): Promise<void> {
+  const schoolId = options.schoolId ?? EXCUSES_DEFAULT_SCHOOL_ID;
   const role = options.actorRole ?? 'eltern';
   const token = await getRoleToken(request, role);
   const res = await request.post(
-    `${EXCUSES_API}/schools/${EXCUSES_SCHOOL_ID}/classbook/excuses/${excuseId}/attachment`,
+    `${EXCUSES_API}/schools/${schoolId}/classbook/excuses/${excuseId}/attachment`,
     {
-      headers: { Authorization: `Bearer ${token}` },
+      headers: {
+        Authorization: `Bearer ${token}`,
+        ...(options.schoolId ? { 'X-School-Id': options.schoolId } : {}),
+      },
       multipart: {
         file: {
           name: options.filename,
@@ -168,33 +156,4 @@ export function todayISODate(anchor: Date = new Date()): string {
   const m = String(d.getMonth() + 1).padStart(2, '0');
   const day = String(d.getDate()).padStart(2, '0');
   return `${y}-${m}-${day}`;
-}
-
-/**
- * Delete every AbsenceExcuse whose `note` field starts with the supplied
- * prefix. Best-effort: swallows errors so a half-applied fixture from a
- * previously killed run doesn't block the next test's setup.
- *
- * The `excuse_attachments` table cascade-deletes via the FK
- * (schema.prisma) so explicit attachment cleanup is not needed.
- */
-export async function cleanupE2EExcuses(
-  prefix: string = EXCUSES_NOTE_PREFIX,
-): Promise<void> {
-  const prisma = new PrismaClient({
-    adapter: new PrismaPg({ connectionString: process.env.DATABASE_URL ?? '' }),
-  });
-  try {
-    await prisma.absenceExcuse.deleteMany({
-      where: { note: { startsWith: prefix } },
-    });
-  } catch (err) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      `[excuses] cleanupE2EExcuses soft-failed:`,
-      err,
-    );
-  } finally {
-    await prisma.$disconnect();
-  }
 }


### PR DESCRIPTION
Phase 3.5/4 — three excuse specs migrated to throwaway-school. Advisory lock + Prisma-direct prefix-sweep cleanup gone.

## Latent backend bug surfaced + fixed in-PR

While running the migrated specs cross-project under parallel load (5x), all 30 instances 403'd with *"Entschuldigungen koennen nur fuer eigene Kinder eingereicht werden"*. Trace network capture showed the SPA was correctly sending `X-School-Id: <throwawayId>` and the interceptor was correctly resolving the throwaway-eltern Person — but the **service-internal** `Person.findFirst({ where: { keycloakUserId } })` queries had **no `schoolId` scope** and returned a sibling-throwaway's Person under parallel test load. The ParentStudent lookup then failed because that sibling parent didn't own a link to THIS throwaway's student.

### `excuse.service.ts` — three resolver sites scoped by `(keycloakUserId, schoolId)`

- `createExcuse(schoolId, …)` — `Person.findFirst` at line 59
- `getExcusesForParent(parentKeycloakId, schoolId)` — signature extended; the controller GET passes the `:schoolId` path param. Excuse list also gains a `schoolId` filter so a multi-school parent sees only the current school's submissions.
- `getPendingExcusesForKlassenvorstand(teacherKeycloakId, schoolId)` — `Person.findFirst` at line 323

No unit-test changes — the 8 spec cases for this service are `it.todo` placeholders; the e2e suite carries the regression-lock.

### Note: broader pattern (~20 sites)

`grep -rn "person.findFirst.*keycloakUserId" apps/api/src/modules/` finds ~20 other sites in messaging / dashboard / attendance / user-directory / poll services that do the same unscoped lookup. Same multi-tenant risk — out of scope for this PR. Will file a follow-up issue to audit + fix the whole pattern (likely a `PersonResolver` helper that bakes the scope in).

## Throwaway fixture extensions

- `withParentLinks?: { eltern?: { studentIndexes: number[] } }` — creates a `Parent` row for the eltern Person and links it to the given student indexes via `ParentStudent`. Cascade-clean via the School delete.
- `withKlassenvorstand?: 'lehrer'` — sets `classIds[0].klassenvorstandId` to the timetable stack's primary Teacher (whose Person is the seed lehrer when `roles.lehrer` is true). Required by the review spec which scopes PENDING excuses to the KV's classes.

## Spec migrations

| Spec | Tests | Setup |
| --- | --- | --- |
| `excuses-parent-submit` | EXC-PARENT-01 | eltern + 1 Lisa-Huber student + parentLinks |
| `excuses-teacher-review` | EXC-TEACHER-01 | lehrer + eltern + KV + timetable stack + Lisa + parentLinks |
| `excuses-attachments` | EXC-ATT-PARENT-01 + EXC-ATT-TEACHER-01 | same as teacher-review (multipart attachment upload routes via `helpers/excuses.ts` with `schoolId` override) |

`helpers/excuses.ts` shrunk — `createExcuseAsParentViaAPI` + `uploadExcuseAttachmentViaAPI` accept an optional `schoolId` (default still SEED for back-compat). `cleanupE2EExcuses` + Prisma plumbing gone (`fixture.cleanup()` cascade-drops AbsenceExcuse + `excuse_attachments` rows via the School FK chain).

## Acceptance Criteria (from #151)

- [x] All 3 specs migrated, `EXCUSES_STUDENT_LOCK_KEY` removed from all
- [x] Cross-project parallel 5 iterations grün for all 3 — **40/40 local**
- [x] Attachment upload still works against throwaway school

## Tests

\`\`\`
pnpm exec playwright test --project=desktop --project=desktop-firefox \\
  e2e/excuses-parent-submit.spec.ts e2e/excuses-teacher-review.spec.ts \\
  e2e/excuses-attachments.spec.ts --repeat-each=5
40 passed (3.4m)
\`\`\`

Closes #151
Refs #147