### PR TITLE
chore(e2e): #166 — migrate 6 classbook specs to throwaway-school (Batch B of #153)

### DIFF
--- a/apps/web/e2e/classbook-attendance.spec.ts
+++ b/apps/web/e2e/classbook-attendance.spec.ts
@@ -1,94 +1,75 @@
 /**
  * Issue #81 — Classbook Attendance E2E coverage.
  *
- * Locks the most operationally critical sub-surface of `/classbook/$lessonId`:
- * Lehrer öffnet die Stunde → "Alle anwesend" → cyclet einen Schüler auf
- * ABSENT → speichert (debounced bulk PUT) → reload zeigt den Zustand.
+ * Issue #166 (Phase 3.5/6 Batch B) — migrated to throwaway-school per
+ * CLAUDE.md D4. The `active-timetable-run:SEED_SCHOOL_UUID` advisory lock
+ * is gone; each invocation owns its own school with 3 students. The
+ * resolve/reset helper-calls against the legacy seed school are gone —
+ * the throwaway entry is fresh on every test, so the canonical
+ * "alle anwesend" state holds by construction.
  *
- * CI/local divergence note (2026-05-15): the seed (`apps/api/prisma/seed.ts`)
- * does NOT create any `TimetableLesson` rows — those are produced by a
- * solver run, which only happens in local dev. The first commit of this
- * spec assumed a MONDAY/period-1 seed lesson would exist; CI was red
- * because it doesn't. Switched to the existing `seedTimetableRun()`
- * fixture (timetable-generation-flow.spec.ts and the DnD/perspective
- * specs use the same one) which deterministically seeds one
- * MONDAY/period-1 lesson for class 1A in `beforeAll`. The fixture
- * cleanup (`afterAll`) cascade-deletes the run.
+ * Locks the most operationally critical sub-surface of `/classbook/$lessonId`:
+ * Lehrer öffnet die Stunde → cyclet einen Schüler auf ABSENT → speichert
+ * (debounced bulk PUT) → reload zeigt den Zustand.
  */
 import { test, expect } from '@playwright/test';
 import { loginAsAdmin } from './helpers/login';
 import {
-  CLASSBOOK_SCHOOL_ID,
-  resetAttendanceForEntry,
-  resolveEntryByTimetableLesson,
-} from './helpers/classbook';
-import {
-  cleanupTimetableRun,
-  seedTimetableRun,
-  type TimetableRunFixture,
-} from './fixtures/timetable-run';
+  createThrowawaySchool,
+  type ThrowawaySchoolFixture,
+} from './fixtures/throwaway-school';
+import { useThrowawaySchoolHeader } from './helpers/school-context';
 
 test.describe('Issue #81 — Classbook Attendance (desktop)', () => {
   test.skip(
     ({ isMobile }) => isMobile,
     'Attendance contract is identical across viewports — desktop only for the first lock.',
   );
-  // Per-test seeding instead of beforeAll/afterAll. Reason: describe-
-  // level `test.skip(condition, reason)` does NOT gate beforeAll —
-  // beforeAll runs in EVERY project including skipped ones (CI run
-  // 25905955650 hit `cleanupTimetableRun(undefined)` → TypeError in
-  // the desktop-firefox project). Per-test hooks ARE gated by
-  // test.skip, and `if (!fixture)` matches the existing defensive
-  // pattern in admin-timetable-edit-dnd.spec.ts.
-  let fixture: TimetableRunFixture | undefined;
 
-  test.beforeEach(async ({ page }) => {
-    fixture = await seedTimetableRun(CLASSBOOK_SCHOOL_ID);
+  let fixture: ThrowawaySchoolFixture | undefined;
+
+  test.beforeEach(async ({ context, page }) => {
+    fixture = await createThrowawaySchool({
+      roles: { admin: true, lehrer: true },
+      withClasses: 1,
+      withTimetableStack: true,
+      withStudents: [
+        { firstName: 'Anna', lastName: 'Schueler' },
+        { firstName: 'Berta', lastName: 'Schueler' },
+        { firstName: 'Carla', lastName: 'Schueler' },
+      ],
+      namePrefix: 'E2E-CB-ATTEND',
+    });
+    await useThrowawaySchoolHeader(context, fixture.schoolId);
     await loginAsAdmin(page);
   });
 
-  test.afterEach(async ({ request }) => {
-    if (!fixture) return;
-    // Restore the canonical alle-anwesend state on the seeded entry,
-    // then cascade-delete the fixture run. Pure read-only assertions in
-    // the test body make this cleanup the single source of mutation-
-    // resetting truth.
-    const entry = await resolveEntryByTimetableLesson(
-      request,
-      CLASSBOOK_SCHOOL_ID,
-      fixture.lessonId,
-    );
-    await resetAttendanceForEntry(request, CLASSBOOK_SCHOOL_ID, entry.id);
-    await cleanupTimetableRun(fixture);
-    fixture = undefined;
+  test.afterEach(async () => {
+    if (fixture) {
+      await fixture.cleanup();
+      fixture = undefined;
+    }
   });
 
   test('CB-ATTEND-01: cycle first student to ABSENT → reload persists', async ({
     page,
-    request,
   }) => {
-    // Force the API-side baseline before opening the UI. The cycle
-    // click below assumes PRESENT → ABSENT after one tap; a previously
-    // killed run could otherwise leave a row in LATE or EXCUSED.
-    const entry = await resolveEntryByTimetableLesson(
-      request,
-      CLASSBOOK_SCHOOL_ID,
-      fixture.lessonId,
-    );
-    await resetAttendanceForEntry(request, CLASSBOOK_SCHOOL_ID, entry.id);
+    if (!fixture) throw new Error('fixture not seeded');
+    const lessonId = fixture.timetable!.timetableLessonId;
 
-    await page.goto(`/classbook/${fixture.lessonId}?tab=anwesenheit`);
+    await page.goto(`/classbook/${lessonId}?tab=anwesenheit`);
 
     const list = page.getByRole('list', { name: 'Anwesenheitsliste' });
     await expect(list).toBeVisible();
     const rows = list.getByRole('listitem');
     expect(
       await rows.count(),
-      'seed class 1A must have students',
+      'throwaway class must have students',
     ).toBeGreaterThan(0);
 
-    // Cycle order is PRESENT → ABSENT → LATE → EXCUSED. The API-side
-    // baseline above guarantees one click here lands on ABSENT.
+    // Cycle order is PRESENT → ABSENT → LATE → EXCUSED. A fresh
+    // throwaway entry has all students in the default PRESENT state, so
+    // one click here lands on ABSENT.
     const firstStatus = rows.nth(0).getByRole('button').first();
     await expect(firstStatus).toHaveAccessibleName(/anwesend/i);
     await firstStatus.click();

--- a/apps/web/e2e/classbook-exams.spec.ts
+++ b/apps/web/e2e/classbook-exams.spec.ts
@@ -1,10 +1,14 @@
 /**
  * Issue #82 — Classbook Exam create + collision override flow.
  *
- * Second sub-spec of the Hausaufgaben/Klausuren coverage gap (after
- * PR #99 classbook-homework). Locks the headline regression-risk
- * surface called out in the issue body: the ExamCollisionWarning
- * banner + the "Trotzdem eintragen" override path.
+ * Issue #166 (Phase 3.5/6 Batch B) — migrated to throwaway-school per
+ * CLAUDE.md D4. The `active-timetable-run:SEED_SCHOOL_UUID` advisory lock
+ * is gone; each invocation owns its own ClassSubject so the
+ * "Pruefungen" empty-state is automatic on first load and the
+ * `cleanupE2EExams` prefix-sweep is no longer needed.
+ *
+ * Locks the headline regression-risk surface called out in #82: the
+ * ExamCollisionWarning banner + the "Trotzdem eintragen" override path.
  *
  * Flow:
  *   1. Open /classbook/$lessonId?tab=aufgaben → "Pruefungen" sub-tab.
@@ -18,27 +22,18 @@
  *   6. Submit is BLOCKED until override is clicked (canSubmit gate at
  *      ExamDialog.tsx:73). Click "Trotzdem eintragen" → submit → exam
  *      #2 row also visible.
- *
- * Exercises POST /exams + GET /exams/collision-check + the
- * ExamDialog's forceCreate gate + the ExamCollisionWarning render.
- *
- * Chromium-only-skip per the race-family precedent — every spec on
- * this surface writes Exam rows on the same seed class. Cleanup
- * sweeps by title-prefix so parallel specs only delete their own.
  */
 import { test, expect } from '@playwright/test';
 import { loginAsAdmin } from './helpers/login';
-import { CLASSBOOK_SCHOOL_ID } from './helpers/classbook';
 import {
   EXAMS_TITLE_PREFIX,
-  cleanupE2EExams,
   isoDaysFromNow,
 } from './helpers/exams';
 import {
-  cleanupTimetableRun,
-  seedTimetableRun,
-  type TimetableRunFixture,
-} from './fixtures/timetable-run';
+  createThrowawaySchool,
+  type ThrowawaySchoolFixture,
+} from './fixtures/throwaway-school';
+import { useThrowawaySchoolHeader } from './helpers/school-context';
 
 test.describe('Issue #82 — Classbook Exam create + collision (desktop)', () => {
   test.skip(
@@ -46,34 +41,33 @@ test.describe('Issue #82 — Classbook Exam create + collision (desktop)', () =>
     'Dialog + collision-warning layout is identical across viewports — desktop only for the first lock.',
   );
 
-  let fixture: TimetableRunFixture | undefined;
+  let fixture: ThrowawaySchoolFixture | undefined;
 
-  test.beforeEach(async ({ page }) => {
-    fixture = await seedTimetableRun(CLASSBOOK_SCHOOL_ID);
+  test.beforeEach(async ({ context, page }) => {
+    fixture = await createThrowawaySchool({
+      roles: { admin: true, lehrer: true },
+      withClasses: 1,
+      withTimetableStack: true,
+      namePrefix: 'E2E-CB-EX',
+    });
+    await useThrowawaySchoolHeader(context, fixture.schoolId);
     await loginAsAdmin(page);
   });
 
-  test.afterEach(async ({ request }) => {
-    // Sweep ALL E2E-EX- rows. No FK to TimetableRun, so
-    // cleanupTimetableRun does NOT cascade to Exam rows; they
-    // accumulate across specs without this explicit sweep.
-    await cleanupE2EExams(request, `${EXAMS_TITLE_PREFIX}CREATE-`);
+  test.afterEach(async () => {
     if (fixture) {
-      await cleanupTimetableRun(fixture);
+      await fixture.cleanup();
       fixture = undefined;
     }
   });
 
   test('CB-EX-01: create exam, then second exam same day → collision warning → override → both visible', async ({
     page,
-    request,
   }) => {
     if (!fixture) throw new Error('fixture not seeded');
+    const lessonId = fixture.timetable!.timetableLessonId;
 
-    // API-side baseline so the empty-state check below is honest.
-    await cleanupE2EExams(request, `${EXAMS_TITLE_PREFIX}CREATE-`);
-
-    await page.goto(`/classbook/${fixture.lessonId}?tab=aufgaben`);
+    await page.goto(`/classbook/${lessonId}?tab=aufgaben`);
 
     // Switch to the Pruefungen sub-tab. The HomeworkExamList Tabs
     // default to hausaufgaben; we drive the click explicitly so a
@@ -101,9 +95,8 @@ test.describe('Issue #82 — Classbook Exam create + collision (desktop)', () =>
     await page.getByLabel('Datum *').fill(sharedDate);
 
     // No collision yet — ExamCollisionWarning must NOT render here.
-    // The negative-presence check guards against a backend mis-scope
-    // that flags ANY existing exam as a collision (would have flagged
-    // a parallel spec's row).
+    // Per-school isolation means there's no parallel-spec exam that
+    // could trigger a false-positive collision.
     await expect(
       page.getByRole('alert').filter({ hasText: 'Achtung: Am' }),
       'no collision is expected for the FIRST exam on this date — the alert must not render',

--- a/apps/web/e2e/classbook-grades.spec.ts
+++ b/apps/web/e2e/classbook-grades.spec.ts
@@ -1,9 +1,13 @@
 /**
  * Issue #81 — Classbook Grade-Matrix create flow.
  *
- * Fourth sub-spec for the Klassenbuch surface (after #89 attendance +
- * #95 inhalt + #96 notizen). Locks the "Noten" tab's create-flow on
- * /classbook/$lessonId:
+ * Issue #166 (Phase 3.5/6 Batch B) — migrated to throwaway-school per
+ * CLAUDE.md D4. The `active-timetable-run:SEED_SCHOOL_UUID` advisory lock
+ * is gone; each invocation owns its own ClassSubject so the GradeMatrix
+ * empty-state is automatic and the `cleanupGradesForClassSubject` sweep
+ * is no longer needed.
+ *
+ * Locks the "Noten" tab's create-flow on /classbook/$lessonId:
  *   1. Open the lesson with ?tab=noten → "Noch keine Noten erfasst"
  *      empty state for a fresh ClassSubject.
  *   2. Click "Note hinzufuegen" → GradeEntryDialog opens.
@@ -13,24 +17,14 @@
  *   5. Dialog closes, GradeMatrix renders the student row with the
  *      grade column AND a weighted average. The average for one
  *      MITARBEIT-2 should display as "2.0".
- *
- * Exercises POST /classbook/grades + the GradeEntryDialog form +
- * GradeMatrix render + the grade-average util (one grade ⇒ avg =
- * that grade's value). Edit + delete + category-filter + weight
- * adjustment are deferred to follow-up sub-specs.
- *
- * Chromium-only-skip per the race-family precedent — every spec on
- * this surface writes Grade rows under the same seed ClassSubject.
  */
 import { test, expect } from '@playwright/test';
 import { loginAsAdmin } from './helpers/login';
-import { CLASSBOOK_SCHOOL_ID } from './helpers/classbook';
-import { cleanupGradesForClassSubject } from './helpers/grades';
 import {
-  cleanupTimetableRun,
-  seedTimetableRun,
-  type TimetableRunFixture,
-} from './fixtures/timetable-run';
+  createThrowawaySchool,
+  type ThrowawaySchoolFixture,
+} from './fixtures/throwaway-school';
+import { useThrowawaySchoolHeader } from './helpers/school-context';
 
 test.describe('Issue #81 — Classbook Grade-Matrix (desktop)', () => {
   test.skip(
@@ -38,37 +32,40 @@ test.describe('Issue #81 — Classbook Grade-Matrix (desktop)', () => {
     'GradeMatrix layout is identical across viewports — desktop only for the first lock.',
   );
 
-  let fixture: TimetableRunFixture | undefined;
+  let fixture: ThrowawaySchoolFixture | undefined;
 
-  test.beforeEach(async ({ page }) => {
-    fixture = await seedTimetableRun(CLASSBOOK_SCHOOL_ID);
+  test.beforeEach(async ({ context, page }) => {
+    fixture = await createThrowawaySchool({
+      roles: { admin: true, lehrer: true },
+      withClasses: 1,
+      withTimetableStack: true,
+      withStudents: [
+        { firstName: 'Anna', lastName: 'Schueler' },
+        { firstName: 'Berta', lastName: 'Schueler' },
+        { firstName: 'Carla', lastName: 'Schueler' },
+      ],
+      namePrefix: 'E2E-CB-GRADE',
+    });
+    await useThrowawaySchoolHeader(context, fixture.schoolId);
     await loginAsAdmin(page);
   });
 
-  test.afterEach(async ({ request }) => {
-    if (!fixture) return;
-    // Sweep every grade on this classSubject. The Grade FK to
-    // ClassSubject is a hard reference (no cascade-from-TimetableRun),
-    // so cleanupTimetableRun does NOT cascade to Grade rows; they
-    // would otherwise survive into the next test's GradeMatrix and
-    // turn the empty-state check below into a strict-mode flake.
-    await cleanupGradesForClassSubject(request, fixture.classSubjectId);
-    await cleanupTimetableRun(fixture);
-    fixture = undefined;
+  test.afterEach(async () => {
+    if (fixture) {
+      await fixture.cleanup();
+      fixture = undefined;
+    }
   });
 
   test('CB-GRADE-01: create grade via dialog → toast → student row + average visible', async ({
     page,
-    request,
   }) => {
     if (!fixture) throw new Error('fixture not seeded');
+    const lessonId = fixture.timetable!.timetableLessonId;
 
-    // API-side baseline so the empty-state assertion is honest.
-    await cleanupGradesForClassSubject(request, fixture.classSubjectId);
+    await page.goto(`/classbook/${lessonId}?tab=noten`);
 
-    await page.goto(`/classbook/${fixture.lessonId}?tab=noten`);
-
-    // Empty state on a freshly-cleared classSubject (GradeMatrix.tsx:206).
+    // Empty state on a fresh ClassSubject (GradeMatrix.tsx:206).
     await expect(
       page.getByRole('heading', { name: 'Noch keine Noten erfasst' }),
       'fresh ClassSubject must render the GradeMatrix empty state',
@@ -82,7 +79,7 @@ test.describe('Issue #81 — Classbook Grade-Matrix (desktop)', () => {
     ).toBeVisible();
 
     // Pick first student. The select is populated from the matrix's
-    // studentList → all class-1A members. The actual student doesn't
+    // studentList → all class members. The actual student doesn't
     // matter for the create-flow lock; deterministic first pick keeps
     // the assertion stable.
     await page.getByRole('combobox', { name: 'Schueler/in' }).click();

--- a/apps/web/e2e/classbook-homework.spec.ts
+++ b/apps/web/e2e/classbook-homework.spec.ts
@@ -1,8 +1,14 @@
 /**
  * Issue #82 — Classbook Homework create flow.
  *
- * First sub-spec of the Hausaufgaben/Klausuren coverage gap. Locks the
- * create-flow on the "Aufgaben" tab of /classbook/$lessonId:
+ * Issue #166 (Phase 3.5/6 Batch B) — migrated to throwaway-school per
+ * CLAUDE.md D4. The `active-timetable-run:SEED_SCHOOL_UUID` advisory lock
+ * is gone; each invocation owns its own ClassSubject so the
+ * "Hausaufgaben" empty-state is automatic on first load and the
+ * `cleanupE2EHomework` prefix-sweep is no longer needed (the throwaway
+ * cascade-delete takes the Homework rows with the school).
+ *
+ * Locks the create-flow on the "Aufgaben" tab of /classbook/$lessonId:
  *   1. Open the lesson with ?tab=aufgaben → "Hausaufgaben" tab shows the
  *      empty state for a fresh ClassSubject.
  *   2. Click "Hausaufgabe erstellen" → HomeworkDialog opens.
@@ -12,28 +18,19 @@
  *      refetch surfaces the new row in the list.
  *
  * Exercises POST /homework + the HomeworkDialog form + the
- * HomeworkExamList Hausaufgaben-tab render. Edit + delete + the Exam
- * surface (which has the ExamCollisionWarning regression risk per the
- * issue body) are deferred to follow-up sub-specs.
- *
- * Chromium-only-skip per the race-family precedent — every spec on
- * this surface writes Homework rows on the shared seed ClassSubject.
- * Cleanup sweeps by title-prefix so parallel specs only delete their
- * own rows.
+ * HomeworkExamList Hausaufgaben-tab render.
  */
 import { test, expect } from '@playwright/test';
 import { loginAsAdmin } from './helpers/login';
-import { CLASSBOOK_SCHOOL_ID } from './helpers/classbook';
 import {
   HOMEWORK_TITLE_PREFIX,
-  cleanupE2EHomework,
   isoDaysFromNow,
 } from './helpers/homework';
 import {
-  cleanupTimetableRun,
-  seedTimetableRun,
-  type TimetableRunFixture,
-} from './fixtures/timetable-run';
+  createThrowawaySchool,
+  type ThrowawaySchoolFixture,
+} from './fixtures/throwaway-school';
+import { useThrowawaySchoolHeader } from './helpers/school-context';
 
 test.describe('Issue #82 — Classbook Homework create (desktop)', () => {
   test.skip(
@@ -41,42 +38,37 @@ test.describe('Issue #82 — Classbook Homework create (desktop)', () => {
     'Dialog layout is identical across viewports — desktop only for the first lock.',
   );
 
-  let fixture: TimetableRunFixture | undefined;
+  let fixture: ThrowawaySchoolFixture | undefined;
 
-  test.beforeEach(async ({ page }) => {
-    fixture = await seedTimetableRun(CLASSBOOK_SCHOOL_ID);
+  test.beforeEach(async ({ context, page }) => {
+    fixture = await createThrowawaySchool({
+      roles: { admin: true, lehrer: true },
+      withClasses: 1,
+      withTimetableStack: true,
+      namePrefix: 'E2E-CB-HW',
+    });
+    await useThrowawaySchoolHeader(context, fixture.schoolId);
     await loginAsAdmin(page);
   });
 
-  test.afterEach(async ({ request }) => {
-    // Sweep ALL E2E-HW- rows on this school. The Homework FK to
-    // ClassBookEntry is `onDelete: SetNull` (schema.prisma:1425) and
-    // there's no FK to TimetableRun, so cleanupTimetableRun() does NOT
-    // cascade to Homework rows; they accumulate across specs without
-    // this explicit sweep.
-    await cleanupE2EHomework(request, `${HOMEWORK_TITLE_PREFIX}CREATE-`);
+  test.afterEach(async () => {
     if (fixture) {
-      await cleanupTimetableRun(fixture);
+      await fixture.cleanup();
       fixture = undefined;
     }
   });
 
   test('CB-HW-01: create homework via dialog → row visible in Hausaufgaben tab', async ({
     page,
-    request,
   }) => {
     if (!fixture) throw new Error('fixture not seeded');
+    const lessonId = fixture.timetable!.timetableLessonId;
 
-    // Make sure no leftover homework from a killed prior run pollutes
-    // the assertions below — the empty-state and the row-visibility
-    // checks both depend on a known starting state.
-    await cleanupE2EHomework(request, `${HOMEWORK_TITLE_PREFIX}CREATE-`);
-
-    await page.goto(`/classbook/${fixture.lessonId}?tab=aufgaben`);
+    await page.goto(`/classbook/${lessonId}?tab=aufgaben`);
 
     // The empty state is rendered when homework.length === 0
-    // (HomeworkExamList.tsx:61). A polluted DB or a wrong tab default
-    // would fail this loudly.
+    // (HomeworkExamList.tsx:61). Throwaway guarantees an empty
+    // ClassSubject on every test.
     await expect(
       page.getByText('Keine Hausaufgaben', { exact: true }),
       'fresh ClassSubject must render the Hausaufgaben empty state',
@@ -96,8 +88,9 @@ test.describe('Issue #82 — Classbook Homework create (desktop)', () => {
       page.getByRole('heading', { name: 'Hausaufgabe erstellen', level: 2 }),
     ).toBeVisible();
 
-    // Timestamped title doubles as the cleanup discriminator (the
-    // prefix-sweep in afterEach hooks on HOMEWORK_TITLE_PREFIX).
+    // Timestamped title doubles as a regression-friendly discriminator
+    // even though throwaway-school isolation makes the prefix-sweep no
+    // longer necessary.
     const title = `${HOMEWORK_TITLE_PREFIX}CREATE-${Date.now()} — Mathe Kapitel 3`;
     await page.getByLabel('Titel *').fill(title);
     await page

--- a/apps/web/e2e/classbook-lesson-content.spec.ts
+++ b/apps/web/e2e/classbook-lesson-content.spec.ts
@@ -1,7 +1,11 @@
 /**
  * Issue #81 — Classbook Lesson-Content E2E coverage.
  *
- * Second sub-spec for the Klassenbuch surface (after #89 attendance).
+ * Issue #166 (Phase 3.5/6 Batch B) — migrated to throwaway-school per
+ * CLAUDE.md D4. The `active-timetable-run:SEED_SCHOOL_UUID` advisory lock
+ * is gone; each invocation owns its own ClassBookEntry (resolved on first
+ * GET), so the API-side reset before the test body is no longer needed.
+ *
  * Locks the auto-save flow on the "Inhalt" tab of /classbook/$lessonId:
  *   1. Open the lesson page with ?tab=inhalt.
  *   2. Fill the Thema textarea, blur (debounced 1 s PATCH /content).
@@ -10,30 +14,17 @@
  *      race the debounce).
  *   4. Reload → assert the value persists.
  *
- * Why this slice: it exercises the LessonContentForm blur-save loop, the
- * PATCH /classbook/:entryId/content endpoint, and the by-timetable-lesson
- * resolver chain (TimetableLesson → ClassBookEntry auto-create).
- * Lehrstoff + Hausaufgabe share the exact same hook + endpoint, so locking
- * one field locks all three at the wire level; field-specific UI quirks
- * (e.g. Thema character counter at >50 chars) can be added in a follow-up
- * spec when they become regression-prone.
- *
- * Chromium-only-skip per the race-family precedent — every spec on this
- * surface mutates the SAME seeded ClassBookEntry. Same pattern as
- * classbook-attendance.spec.ts.
+ * Exercises the LessonContentForm blur-save loop, PATCH
+ * /classbook/:entryId/content, and the by-timetable-lesson resolver
+ * chain (TimetableLesson → ClassBookEntry auto-create).
  */
 import { test, expect } from '@playwright/test';
 import { loginAsAdmin } from './helpers/login';
 import {
-  CLASSBOOK_SCHOOL_ID,
-  resetLessonContent,
-  resolveEntryByTimetableLesson,
-} from './helpers/classbook';
-import {
-  cleanupTimetableRun,
-  seedTimetableRun,
-  type TimetableRunFixture,
-} from './fixtures/timetable-run';
+  createThrowawaySchool,
+  type ThrowawaySchoolFixture,
+} from './fixtures/throwaway-school';
+import { useThrowawaySchoolHeader } from './helpers/school-context';
 
 test.describe('Issue #81 — Classbook Lesson-Content (desktop)', () => {
   test.skip(
@@ -41,63 +32,43 @@ test.describe('Issue #81 — Classbook Lesson-Content (desktop)', () => {
     'Content form is identical across viewports — desktop only for the first lock.',
   );
 
-  // Per-test seeding — describe-level test.skip does NOT gate beforeAll
-  // (CI lesson from #81 attendance run). Per-test hooks ARE gated.
-  let fixture: TimetableRunFixture | undefined;
+  let fixture: ThrowawaySchoolFixture | undefined;
 
-  test.beforeEach(async ({ page }) => {
-    fixture = await seedTimetableRun(CLASSBOOK_SCHOOL_ID);
+  test.beforeEach(async ({ context, page }) => {
+    fixture = await createThrowawaySchool({
+      roles: { admin: true, lehrer: true },
+      withClasses: 1,
+      withTimetableStack: true,
+      namePrefix: 'E2E-CB-CONTENT',
+    });
+    await useThrowawaySchoolHeader(context, fixture.schoolId);
     await loginAsAdmin(page);
   });
 
-  test.afterEach(async ({ request }) => {
-    if (!fixture) return;
-    // Reset content fields BEFORE cascade-deleting the run. The
-    // ClassBookEntry is NOT FK-linked to TimetableRun (it's keyed on
-    // classSubjectId + date + period + weekType — schema.prisma:950), so
-    // the run's cascade-delete does not remove the entry. Without this
-    // reset, the next test would auto-resolve to an entry pre-populated
-    // with this test's Thema content.
-    const entry = await resolveEntryByTimetableLesson(
-      request,
-      CLASSBOOK_SCHOOL_ID,
-      fixture.lessonId,
-    );
-    await resetLessonContent(request, CLASSBOOK_SCHOOL_ID, entry.id);
-    await cleanupTimetableRun(fixture);
-    fixture = undefined;
+  test.afterEach(async () => {
+    if (fixture) {
+      await fixture.cleanup();
+      fixture = undefined;
+    }
   });
 
   test('CB-CONTENT-01: fill Thema → blur → "Gespeichert" → reload persists', async ({
     page,
-    request,
   }) => {
     if (!fixture) throw new Error('fixture not seeded');
+    const lessonId = fixture.timetable!.timetableLessonId;
 
-    // API-side baseline: clear content fields. A previously killed run
-    // could otherwise leave a Thema value in the row, and the reload
-    // assertion below would pass against state we didn't put there.
-    const entry = await resolveEntryByTimetableLesson(
-      request,
-      CLASSBOOK_SCHOOL_ID,
-      fixture.lessonId,
-    );
-    await resetLessonContent(request, CLASSBOOK_SCHOOL_ID, entry.id);
-
-    await page.goto(`/classbook/${fixture.lessonId}?tab=inhalt`);
+    await page.goto(`/classbook/${lessonId}?tab=inhalt`);
 
     const themaField = page.getByLabel('Thema', { exact: true });
     await expect(themaField).toBeVisible();
     await expect(
       themaField,
-      'Thema must start empty — reset wiped any prior content',
+      'Thema must start empty — fresh throwaway entry has no content',
     ).toHaveValue('');
 
-    // Timestamped value guards against the (unlikely) case that a sibling
-    // spec writes a fixed-string Thema between our PATCH-reset and the
-    // page reload. If we asserted on a literal like "Photosynthese" and
-    // a parallel test wrote the same, the persistence check would pass
-    // against state we didn't produce.
+    // Timestamped value keeps the assertion specific to this run even
+    // though the per-spec throwaway school already isolates state.
     const themaValue = `E2E Thema ${Date.now()}`;
     await themaField.fill(themaValue);
 

--- a/apps/web/e2e/classbook-student-notes.spec.ts
+++ b/apps/web/e2e/classbook-student-notes.spec.ts
@@ -1,39 +1,30 @@
 /**
  * Issue #81 — Classbook Student-Notes E2E coverage.
  *
- * Third sub-spec for the Klassenbuch surface (after #89 attendance +
- * Inhalt-tab content). Locks the "Notizen" tab's create-flow on
- * /classbook/$lessonId:
+ * Issue #166 (Phase 3.5/6 Batch B) — migrated to throwaway-school per
+ * CLAUDE.md D4. The `active-timetable-run:SEED_SCHOOL_UUID` advisory lock
+ * is gone; each invocation owns its own ClassBookEntry (no leftover
+ * notes from a killed prior run can pollute the empty-state check).
+ *
+ * Locks the "Notizen" tab's create-flow on /classbook/$lessonId:
  *   1. Open the lesson with ?tab=notizen → "Keine Notizen vorhanden".
  *   2. Click "Notiz hinzufuegen" → inline StudentNoteForm appears.
  *   3. Pick a student, type a timestamped content, click submit.
- *   4. Wait for "Notiz gespeichert" toast (the on-screen wire-success
- *      signal — without it the next assertion races the mutation).
+ *   4. Wait for "Notiz gespeichert" toast.
  *   5. Empty-state must be gone + the note content appears under the
  *      student's section header.
  *
- * Why this slice: it exercises POST /classbook/:entryId/notes + the
- * useCreateNote mutation invalidation + the GET /notes refetch + the
- * grouped-by-student rendering in StudentNoteList. Edit + delete +
- * private-flag visibility are deferred to follow-up sub-specs once the
- * create-loop is regression-locked.
- *
- * Chromium-only-skip per the race-family precedent — every spec on this
- * surface mutates the SAME seeded ClassBookEntry. Same pattern as
- * classbook-attendance and classbook-lesson-content.
+ * Exercises POST /classbook/:entryId/notes + the useCreateNote
+ * mutation invalidation + the GET /notes refetch + the grouped-by-
+ * student rendering in StudentNoteList.
  */
 import { test, expect } from '@playwright/test';
 import { loginAsAdmin } from './helpers/login';
 import {
-  CLASSBOOK_SCHOOL_ID,
-  cleanupNotesForEntry,
-  resolveEntryByTimetableLesson,
-} from './helpers/classbook';
-import {
-  cleanupTimetableRun,
-  seedTimetableRun,
-  type TimetableRunFixture,
-} from './fixtures/timetable-run';
+  createThrowawaySchool,
+  type ThrowawaySchoolFixture,
+} from './fixtures/throwaway-school';
+import { useThrowawaySchoolHeader } from './helpers/school-context';
 
 test.describe('Issue #81 — Classbook Student-Notes (desktop)', () => {
   test.skip(
@@ -41,53 +32,41 @@ test.describe('Issue #81 — Classbook Student-Notes (desktop)', () => {
     'Note-create flow is identical across viewports — desktop only for the first lock.',
   );
 
-  // Per-test seeding — describe-level test.skip does NOT gate beforeAll
-  // (CI lesson from #81 attendance). Per-test hooks ARE gated.
-  let fixture: TimetableRunFixture | undefined;
+  let fixture: ThrowawaySchoolFixture | undefined;
 
-  test.beforeEach(async ({ page }) => {
-    fixture = await seedTimetableRun(CLASSBOOK_SCHOOL_ID);
+  test.beforeEach(async ({ context, page }) => {
+    fixture = await createThrowawaySchool({
+      roles: { admin: true, lehrer: true },
+      withClasses: 1,
+      withTimetableStack: true,
+      withStudents: [
+        { firstName: 'Anna', lastName: 'Schueler' },
+        { firstName: 'Berta', lastName: 'Schueler' },
+        { firstName: 'Carla', lastName: 'Schueler' },
+      ],
+      namePrefix: 'E2E-CB-NOTES',
+    });
+    await useThrowawaySchoolHeader(context, fixture.schoolId);
     await loginAsAdmin(page);
   });
 
-  test.afterEach(async ({ request }) => {
-    if (!fixture) return;
-    // Sweep notes BEFORE cascade-deleting the run. ClassBookEntry has no
-    // FK back to TimetableRun (it's keyed on classSubjectId + date +
-    // period + weekType — schema.prisma:950), so cleanupTimetableRun does
-    // NOT cascade to it. Notes attached to the entry would leak into the
-    // next test's "Keine Notizen vorhanden" empty-state assertion.
-    const entry = await resolveEntryByTimetableLesson(
-      request,
-      CLASSBOOK_SCHOOL_ID,
-      fixture.lessonId,
-    );
-    await cleanupNotesForEntry(request, CLASSBOOK_SCHOOL_ID, entry.id);
-    await cleanupTimetableRun(fixture);
-    fixture = undefined;
+  test.afterEach(async () => {
+    if (fixture) {
+      await fixture.cleanup();
+      fixture = undefined;
+    }
   });
 
   test('CB-NOTES-01: create note via inline form → toast → row visible in grouped list', async ({
     page,
-    request,
   }) => {
     if (!fixture) throw new Error('fixture not seeded');
+    const lessonId = fixture.timetable!.timetableLessonId;
 
-    // API-side baseline: clear any leftover notes from a previously
-    // killed run on this same entry. Without it the "Keine Notizen
-    // vorhanden" empty-state check below could legitimately fail before
-    // the test does anything wrong.
-    const entry = await resolveEntryByTimetableLesson(
-      request,
-      CLASSBOOK_SCHOOL_ID,
-      fixture.lessonId,
-    );
-    await cleanupNotesForEntry(request, CLASSBOOK_SCHOOL_ID, entry.id);
+    await page.goto(`/classbook/${lessonId}?tab=notizen`);
 
-    await page.goto(`/classbook/${fixture.lessonId}?tab=notizen`);
-
-    // Empty state must show on a freshly-cleared entry. The
-    // StudentNoteList renders this verbatim (StudentNoteList.tsx:151).
+    // Empty state must show on a fresh entry. The StudentNoteList
+    // renders this verbatim (StudentNoteList.tsx:151).
     await expect(
       page.getByText('Keine Notizen vorhanden'),
       'fresh entry must render the StudentNoteList empty state',
@@ -96,15 +75,13 @@ test.describe('Issue #81 — Classbook Student-Notes (desktop)', () => {
     await page.getByRole('button', { name: 'Notiz hinzufuegen' }).click();
 
     // Student select — the form pulls students from useAttendance which
-    // returns all class-1A members. Picking ANY student is sufficient
-    // for this regression lock (the create-flow itself is what we test;
-    // which student doesn't matter). Take the first option for
-    // determinism.
+    // returns all class members. Picking ANY student is sufficient for
+    // this regression lock; first option for determinism.
     await page.getByRole('combobox', { name: 'Schueler/in' }).click();
     const firstOption = page.getByRole('option').first();
     await expect(
       firstOption,
-      'student select must surface at least one option from the 1A roster',
+      'student select must surface at least one option from the throwaway roster',
     ).toBeVisible();
     const pickedStudentName = (await firstOption.textContent())?.trim() ?? '';
     expect(
@@ -113,16 +90,12 @@ test.describe('Issue #81 — Classbook Student-Notes (desktop)', () => {
     ).toBeGreaterThan(0);
     await firstOption.click();
 
-    // Timestamped content guards against the (unlikely) case that a
-    // sibling spec writes a fixed string Notiz between our sweep and
-    // the page reload. The full content is asserted on screen below
-    // (NoteCard renders the content verbatim).
     const noteContent = `E2E Notiz ${Date.now()}`;
     await page.getByLabel('Notiz', { exact: true }).fill(noteContent);
 
     // Submit. The form's submit button has the label "Notiz hinzufuegen"
-    // in CREATE mode, same as the action-bar button — we scope by the
-    // surrounding card region to disambiguate.
+    // in CREATE mode, same as the action-bar button — we scope to .last()
+    // to disambiguate (the form-submit is rendered after the action-bar).
     await page
       .getByRole('button', { name: 'Notiz hinzufuegen' })
       .last()


### PR DESCRIPTION
Closes #166. Part of #153 (Phase 3.5/6 tracking).

## Summary

- Replaces `seedTimetableRun(CLASSBOOK_SCHOOL_ID)` + `active-timetable-run:` advisory lock with `createThrowawaySchool({ withTimetableStack: true, withStudents? })` across all 6 classbook specs.
- Specs needing per-student interaction (attendance, notes, grades) seed 3 students inline via `withStudents`; the others lean on the lesson + entry auto-create resolver chain.
- Drops the API-side baseline/cleanup helpers used to defend against shared-tenant leftover state — throwaway-cascade covers them.

## Files migrated

- `apps/web/e2e/classbook-attendance.spec.ts`
- `apps/web/e2e/classbook-homework.spec.ts`
- `apps/web/e2e/classbook-exams.spec.ts`
- `apps/web/e2e/classbook-lesson-content.spec.ts`
- `apps/web/e2e/classbook-student-notes.spec.ts`
- `apps/web/e2e/classbook-grades.spec.ts`

## D-Direktiven check

- D3: merge only on full-green CI.
- D4: no new chromium-only race skips. Existing `isMobile` skips are viewport gates and stay.
- D5/D6: #166 linked to parent #153 + was blocked-by #165 (now CLOSED).

## Test plan

- [ ] CI cross-project parallel run green (chromium + firefox).
- [ ] No `seedTimetableRun` / `CLASSBOOK_SCHOOL_ID` runtime imports remain in any Batch B spec (only docstring history mentions stay).
- [ ] Throwaway cascade verified — no orphan Homework/Exam/Note/Grade rows surviving the school delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)