### PR TITLE
chore(e2e): #165 — migrate 4 admin specs to throwaway-school (Batch A of #153)

### DIFF
--- a/apps/web/e2e/admin-substitutions-create.spec.ts
+++ b/apps/web/e2e/admin-substitutions-create.spec.ts
@@ -1,30 +1,22 @@
 /**
  * Issue #85 — Admin "Neue Abwesenheit erfassen" UI flow.
  *
- * Third sub-spec of the Substitutions coverage gap. Locks the admin-side
- * UI for creating an absence end-to-end:
+ * Issue #165 (Phase 3.5/6 Batch A) — migrated to throwaway-school per
+ * CLAUDE.md D4. The `active-timetable-run:SEED_SCHOOL_UUID` advisory lock
+ * is gone; each invocation owns its own school so the AbsenceList +
+ * OpenSubstitutionsPanel render only this spec's rows. `.first()` race
+ * guards on the panel matches are no longer needed.
  *
- *   1. Seed an active TimetableRun with one lesson at MONDAY/period-1
- *      for kc-lehrer (Maria Mueller).
+ *   1. Throwaway TimetableRun + one lesson at MONDAY/period-1 for the
+ *      throwaway teacher (bound to kc-lehrer Person).
  *   2. Admin opens /admin/substitutions?tab=absences, clicks "Neue
- *      Abwesenheit erfassen", picks Maria Mueller + date range +
+ *      Abwesenheit erfassen", picks the throwaway teacher + Monday +
  *      KRANK reason, submits.
  *   3. Toast "Abwesenheit erfasst. 1 Stunden betroffen." confirms the
  *      backend expansion produced exactly one row, and the AbsenceList
- *      below the form re-renders with the new row.
+ *      re-renders with the new row.
  *   4. Switch to "Offene Vertretungen" tab — the auto-generated
  *      substitution surfaces.
- *
- * Why this slice: SUB-ADMIN-01 (PR #92) drove the absence creation via
- * the API helper and only locked the list-side rendering. This one
- * exercises the actual `<AbsenceForm>` ↔ `useCreateAbsence` ↔
- * `POST /absences` path through the UI, which is the production-user
- * flow and the only place the date inputs, the teacher Select, and the
- * affectedLessonCount toast are wired together.
- *
- * Chromium-only-skip per the race-family precedent — shared seed-school
- * mutating specs collide on parallel browser projects (TimetableRun is
- * the canonical race surface).
  */
 import { test, expect } from '@playwright/test';
 import { loginAsAdmin } from './helpers/login';
@@ -33,12 +25,10 @@ import {
   listSubstitutionsViaAPI,
 } from './helpers/substitutions';
 import {
-  cleanupTimetableRun,
-  seedTimetableRun,
-  purgeAbsenceViaPrisma,
-  type TimetableRunFixture,
-} from './fixtures/timetable-run';
-import { SEED_SCHOOL_UUID } from './fixtures/seed-uuids';
+  createThrowawaySchool,
+  type ThrowawaySchoolFixture,
+} from './fixtures/throwaway-school';
+import { useThrowawaySchoolHeader } from './helpers/school-context';
 
 test.describe('Issue #85 — Admin Neue Abwesenheit erfassen UI flow (desktop)', () => {
   test.skip(
@@ -46,25 +36,25 @@ test.describe('Issue #85 — Admin Neue Abwesenheit erfassen UI flow (desktop)',
     'AbsenceForm is desktop-prioritised — mobile flow is a follow-up slice once the form layout is mobile-audited.',
   );
 
-  let fixture: TimetableRunFixture | undefined;
-  // The UI flow leaves the absence row created via POST /absences on
-  // the server. afterEach tracks it by id (resolved post-submit via the
-  // admin GET /substitutions list) so the cleanup hard-deletes it
-  // through Prisma (cascades the auto-generated PENDING substitution).
-  let absenceId: string | undefined;
+  let fixture: ThrowawaySchoolFixture | undefined;
 
-  test.beforeEach(async ({ page }) => {
-    fixture = await seedTimetableRun(SEED_SCHOOL_UUID);
+  test.beforeEach(async ({ context, page }) => {
+    fixture = await createThrowawaySchool({
+      roles: { admin: true, lehrer: true },
+      withClasses: 1,
+      withTimetableStack: true,
+      namePrefix: 'E2E-SUB-CREATE',
+    });
+    await useThrowawaySchoolHeader(context, fixture.schoolId);
     await loginAsAdmin(page);
   });
 
   test.afterEach(async () => {
-    if (absenceId) {
-      await purgeAbsenceViaPrisma(absenceId);
-      absenceId = undefined;
-    }
+    // The UI flow creates an absence that the throwaway-school cascade
+    // covers — TeacherAbsence + Substitution + HandoverNote all go with
+    // the School. `purgeAbsenceViaPrisma` (legacy) is no longer needed.
     if (fixture) {
-      await cleanupTimetableRun(fixture);
+      await fixture.cleanup();
       fixture = undefined;
     }
   });
@@ -74,6 +64,16 @@ test.describe('Issue #85 — Admin Neue Abwesenheit erfassen UI flow (desktop)',
     request,
   }) => {
     if (!fixture) throw new Error('fixture not seeded');
+    const stack = fixture.timetable!;
+
+    // Derive the throwaway teacher's name parts from the perspective
+    // format (`${lastName} ${firstName}`). The AbsenceForm Select option
+    // renders as "{lastName}, {firstName}" (AbsenceForm.tsx:152); the
+    // AbsenceList table row and OpenSubstitutionsPanel header both render
+    // "{firstName} {lastName}" (teacher-absence.service.ts:268 +
+    // substitution.service.ts:455).
+    const [tLast, tFirst] = stack.teacherDisplayName.split(' ');
+    const selectOptionLabel = `${tLast}, ${tFirst}`;
 
     const monday = nextMondayISODate();
 
@@ -87,17 +87,11 @@ test.describe('Issue #85 — Admin Neue Abwesenheit erfassen UI flow (desktop)',
       .getByRole('button', { name: 'Neue Abwesenheit erfassen' })
       .click();
 
-    // Teacher Select — Radix Select renders option labels as
-    // "{lastName}, {firstName}" (AbsenceForm.tsx:152). The seed
-    // teacher is Maria Mueller.
     await page.getByRole('combobox', { name: 'Lehrer/in' }).click();
     await page
-      .getByRole('option', { name: 'Mueller, Maria' })
+      .getByRole('option', { name: selectOptionLabel })
       .click();
 
-    // Date range — both inputs default to today but the fixture lesson
-    // is on MONDAY, so override to the next Monday to guarantee the
-    // expansion algorithm picks up exactly one lesson.
     await page.fill('input#absence-date-from', monday);
     await page.fill('input#absence-date-to', monday);
 
@@ -111,34 +105,29 @@ test.describe('Issue #85 — Admin Neue Abwesenheit erfassen UI flow (desktop)',
 
     // Submission toast — exact text from AbsenceForm.tsx:115. "1" is
     // load-bearing: it proves the backend treated the absence as
-    // covering exactly the one seed lesson, not zero (would-fail check
+    // covering exactly the one throwaway lesson, not zero (would-fail check
     // below) and not many (which would mean cross-fixture leakage).
     await expect(
       page.getByText('Abwesenheit erfasst. 1 Stunden betroffen.'),
     ).toBeVisible();
 
-    // AbsenceList below the form re-renders with the new row. The
-    // teacherName field is "{firstName} {lastName}" (space-separated)
-    // from teacher-absence.service.ts:268, NOT the comma form the
-    // dropdown option uses. `.first()` because parallel-spec absences
-    // for Maria Mueller on the same Monday show up alongside ours in
-    // the shared tenant — assertion intent ("the row landed in the
-    // list") is preserved.
+    // AbsenceList below the form re-renders with the new row. Strict
+    // match (no `.first()`) is now safe — per-school isolation means the
+    // only matching row is ours.
     await expect(
       page
         .locator('table')
-        .getByText(/Maria\s+Mueller/)
-        .first(),
+        .getByText(new RegExp(`${tFirst}\\s+${tLast}`)),
     ).toBeVisible();
 
-    // Resolve the absence id via the admin substitutions API so
-    // afterEach can hard-delete it. We match by (originalTeacherId,
-    // dayOfWeek=MONDAY, periodNumber=1, status=PENDING) — the only
-    // substitution our spec could have produced given the fixture.
-    const subs = await listSubstitutionsViaAPI(request);
+    // Resolve the absence id via the admin substitutions API so the
+    // assertion below can match it back to the panel row. The throwaway
+    // school has exactly one (originalTeacherId, MONDAY, period 1)
+    // substitution.
+    const subs = await listSubstitutionsViaAPI(request, fixture.schoolId);
     const ours = subs.find(
       (s) =>
-        s.originalTeacherId === fixture!.teacherId &&
+        s.originalTeacherId === stack.teacherId &&
         s.dayOfWeek === 'MONDAY' &&
         s.periodNumber === 1 &&
         s.status === 'PENDING',
@@ -147,7 +136,6 @@ test.describe('Issue #85 — Admin Neue Abwesenheit erfassen UI flow (desktop)',
       ours,
       'admin substitutions list must contain the auto-generated row for our absence',
     ).toBeTruthy();
-    absenceId = ours!.absenceId;
 
     // Switch tabs and verify the substitution surfaces in
     // OpenSubstitutionsPanel. This validates the end-to-end loop:
@@ -155,7 +143,9 @@ test.describe('Issue #85 — Admin Neue Abwesenheit erfassen UI flow (desktop)',
     // refetch → panel render.
     await page.getByRole('tab', { name: 'Offene Vertretungen' }).click();
     await expect(
-      page.getByText(/Vertretung fuer:\s*Maria Mueller/).first(),
+      page.getByText(
+        new RegExp(`Vertretung fuer:\\s*${tFirst}\\s+${tLast}`),
+      ),
       'newly created absence must produce a substitution row in the open panel',
     ).toBeVisible();
   });

--- a/apps/web/e2e/admin-substitutions-list.spec.ts
+++ b/apps/web/e2e/admin-substitutions-list.spec.ts
@@ -1,26 +1,24 @@
 /**
  * Issue #85 — Admin "Offene Vertretungen" panel.
  *
- * First sub-spec of the Substitutions coverage gap. Locks the admin-side
- * view of auto-generated substitutions:
+ * Issue #165 (Phase 3.5/6 Batch A) — migrated to throwaway-school per
+ * CLAUDE.md D4. The `active-timetable-run:SEED_SCHOOL_UUID` advisory lock
+ * is gone for this spec; each invocation owns its own throwaway School so
+ * the substitution-list panel renders only rows this spec created. The
+ * `.first()` race-defense on the panel match is therefore no longer needed
+ * either — replaced with a strict-mode assertion.
  *
  *   1. Seed an active TimetableRun with one lesson at MONDAY/period-1
- *      for class 1A, taught by kc-lehrer (Maria Mueller).
- *   2. POST an absence for kc-lehrer covering the upcoming Monday →
- *      backend auto-expands to one Substitution row.
+ *      for the throwaway class, taught by kc-lehrer.
+ *   2. POST an absence for the throwaway teacher covering the upcoming
+ *      Monday → backend auto-expands to one Substitution row.
  *   3. Admin opens /admin/substitutions?tab=open → OpenSubstitutionsPanel
  *      surfaces the row with the absent teacher's name.
  *
  * Why this slice first: it exercises three load-bearing layers in one
  * test — backend absence-to-substitution expansion (4 .createMany
  * branch in teacher-absence.service.ts), useSubstitutions list fetch,
- * and OpenSubstitutionsPanel rendering. The UI-driven AbsenceForm
- * flow and the "assign substitute" / Entfall / Stillarbeit actions are
- * deferred to follow-up sub-specs.
- *
- * Chromium-only-skip per the race-family precedent — shared seed-school
- * mutating specs collide on parallel browser projects (TimetableRun is
- * the canonical race surface).
+ * and OpenSubstitutionsPanel rendering.
  */
 import { test, expect } from '@playwright/test';
 import { loginAsAdmin } from './helpers/login';
@@ -31,11 +29,10 @@ import {
   type CreatedAbsence,
 } from './helpers/substitutions';
 import {
-  cleanupTimetableRun,
-  seedTimetableRun,
-  type TimetableRunFixture,
-} from './fixtures/timetable-run';
-import { SEED_SCHOOL_UUID } from './fixtures/seed-uuids';
+  createThrowawaySchool,
+  type ThrowawaySchoolFixture,
+} from './fixtures/throwaway-school';
+import { useThrowawaySchoolHeader } from './helpers/school-context';
 
 test.describe('Issue #85 — Admin Offene Vertretungen (desktop)', () => {
   test.skip(
@@ -43,47 +40,68 @@ test.describe('Issue #85 — Admin Offene Vertretungen (desktop)', () => {
     'Panel rendering is identical across viewports — desktop only for the first lock.',
   );
 
-  // Per-test seeding — describe-level test.skip does NOT gate
-  // beforeAll/afterAll (CI lesson from #81/#86). Per-test hooks ARE
-  // gated and the `if (!x)` guards belt-and-brace the cleanup against
-  // any half-applied state.
-  let fixture: TimetableRunFixture | undefined;
+  let fixture: ThrowawaySchoolFixture | undefined;
   let absence: CreatedAbsence | undefined;
 
-  test.beforeEach(async ({ page }) => {
-    fixture = await seedTimetableRun(SEED_SCHOOL_UUID);
+  test.beforeEach(async ({ context, page }) => {
+    // roles: admin (drives /admin/substitutions) + lehrer (the absent
+    // teacher must be tied to a Person row; the throwaway timetable stack
+    // binds the lone Teacher to the lehrer Person when roles.lehrer is on,
+    // so the absence has a teacher to belong to and the panel has a name
+    // to render).
+    fixture = await createThrowawaySchool({
+      roles: { admin: true, lehrer: true },
+      withClasses: 1,
+      withTimetableStack: true,
+      namePrefix: 'E2E-SUB-LIST',
+    });
+    await useThrowawaySchoolHeader(context, fixture.schoolId);
     await loginAsAdmin(page);
   });
 
   test.afterEach(async ({ request }) => {
-    if (absence) {
-      await cancelAbsenceViaAPI(request, absence.id);
+    // Belt-and-braces cancel: the throwaway-school cleanup cascades
+    // through TeacherAbsence + Substitution rows, but explicit cancel
+    // protects against a half-applied cleanup if a later edit re-orders
+    // teardown.
+    if (absence && fixture) {
+      await cancelAbsenceViaAPI(request, absence.id, fixture.schoolId);
       absence = undefined;
     }
     if (fixture) {
-      await cleanupTimetableRun(fixture);
+      await fixture.cleanup();
       fixture = undefined;
     }
   });
 
-  test('SUB-ADMIN-01: absence for kc-lehrer surfaces a substitution row in OpenSubstitutionsPanel', async ({
+  test('SUB-ADMIN-01: absence for the throwaway teacher surfaces a substitution row in OpenSubstitutionsPanel', async ({
     page,
     request,
   }) => {
     if (!fixture) throw new Error('fixture not seeded');
+    const stack = fixture.timetable!;
 
-    // Absence covering the upcoming Monday — aligns with the seed
+    // Throwaway teacher Person was created as
+    // `firstName = '<namePrefix>-lehrer'`, `lastName = '<suffix>'`. The
+    // perspective format `${lastName} ${firstName}` is exposed via
+    // `teacherDisplayName`; split it for the substitution panel which
+    // renders `${firstName} ${lastName}` (substitution.service.ts:455).
+    const [tLast, tFirst] = stack.teacherDisplayName.split(' ');
+
+    // Absence covering the upcoming Monday — aligns with the throwaway
     // lesson's day-of-week so the expansion algorithm produces one
-    // substitution row (teacher-absence.service.ts:138 eachDayOfInterval
-    // → filter by activeDaySet → match lesson by runId+teacherId+
-    // dayOfWeek).
+    // substitution row.
     const monday = nextMondayISODate();
-    absence = await createAbsenceViaAPI(request, {
-      teacherId: fixture.teacherId,
-      dateFrom: monday,
-      dateTo: monday,
-      reason: 'KRANK',
-    });
+    absence = await createAbsenceViaAPI(
+      request,
+      {
+        teacherId: stack.teacherId,
+        dateFrom: monday,
+        dateTo: monday,
+        reason: 'KRANK',
+      },
+      fixture.schoolId,
+    );
     expect(
       absence.affectedLessonCount ?? 0,
       'absence-expansion must create at least one substitution row',
@@ -98,19 +116,14 @@ test.describe('Issue #85 — Admin Offene Vertretungen (desktop)', () => {
     // the absence we just created should have populated the panel.
     await expect(page.getByText('Keine offenen Vertretungen')).toHaveCount(0);
 
-    // The OpenSubstitutionsPanel renders "Vertretung fuer: <originalTeacherName>"
-    // (apps/web/src/components/substitution/OpenSubstitutionsPanel.tsx:125).
-    // kc-lehrer's Person record is Maria Mueller (apps/api/prisma/seed.ts).
-    //
-    // `.first()` guards against the race-family pattern: sibling specs in
-    // the #85 cluster (notably teacher-substitutions-my-absences.spec.ts)
-    // also seed kc-lehrer absences on the same Monday, producing extra rows
-    // in this admin panel and tripping Playwright's strict-mode locator
-    // resolution. The assertion's intent — "panel shows the absent
-    // teacher's name on at least one row" — is preserved.
+    // Per-school isolation: the panel ONLY shows this throwaway school's
+    // substitutions, so a strict (non-`.first()`) match is now safe. The
+    // shared-tenant race that motivated `.first()` is gone.
     await expect(
-      page.getByText(/Vertretung fuer:\s*Maria Mueller/).first(),
-      'panel must show the absent teacher name on at least one substitution row',
+      page.getByText(
+        new RegExp(`Vertretung fuer:\\s*${tFirst}\\s+${tLast}`),
+      ),
+      'panel must show the absent teacher name on the substitution row',
     ).toBeVisible();
   });
 });

--- a/apps/web/e2e/admin-timetable-edit-dnd.spec.ts
+++ b/apps/web/e2e/admin-timetable-edit-dnd.spec.ts
@@ -12,22 +12,26 @@
  *           visual preview; the original stays put to keep its bbox stable
  *           for collision detection).
  *
+ * Issue #165 (Phase 3.5/6 Batch A) — migrated to throwaway-school per
+ * CLAUDE.md D4. The `active-timetable-run:SEED_SCHOOL_UUID` advisory lock
+ * is gone; each invocation owns its own school. The teacher-perspective
+ * driver still works because the throwaway timetable stack pins the lone
+ * Teacher row to the lehrer Person, exposed via `teacherDisplayName`.
+ *
  * The describe is gated to the desktop Playwright project — see
  * playwright.config.ts:35 — because page.mouse pointer drags are reliable on
  * Chromium-Desktop only (mobile WebKit / mobile-Chromium are known-flaky for
  * DnD, see the Phase 11 mobile DnD note at playwright.config.ts:50–56).
  */
 import { test, expect } from '@playwright/test';
-import { SEED_SCHOOL_UUID } from './fixtures/seed-uuids';
 import { getAdminToken, loginAsAdmin } from './helpers/login';
 import {
-  seedTimetableRun,
-  cleanupTimetableRun,
-  type TimetableRunFixture,
-} from './fixtures/timetable-run';
+  createThrowawaySchool,
+  type ThrowawaySchoolFixture,
+} from './fixtures/throwaway-school';
+import { useThrowawaySchoolHeader } from './helpers/school-context';
 
 const API_BASE = process.env.E2E_API_URL ?? 'http://localhost:3000/api/v1';
-const SCHOOL_ID = process.env.E2E_SCHOOL_ID ?? SEED_SCHOOL_UUID;
 
 // File-naming gate: playwright.config.ts:42 routes `*.spec.ts` to the desktop
 // project and `*-mobile.spec.ts` / `*.mobile.spec.ts` to the mobile projects.
@@ -43,16 +47,22 @@ test.describe('Phase 04 regression — DnD timetable-edit (commit de9ee2b)', () 
     'DnD pointer drag is supported on desktop Chromium only',
   );
 
-  let fixture: TimetableRunFixture;
+  let fixture: ThrowawaySchoolFixture;
 
-  test.beforeEach(async ({ page }) => {
-    fixture = await seedTimetableRun(SCHOOL_ID);
+  test.beforeEach(async ({ context, page }) => {
+    fixture = await createThrowawaySchool({
+      roles: { admin: true, lehrer: true },
+      withClasses: 1,
+      withTimetableStack: true,
+      namePrefix: 'E2E-DND',
+    });
+    await useThrowawaySchoolHeader(context, fixture.schoolId);
     await loginAsAdmin(page);
   });
 
   test.afterEach(async () => {
     if (fixture) {
-      await cleanupTimetableRun(fixture);
+      await fixture.cleanup();
     }
   });
 
@@ -67,8 +77,9 @@ test.describe('Phase 04 regression — DnD timetable-edit (commit de9ee2b)', () 
   test('REGRESSION-DND-422: PATCH /lessons/:id/move rejects extra lessonId in body, accepts whitelist-only body', async ({
     request,
   }) => {
+    const stack = fixture.timetable!;
     const token = await getAdminToken(request);
-    const url = `${API_BASE}/schools/${SCHOOL_ID}/timetable/lessons/${fixture.lessonId}/move`;
+    const url = `${API_BASE}/schools/${fixture.schoolId}/timetable/lessons/${stack.timetableLessonId}/move`;
 
     // Negative: extra `lessonId` field in body → 422 (forbidNonWhitelisted)
     const negative = await request.patch(url, {
@@ -77,7 +88,7 @@ test.describe('Phase 04 regression — DnD timetable-edit (commit de9ee2b)', () 
         'Content-Type': 'application/json',
       },
       data: {
-        lessonId: fixture.lessonId,
+        lessonId: stack.timetableLessonId,
         targetDay: 'TUESDAY',
         targetPeriod: 2,
       },
@@ -118,11 +129,12 @@ test.describe('Phase 04 regression — DnD timetable-edit (commit de9ee2b)', () 
       true,
       'Phase 17 deferred: DnD pointer-drag timing regression — see 17-TRIAGE.md row #cluster-04-dnd.',
     );
+    const stack = fixture.timetable!;
     // Pick the seeded teacher in the perspective selector so the
     // timetable-view query becomes enabled (timetable-store default is
     // perspectiveId: null → query disabled → grid never mounts).
     await page.goto('/admin/timetable-edit');
-    await selectTeacherPerspective(page, fixture.teacherDisplayName);
+    await selectTeacherPerspective(page, stack.teacherDisplayName);
 
     // Enter edit mode — the page only mounts the DndContext when
     // editMode === true (timetable-edit.tsx:328).
@@ -138,7 +150,7 @@ test.describe('Phase 04 regression — DnD timetable-edit (commit de9ee2b)', () 
     // apps/api/src/modules/timetable/timetable.service.ts:447).
     const sourceLesson = page
       .getByRole('grid', { name: 'Stundenplan' })
-      .getByText(fixture.subjectAbbreviation, { exact: true })
+      .getByText(stack.subjectAbbreviation, { exact: true })
       .first();
     const targetCell = page.locator(
       '[data-slot-day="THURSDAY"][data-slot-period="5"]',
@@ -163,7 +175,7 @@ test.describe('Phase 04 regression — DnD timetable-edit (commit de9ee2b)', () 
     // checking the post-drop DOM state.
     const movePromise = page.waitForResponse(
       (r) =>
-        r.url().includes(`/lessons/${fixture.lessonId}/move`) &&
+        r.url().includes(`/lessons/${stack.timetableLessonId}/move`) &&
         r.request().method() === 'PATCH',
       { timeout: 15_000 },
     );
@@ -228,8 +240,9 @@ test.describe('Phase 04 regression — DnD timetable-edit (commit de9ee2b)', () 
   test('REGRESSION-DND-TRANSFORM: original DraggableLesson does not apply CSS translate during drag', async ({
     page,
   }) => {
+    const stack = fixture.timetable!;
     await page.goto('/admin/timetable-edit');
-    await selectTeacherPerspective(page, fixture.teacherDisplayName);
+    await selectTeacherPerspective(page, stack.teacherDisplayName);
     await page.getByRole('button', { name: 'Bearbeiten' }).click();
     await expect(
       page.getByRole('grid', { name: 'Stundenplan' }),
@@ -237,7 +250,7 @@ test.describe('Phase 04 regression — DnD timetable-edit (commit de9ee2b)', () 
 
     const sourceLesson = page
       .getByRole('grid', { name: 'Stundenplan' })
-      .getByText(fixture.subjectAbbreviation, { exact: true })
+      .getByText(stack.subjectAbbreviation, { exact: true })
       .first();
     await expect(sourceLesson).toBeVisible();
 
@@ -280,31 +293,11 @@ test.describe('Phase 04 regression — DnD timetable-edit (commit de9ee2b)', () 
     await page.mouse.move(sx + 30, sy + 30, { steps: 8 });
 
     // Active-drag detection via `aria-pressed="true"` on the OUTER
-    // useDraggable element. dnd-kit's `attributes` object sets
-    // `aria-pressed` to true while the draggable's own `isDragging`
-    // is true — same source-of-truth as the inner-cell
-    // `data-dragging-source` attribute, but bound to the element the
-    // test already located instead of a separate selector keyed on
-    // `fixture.lessonId`.
-    //
-    // The pre-fix inner-data-attribute approach was unreliable for two
-    // reasons. (1) Playwright's `toBeVisible` heuristics returned
-    // false intermittently under CI load, likely because the
-    // DragOverlay portal momentarily occludes the source cell's bbox
-    // and Playwright's visibility check briefly considered it
-    // offscreen. (2) The selector keyed on `fixture.lessonId` could
-    // mismatch the lessonId actually rendered in the grid when the
-    // page-query saw an in-flight DB state from a partially-completed
-    // cleanup of the previous test in a repeat-each batch (a stale
-    // ClassSubject still pointed the page-fetched lesson back to the
-    // previous run's id while the fixture variable already held the
-    // new one). The aria-pressed signal sidesteps both: it is
-    // intrinsic to the actually-dragged element regardless of which
-    // lessonId rendered.
-    //
-    // Timeout lifted to 20s (vs the global expect default of 10s) so
-    // a stalled CI worker does not RED-flag a drag that simply needs
-    // an extra rerender tick to commit the attribute.
+    // useDraggable element. Same source-of-truth as the inner-cell
+    // `data-dragging-source` attribute but bound to the element the
+    // test already located. Timeout lifted to 20s vs the global expect
+    // default so a stalled CI worker does not RED-flag a drag that
+    // simply needs an extra rerender tick to commit the attribute.
     await expect(
       draggableSource,
       'drag must be active (outer draggable carries aria-pressed=true)',
@@ -337,7 +330,7 @@ test.describe('Phase 04 regression — DnD timetable-edit (commit de9ee2b)', () 
     ).toBe(true);
 
     // Cleanly cancel the drag so the lesson is not moved (afterEach
-    // cleanup deletes the run anyway, but a clean drag-cancel keeps the
+    // cleanup deletes the school anyway, but a clean drag-cancel keeps the
     // page in a sane state should diagnostics need to inspect it).
     await page.keyboard.press('Escape');
     await page.mouse.up();
@@ -345,29 +338,16 @@ test.describe('Phase 04 regression — DnD timetable-edit (commit de9ee2b)', () 
 });
 
 /**
- * Switch the PerspectiveSelector to the seeded teacher (Maria Mueller).
- * Required because the timetable-store default perspective is
+ * Switch the PerspectiveSelector to the seeded throwaway teacher. Required
+ * because the timetable-store default perspective is
  * `{ perspective: 'teacher', perspectiveId: null }`, which leaves
  * useTimetableView disabled (`enabled: !!perspectiveId`) and the page
  * renders the "Kein Stundenplan vorhanden" empty state.
  *
- * Why teacher (not class): the production frontend hook
- * `useClasses` in apps/web/src/hooks/useTimetable.ts:91 calls
- * `/api/v1/classes` WITHOUT the required `?schoolId=...` query param,
- * so the API returns 404 → `classes = []` → no "Klassen" group ever
- * renders in the perspective dropdown. That's a separate frontend bug
- * (out of scope for this regression-coverage task — see SUMMARY
- * deviations). Driving via the teacher perspective is functionally
- * identical for the three FIXes under test (collision detection, body
- * shape, drag transform are all perspective-agnostic).
- *
  * Selector strategy: PerspectiveSelector renders a shadcn Select whose
- * trigger has role=combobox but no accessible name (Radix renders the
- * placeholder as inert text inside the trigger, so getByRole-with-name
- * misses it). The page only has ONE combobox before the grid mounts (the
- * DayWeekToggle is role=tablist), so `.first()` is safe and matches the
- * established pattern in admin-user-overrides.spec.ts:59 +
- * rooms-booking.spec.ts:202.
+ * trigger has role=combobox but no accessible name. The page only has ONE
+ * combobox before the grid mounts (DayWeekToggle is role=tablist), so
+ * `.first()` is safe.
  */
 async function selectTeacherPerspective(
   page: import('@playwright/test').Page,

--- a/apps/web/e2e/admin-timetable-edit-perspective.spec.ts
+++ b/apps/web/e2e/admin-timetable-edit-perspective.spec.ts
@@ -2,6 +2,13 @@
  * Regression spec for the useClasses() schoolId fix AND the useRooms()
  * pagination-params fix.
  *
+ * Issue #165 (Phase 3.5/6 Batch A) — migrated to throwaway-school per
+ * CLAUDE.md D4. The `active-timetable-run:SEED_SCHOOL_UUID` advisory lock
+ * is gone; each invocation owns its own school with exactly one class
+ * (overridden via `classNames: ['1A']` so the existing `/^\d+[A-Z]$/`
+ * regex match + exact-name click stay intact) and one Room (from
+ * `withTimetableStack: true`).
+ *
  * Background — the bugs this guards:
  *   useClasses() in apps/web/src/hooks/useTimetable.ts previously fetched
  *   `/api/v1/classes` with no query string. The API requires `?schoolId=...`
@@ -13,7 +20,6 @@
  *   the entire class perspective with no error toast or visible failure.
  *
  *   Full debug session: .planning/debug/resolved/useclasses-missing-schoolid.md
- *   Knowledge-base entry pattern: .planning/debug/knowledge-base.md
  *
  * Background — second guard added 2026-04-26:
  *   useRooms() in apps/web/src/hooks/useTimetable.ts had a structurally
@@ -27,16 +33,11 @@
  *   present spec asserts the Räume group renders inside the open dropdown
  *   with at least one selectable option, guarding both fixes end-to-end:
  *     - if useRooms reverts to bare path → backend may truncate to 20 rows
- *       but the spec still has at least one option (the seedTimetableRun
- *       fixture self-provisions a Room → guaranteed presence). The
- *       quantitative regression is locked by the unit test from the same
- *       commit (Vitest, "useRooms — pagination params regression guard").
+ *       but the spec still has at least one option (throwaway-school's
+ *       timetable stack self-provisions a Room → guaranteed presence).
  *     - if useRooms unwrap is reverted to `return res.json()` → iteration
  *       breaks and the Räume SelectGroup vanishes entirely → label
  *       expectation fails loudly.
- *
- *   Closes deferred items 1-3 from
- *   `.planning/debug/resolved/missing-raeume-perspective.md`.
  *
  * What this spec asserts:
  *   1. After navigating to /admin/timetable-edit and opening the
@@ -49,31 +50,24 @@
  *      → useTimetableView → grid).
  *   3. The "Raeume" SelectLabel (umlaut-less ASCII) is visible in the
  *      same open dropdown AND the Räume group contains at least one
- *      selectable option (proves the `/api/v1/schools/:schoolId/rooms`
- *      request returned data, the response was correctly unwrapped to
- *      `EntityOption[]`, and the length>0 conditional render fires).
+ *      selectable option.
  *
  * Why a sibling spec (not extending admin-timetable-edit-dnd.spec.ts):
  *   The DnD spec deliberately drives via the teacher perspective so the
- *   three FIXes from commit de9ee2b stay isolated from any other concern
- *   (collisionDetection, body shape, transform — perspective-agnostic).
- *   Switching that spec to the class perspective would conflate two
- *   independent regression guards. The teacher-perspective workaround in
- *   the timetable-run fixture is retained for that spec.
+ *   three FIXes from commit de9ee2b stay isolated. Switching that spec to
+ *   the class perspective would conflate two independent regression
+ *   guards.
  *
  * Desktop-only via file naming (no `mobile` infix) — playwright.config.ts:42
  * routes `*.spec.ts` files to the desktop project.
  */
 import { test, expect } from '@playwright/test';
-import { SEED_SCHOOL_UUID } from './fixtures/seed-uuids';
 import { loginAsAdmin } from './helpers/login';
 import {
-  seedTimetableRun,
-  cleanupTimetableRun,
-  type TimetableRunFixture,
-} from './fixtures/timetable-run';
-
-const SCHOOL_ID = process.env.E2E_SCHOOL_ID ?? SEED_SCHOOL_UUID;
+  createThrowawaySchool,
+  type ThrowawaySchoolFixture,
+} from './fixtures/throwaway-school';
+import { useThrowawaySchoolHeader } from './helpers/school-context';
 
 test.describe('Admin timetable-edit — Klassen + Räume perspectives render (useClasses schoolId fix + useRooms pagination fix)', () => {
   // Mobile projects run their own viewport-sized specs; this regression
@@ -84,22 +78,27 @@ test.describe('Admin timetable-edit — Klassen + Räume perspectives render (us
     'Klassen-perspective render check is identical across viewports — desktop only.',
   );
 
-  let fixture: TimetableRunFixture;
+  let fixture: ThrowawaySchoolFixture;
 
-  test.beforeEach(async ({ page }) => {
-    // The fixture seeds a TimetableRun + a single lesson for class 1A. We do
-    // NOT depend on the lesson here — what matters is that the seed school
-    // has at least one Class row (1A, 1B, 2A, ... seeded by prisma:seed)
-    // and that the page can mount. Reusing seedTimetableRun keeps the test
-    // surface aligned with the sibling DnD spec (same setup, same teardown,
-    // same school) so future fixture changes flow uniformly through both.
-    fixture = await seedTimetableRun(SCHOOL_ID);
+  test.beforeEach(async ({ context, page }) => {
+    // `classNames: ['1A']` keeps the regex /^\d+[A-Z]$/ matching and the
+    // explicit-name click (line 156) working without renaming both. The
+    // throwaway timetable stack guarantees one Room exists → the Räume
+    // assertion holds.
+    fixture = await createThrowawaySchool({
+      roles: { admin: true, lehrer: true },
+      withClasses: 1,
+      classNames: ['1A'],
+      withTimetableStack: true,
+      namePrefix: 'E2E-PERSP',
+    });
+    await useThrowawaySchoolHeader(context, fixture.schoolId);
     await loginAsAdmin(page);
   });
 
   test.afterEach(async () => {
     if (fixture) {
-      await cleanupTimetableRun(fixture);
+      await fixture.cleanup();
     }
   });
 
@@ -124,14 +123,6 @@ test.describe('Admin timetable-edit — Klassen + Räume perspectives render (us
     // state), the SelectLabel "Klassen" would be absent from the DOM
     // entirely and this expectation would fail — which is the exact
     // regression we are guarding against.
-    //
-    // Scope to the open Radix Select dropdown via [role="listbox"]; the
-    // sidebar nav also contains the word "Klassen" (link to the admin
-    // Klassen page) which would trip strict-mode if we matched globally.
-    // Radix renders the open dropdown content as role=listbox containing
-    // role=group children — that's the SelectGroup. The SelectLabel is
-    // emitted as a `<div>` (NOT a role=label or role=option), so we match
-    // it positionally inside the listbox.
     const dropdown = page.getByRole('listbox');
     await expect(dropdown).toBeVisible();
 
@@ -141,11 +132,11 @@ test.describe('Admin timetable-edit — Klassen + Räume perspectives render (us
       'Klassen SelectLabel must render inside the open dropdown — proves useClasses returned a non-empty array, which proves the request was made WITH ?schoolId=...',
     ).toBeVisible();
 
-    // The group must contain at least one selectable option. Use the seed
-    // class naming convention (1A, 1B, 2A, ...) to identify a Klassen
-    // option positively. The seed creates these via apps/api/prisma/seed.ts;
-    // teacher/room options never match this pattern (teachers are
-    // "Lastname Firstname", rooms are arbitrary strings).
+    // The group must contain at least one selectable option. Throwaway
+    // creates exactly one class with the seed-style name "1A" (via
+    // `classNames: ['1A']`); the regex `^\d+[A-Z]$` keeps the original
+    // intent ("matches a seed-style class name") portable to future
+    // multi-class throwaway extensions.
     const seededClass = dropdown
       .getByRole('option', { name: /^\d+[A-Z]$/ })
       .first();
@@ -156,15 +147,8 @@ test.describe('Admin timetable-edit — Klassen + Räume perspectives render (us
 
     // ── PRIMARY ASSERTION (Räume) ────────────────────────────────────────
     // The Raeume SelectGroup is wrapped in `{rooms.length > 0 && ...}`
-    // (PerspectiveSelector.tsx:119). If useRooms returned [] (the bug
-    // state — either the original 2026-04-02 unwrap-shape bug or the new
-    // pagination-truncation bug for schools with >20 rooms), the
-    // SelectLabel "Raeume" would be absent from the DOM entirely and this
-    // expectation would fail.
-    //
-    // The seedTimetableRun fixture self-provisions at least one Room
-    // when the seed school has none (per quick-task 260425-u72 SUMMARY)
-    // → precondition is guaranteed.
+    // (PerspectiveSelector.tsx:119). The throwaway timetable stack
+    // provisions a Room → precondition guaranteed.
     //
     // NOTE: The label text is "Raeume" (umlaut-less ASCII), NOT "Räume" —
     // see PerspectiveSelector.tsx:121 SelectLabel content.
@@ -174,37 +158,25 @@ test.describe('Admin timetable-edit — Klassen + Räume perspectives render (us
       'Raeume SelectLabel must render inside the open dropdown — proves useRooms returned a non-empty array, which proves the GET /api/v1/schools/:schoolId/rooms request succeeded AND the response was correctly unwrapped to EntityOption[].',
     ).toBeVisible();
 
-    // The group must contain at least one selectable option. Unlike the
-    // Klassen group, Room names follow no fixed naming convention (the
-    // seedTimetableRun fixture creates a Room with an arbitrary name when
-    // the seed school has none). We cannot use a regex like /^\d+[A-Z]$/.
-    //
-    // Strategy: use the Radix listbox group structure. Each SelectGroup
-    // renders as role=group with the SelectLabel as the first child div.
-    // Find the group whose label is "Raeume" and assert it contains at
-    // least one role=option child. Locator chain:
-    //   listbox > group:has(div:text-is("Raeume")) > [role="option"]
+    // The group must contain at least one selectable option. Room names
+    // follow no fixed naming convention; use the Radix listbox group
+    // structure to find the group whose label is "Raeume" and assert it
+    // contains at least one role=option child.
     const raeumeGroup = dropdown.locator('[role="group"]').filter({
       has: page.getByText('Raeume', { exact: true }),
     });
     await expect(
       raeumeGroup.getByRole('option').first(),
-      'At least one Raeume option must be selectable inside the Raeume SelectGroup — the seedTimetableRun fixture self-provisions a Room, so this is guaranteed by the fixture contract.',
+      'At least one Raeume option must be selectable inside the Raeume SelectGroup — the throwaway timetable stack self-provisions a Room, so this is guaranteed by the fixture contract.',
     ).toBeVisible();
 
     // ── BONUS ASSERTION ──────────────────────────────────────────────────
-    // Click the first seeded class option and verify the timetable grid
-    // mounts. This proves the full wire-up: useClasses → selector value →
-    // timetable-store → useTimetableView → TimetableGrid. The sibling DnD
-    // spec proves the same pipeline via the teacher perspective; doing it
-    // here for class perspective closes the symmetry.
-    //
-    // Pick the option for class 1A by name. The seed creates 1A as the
-    // first class row, and the timetable-run fixture binds its single
-    // lesson to seed-class-1a — so the grid will both mount and surface
-    // that lesson, giving us a stronger end-to-end signal than an empty
-    // grid would. Use exact match because "1A" is a substring of "11A"
-    // etc. in larger school setups.
+    // Click the "1A" option and verify the timetable grid mounts. This
+    // proves the full wire-up: useClasses → selector value →
+    // timetable-store → useTimetableView → TimetableGrid. Throwaway binds
+    // its single lesson to this class so the grid both mounts and
+    // surfaces the lesson, giving a stronger end-to-end signal than an
+    // empty grid would.
     await page.getByRole('option', { name: '1A', exact: true }).click();
 
     await expect(

--- a/apps/web/e2e/helpers/substitutions.ts
+++ b/apps/web/e2e/helpers/substitutions.ts
@@ -19,6 +19,13 @@ import { SEED_SCHOOL_UUID } from '../fixtures/seed-uuids';
 
 export const SUBSTITUTIONS_API =
   process.env.E2E_API_URL ?? 'http://localhost:3000/api/v1';
+/**
+ * Default school id for the legacy seed-school flow. Specs migrating to
+ * throwaway-school (Issue #153 batches A–D) pass `schoolId` explicitly per
+ * call; the default stays for any spec still bound to the seed school
+ * until its batch lands. The constant + default will be removed alongside
+ * the last seed-school caller in Batch D.
+ */
 export const SUBSTITUTIONS_SCHOOL_ID =
   process.env.E2E_SCHOOL_ID ?? SEED_SCHOOL_UUID;
 
@@ -38,14 +45,18 @@ export interface CreatedAbsence {
 /**
  * POST /absences as admin. Returns the new absence id so afterEach can
  * cancel it (cascade-deletes any auto-generated substitutions).
+ *
+ * `schoolId` defaults to the legacy seed-school. Throwaway-school specs
+ * pass `fixture.schoolId` so the absence lands in the per-spec school.
  */
 export async function createAbsenceViaAPI(
   request: APIRequestContext,
   input: CreateAbsenceInput,
+  schoolId: string = SUBSTITUTIONS_SCHOOL_ID,
 ): Promise<CreatedAbsence> {
   const token = await getAdminToken(request);
   const res = await request.post(
-    `${SUBSTITUTIONS_API}/schools/${SUBSTITUTIONS_SCHOOL_ID}/absences`,
+    `${SUBSTITUTIONS_API}/schools/${schoolId}/absences`,
     {
       headers: {
         Authorization: `Bearer ${token}`,
@@ -85,10 +96,11 @@ export async function createAbsenceViaAPI(
 export async function cancelAbsenceViaAPI(
   request: APIRequestContext,
   absenceId: string,
+  schoolId: string = SUBSTITUTIONS_SCHOOL_ID,
 ): Promise<void> {
   const token = await getAdminToken(request);
   const res = await request.delete(
-    `${SUBSTITUTIONS_API}/schools/${SUBSTITUTIONS_SCHOOL_ID}/absences/${absenceId}`,
+    `${SUBSTITUTIONS_API}/schools/${schoolId}/absences/${absenceId}`,
     { headers: { Authorization: `Bearer ${token}` } },
   );
   if (!res.ok() && res.status() !== 404) {
@@ -107,6 +119,7 @@ export async function cancelAbsenceViaAPI(
  */
 export async function listSubstitutionsViaAPI(
   request: APIRequestContext,
+  schoolId: string = SUBSTITUTIONS_SCHOOL_ID,
 ): Promise<
   Array<{
     id: string;
@@ -120,7 +133,7 @@ export async function listSubstitutionsViaAPI(
 > {
   const token = await getAdminToken(request);
   const res = await request.get(
-    `${SUBSTITUTIONS_API}/schools/${SUBSTITUTIONS_SCHOOL_ID}/substitutions`,
+    `${SUBSTITUTIONS_API}/schools/${schoolId}/substitutions`,
     { headers: { Authorization: `Bearer ${token}` } },
   );
   expect(
@@ -150,10 +163,11 @@ export async function assignSubstituteViaAPI(
   request: APIRequestContext,
   substitutionId: string,
   candidateTeacherId: string,
+  schoolId: string = SUBSTITUTIONS_SCHOOL_ID,
 ): Promise<void> {
   const token = await getAdminToken(request);
   const res = await request.post(
-    `${SUBSTITUTIONS_API}/schools/${SUBSTITUTIONS_SCHOOL_ID}/substitutions/${substitutionId}/assign`,
+    `${SUBSTITUTIONS_API}/schools/${schoolId}/substitutions/${substitutionId}/assign`,
     {
       headers: {
         Authorization: `Bearer ${token}`,


### PR DESCRIPTION
Closes #165. Part of #153 (Phase 3.5/6 tracking).

## Summary

- Replaces `seedTimetableRun(SEED_SCHOOL_UUID)` + `active-timetable-run:` advisory lock with `createThrowawaySchool({ withTimetableStack: true })` in 4 admin specs.
- `helpers/substitutions.ts`: all 4 helpers now accept optional `schoolId`, default = legacy `SUBSTITUTIONS_SCHOOL_ID` so Batch B–D callers keep working until they migrate.
- Per-school isolation drops the `.first()` race-defenses on substitution panel assertions — strict matches now safe.

## Files migrated

- `apps/web/e2e/admin-substitutions-list.spec.ts`
- `apps/web/e2e/admin-substitutions-create.spec.ts`
- `apps/web/e2e/admin-timetable-edit-dnd.spec.ts`
- `apps/web/e2e/admin-timetable-edit-perspective.spec.ts`

## D-Direktiven check

- D3: merge only on full-green CI.
- D4: no new chromium-only race skips. The existing `isMobile` skips are viewport/DnD-feature gates, not race-workarounds — preserved.
- D5/D6: #165 already linked to parent #153 + blocked-by chain to #166.

## Test plan

- [ ] CI cross-project parallel run green (chromium + firefox).
- [ ] No `seedTimetableRun` / `cleanupTimetableRun` imports remain in any Batch A spec (verified locally — only docstring mentions of the historical pattern stay).
- [ ] Local stack run on the migrated specs (optional belt-and-braces before merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)