### PR TITLE
chore(e2e): #167 — migrate 5 timetable-view specs + rooms-filter to throwaway-school (Batch C of #153)

### DIFF
--- a/apps/web/e2e/fixtures/throwaway-school.ts
+++ b/apps/web/e2e/fixtures/throwaway-school.ts
@@ -243,6 +243,18 @@ export interface ThrowawaySchoolOptions {
    * (otherwise there is no Teacher row to assign).
    */
   withKlassenvorstand?: 'lehrer';
+  /**
+   * Issue #167 — create a `Student` row for the kc-schueler Person and
+   * enroll it in `classIds[0]` so the schueler-user's
+   * `/users/me`.classId resolves through `Person.student.classId` (per
+   * user-context.service.ts:90). Required by the timetable-schueler-view
+   * spec — without it, `/timetable` sees no class context for the
+   * logged-in schueler and renders the empty-state.
+   *
+   * Requires `roles.schueler: true` and `withClasses >= 1`. The new
+   * Student id is exposed via `ThrowawaySchoolFixture.schuelerStudentId`.
+   */
+  withSchuelerEnrollment?: boolean;
 }
 
 export interface ThrowawayTimetableStack {
@@ -328,6 +340,12 @@ export interface ThrowawaySchoolFixture {
   secondTeacher?: ThrowawaySecondTeacherLesson;
   /** Issue #138 — Student.id values matching the `withStudents` indexes. */
   studentIds: string[];
+  /**
+   * Issue #167 — Student.id created for the kc-schueler Person when
+   * `withSchuelerEnrollment: true` was passed. The Student is enrolled in
+   * `classIds[0]`.
+   */
+  schuelerStudentId?: string;
   /**
    * Issue #151 — Parent.id values per linked role, populated when
    * `withParentLinks` was passed. Only the keys for roles actually linked
@@ -456,6 +474,16 @@ export async function createThrowawaySchool(
       'createThrowawaySchool: withKlassenvorstand=lehrer requires roles.lehrer (otherwise the timetable stack picks a fixture-only Teacher whose Person is not the seed lehrer)',
     );
   }
+  if (options.withSchuelerEnrollment && !roles.schueler) {
+    throw new Error(
+      'createThrowawaySchool: withSchuelerEnrollment requires roles.schueler (no schueler Person to bind a Student row to)',
+    );
+  }
+  if (options.withSchuelerEnrollment && withClasses < 1) {
+    throw new Error(
+      'createThrowawaySchool: withSchuelerEnrollment requires withClasses >= 1 (need a class to enroll the schueler into)',
+    );
+  }
 
   const prisma = buildPrisma();
   try {
@@ -511,6 +539,33 @@ export async function createThrowawaySchool(
         },
       });
       personIds[role] = person.id;
+    }
+
+    // Issue #167 — bind kc-schueler Person to a Student row in classIds[0]
+    // so `/users/me` resolves `classId` for the logged-in schueler (per
+    // user-context.service.ts:88-92). Without this row the
+    // timetable-schueler-view spec sees no class context and the
+    // /timetable page short-circuits to the empty-state.
+    let schuelerStudentId: string | undefined;
+    if (options.withSchuelerEnrollment) {
+      const schuelerPersonId = personIds.schueler;
+      // Defensive — the validation above already guarantees this, but a
+      // localized invariant check keeps the cleanup-by-cascade story
+      // honest if the option set is reordered.
+      if (!schuelerPersonId) {
+        throw new Error(
+          'createThrowawaySchool: withSchuelerEnrollment expected the schueler Person to be created (roles.schueler must be true)',
+        );
+      }
+      const studentRow = await prisma.student.create({
+        data: {
+          personId: schuelerPersonId,
+          schoolId: school.id,
+          classId: classIds[0],
+          studentNumber: `${namePrefix}-SCH-${suffix}`,
+        },
+      });
+      schuelerStudentId = studentRow.id;
     }
 
     let timetable: ThrowawayTimetableStack | undefined;
@@ -882,6 +937,7 @@ export async function createThrowawaySchool(
       timetable,
       secondTeacher,
       studentIds,
+      schuelerStudentId,
       parentIds,
       classBookEntryId,
       timetableEditId,

--- a/apps/web/e2e/rooms-filter.spec.ts
+++ b/apps/web/e2e/rooms-filter.spec.ts
@@ -1,6 +1,13 @@
 /**
  * Quick task 260426-fwb — Rooms-filter E2E regression guard (desktop).
  *
+ * Issue #167 (Phase 3.5/6 Batch C) — migrated to throwaway-school per
+ * CLAUDE.md D4. The `active-timetable-run:SEED_SCHOOL_UUID` advisory lock
+ * is gone; each invocation owns its own school with exactly one Room
+ * (the timetable-stack's fixture room, type KLASSENZIMMER). The filter
+ * tests now run against a one-room tenant — Test 1 hits that room as a
+ * Klassenzimmer match; Test 2 picks Werkraum and gets the empty state.
+ *
  * Drives the running RoomsPage as admin and proves the filter from commit
  * 5378ec0 (2026-04-02) is still wired correctly end-to-end:
  *
@@ -13,44 +20,23 @@
  *     appears anywhere in the request URL.
  *
  *   Test 2 — UI-level guard for hasActiveFilters branching:
- *     Selecting Raumtyp=Werkraum yields zero matches. After #51 the
- *     prisma:seed creates 3 KLASSENZIMMER + Turnsaal + EDV-Raum +
- *     Musikraum, but neither Werkraum nor Labor — Werkraum is the
- *     stable empty-filter target. The empty-state Card must show the
- *     filter-aware copy ("Keine passenden Raeume") and NOT the legacy
- *     un-branched copy ("Keine Raeume angelegt"). Reverting the
- *     hasActiveFilters branch in rooms/index.tsx fails this assertion.
- *
- * Closes deferred items 2 + 3 from
- *   .planning/debug/resolved/room-filter-not-working.md
- * Item 1 (extract RoomType to packages/shared) remains deferred per the
- * original debug session's hardening note (gated on a second consumer).
- *
- * Fixture choice — REUSE seedTimetableRun:
- *   - Self-provisions a Room with roomType KLASSENZIMMER (timetable-run.ts:240-249)
- *     when the seed school has none — kept for back-compat even though
- *     prisma:seed now creates rooms (since #51). Test 1 still finds a
- *     Klassenzimmer match. Test 2 deliberately picks Werkraum (which
- *     neither seed nor fixture provisions) for guaranteed zero matches.
- *   - Activates MON–FRI school days so the availability grid renders.
- *   - Same fixture used by admin-timetable-edit-perspective.spec.ts —
- *     keeping the contract in one place reduces fixture drift.
- *   If a future seed adds a WERKRAUM room, Test 2 will start failing —
- *   that's the correct signal. Flip the assertion to LABOR at that point.
+ *     Selecting Raumtyp=Werkraum yields zero matches in the throwaway
+ *     school (only the fixture KLASSENZIMMER exists). The empty-state
+ *     Card must show the filter-aware copy ("Keine passenden Raeume") and
+ *     NOT the legacy un-branched copy ("Keine Raeume angelegt").
+ *     Reverting the hasActiveFilters branch in rooms/index.tsx fails this
+ *     assertion.
  *
  * Desktop-only via file naming (no `mobile` infix) — playwright.config.ts:42
  * routes `*.spec.ts` files to the desktop project automatically.
  */
 import { test, expect } from '@playwright/test';
-import { SEED_SCHOOL_UUID } from './fixtures/seed-uuids';
 import { loginAsAdmin } from './helpers/login';
 import {
-  seedTimetableRun,
-  cleanupTimetableRun,
-  type TimetableRunFixture,
-} from './fixtures/timetable-run';
-
-const SCHOOL_ID = process.env.E2E_SCHOOL_ID ?? SEED_SCHOOL_UUID;
+  createThrowawaySchool,
+  type ThrowawaySchoolFixture,
+} from './fixtures/throwaway-school';
+import { useThrowawaySchoolHeader } from './helpers/school-context';
 
 test.describe('Rooms-filter regression — German enum + filter-aware empty state (desktop)', () => {
   // Mobile projects run their own viewport-sized specs; this regression
@@ -62,10 +48,16 @@ test.describe('Rooms-filter regression — German enum + filter-aware empty stat
     'Rooms-filter behavior is identical across viewports — desktop only.',
   );
 
-  let fixture: TimetableRunFixture;
+  let fixture: ThrowawaySchoolFixture | undefined;
 
-  test.beforeEach(async ({ page }) => {
-    fixture = await seedTimetableRun(SCHOOL_ID);
+  test.beforeEach(async ({ context, page }) => {
+    fixture = await createThrowawaySchool({
+      roles: { admin: true, lehrer: true },
+      withClasses: 1,
+      withTimetableStack: true,
+      namePrefix: 'E2E-ROOM-FILT',
+    });
+    await useThrowawaySchoolHeader(context, fixture.schoolId);
     await loginAsAdmin(page);
     await page.goto('/rooms');
     // Wait for the Raumtyp combobox to be ready before each test interacts
@@ -75,7 +67,8 @@ test.describe('Rooms-filter regression — German enum + filter-aware empty stat
 
   test.afterEach(async () => {
     if (fixture) {
-      await cleanupTimetableRun(fixture);
+      await fixture.cleanup();
+      fixture = undefined;
     }
   });
 
@@ -128,11 +121,8 @@ test.describe('Rooms-filter regression — German enum + filter-aware empty stat
   }) => {
     await page.waitForLoadState('networkidle');
 
-    // Pick Werkraum — guaranteed zero matches. The seed school has 3
-    // KLASSENZIMMER + Turnsaal + EDV-Raum + Musikraum, but neither
-    // Werkraum nor Labor (#51 added rooms; the doc-comment of this file
-    // foresaw exactly this drift and prescribed flipping the filter to
-    // an empty type when it happens). Day filter stays at the default.
+    // Pick Werkraum — guaranteed zero matches in the throwaway school
+    // (the only room is the timetable-stack KLASSENZIMMER).
     await page.getByRole('combobox').nth(1).click();
     await page
       .getByRole('option', { name: 'Werkraum', exact: true })

--- a/apps/web/e2e/timetable-eltern-view.spec.ts
+++ b/apps/web/e2e/timetable-eltern-view.spec.ts
@@ -1,49 +1,31 @@
 /**
  * Issue #86 — Stundenplan-Sicht Eltern.
  *
- * /timetable wird vom Eltern-User täglich geöffnet und ist heute nur durch
- * `roles-smoke.spec.ts` abgedeckt (das nur prüft, dass die Seite ohne
- * Crash rendert). Cross-Child- oder Cross-Tenant-Leaks an dieser Stelle
- * wären maximal-schmerzhaft — exakt die Pattern-Familie aus
- * `project_useTeachers_tenant_leak.md` /
- * `project_useClasses_missing_schoolId.md`.
+ * Issue #167 (Phase 3.5/6 Batch C) — migrated to throwaway-school per
+ * CLAUDE.md D4. The `active-timetable-run:SEED_SCHOOL_UUID` advisory lock
+ * is gone; each invocation owns its own school. kc-eltern is bound to a
+ * Parent row + ParentStudent link to a throwaway Student in classIds[0]
+ * via `roles.eltern` + `withParentLinks.eltern`.
  *
  * Test-Strategie — zwei Schichten:
  *
  *   1. URL-Param-Lock: der ausgehende `GET /api/v1/schools/.../timetable/view`
- *      MUSS `perspective=class` + `perspectiveId=seed-class-1a` (die Klasse
- *      von Lisa Huber, dem KIND von Franz Huber). KRITISCH: nicht den
- *      Eltern-personId, nicht eine andere Klasse. Eine silent-permissiveness
- *      Variante im Backend (`where: { x: undefined }` → kein Filter) würde
- *      hier auch den eigenen personId durchlassen.
+ *      MUSS `perspective=class` + `perspectiveId=<throwaway-class>` haben.
+ *      Eine silent-permissiveness Variante im Backend würde hier auch den
+ *      eigenen personId durchlassen oder einen anderen Klassen-Slice abrufen.
  *
  *   2. Cell-Render-Lock: die seeded MONDAY/period-1 Cell ist sichtbar.
  *      Verifiziert dass der Eltern-Persona tatsächlich Daten bekommt und
  *      nicht in einem "kein Stundenplan vorhanden" empty-state hängt
  *      (z.B. weil childClassId nicht aufgelöst wurde).
- *
- * Fixture: `seedTimetableRun()` seedet eine Lesson für class 1A (Lisa Hubers
- * Klasse laut seed.ts — Lisa ist Tochter von Franz, dem eltern-user).
- *
- * CI/local divergence note: das Standard-`prisma:seed` erzeugt KEINE
- * TimetableLesson-Rows. Ohne Fixture wäre der /timetable empty-state.
- * Memory: `feedback_seed_no_timetable_lessons.md`.
- *
- * Race-Family-Achtung: per-test seeding + chromium-only-skip (siehe
- * lehrer-view.spec.ts für die ausführliche Begründung). Active-
- * TimetableRun-Singleton-Race ist seit `project_active_timetable_run_race.md`
- * via Backend `orderBy createdAt desc` entschärft.
  */
 import { test, expect } from '@playwright/test';
 import { loginAsRole } from './helpers/login';
 import {
-  cleanupTimetableRun,
-  seedTimetableRun,
-  type TimetableRunFixture,
-} from './fixtures/timetable-run';
-import { SEED_SCHOOL_UUID } from './fixtures/seed-uuids';
-
-const SEED_CLASS_1A_ID = 'seed-class-1a';
+  createThrowawaySchool,
+  type ThrowawaySchoolFixture,
+} from './fixtures/throwaway-school';
+import { useThrowawaySchoolHeader } from './helpers/school-context';
 
 async function captureTimetableViewRequest(
   page: import('@playwright/test').Page,
@@ -63,27 +45,37 @@ test.describe('Issue #86 — Timetable Eltern view (desktop)', () => {
     ({ isMobile }) => isMobile,
     'Perspective routing is identical across viewports — desktop only for the first lock.',
   );
-  // Phase 4 of #112: chromium-only-skip removed. The active-TimetableRun
-  // race is now closed by the Postgres advisory lock in seedTimetableRun()
-  // (commit 9991e74). Parallel firefox + chromium workers seeding for the
-  // same seed school serialize at the lock; this spec is read-only after
-  // the lock is held, so cross-project parallelism is safe.
 
-  let fixture: TimetableRunFixture | undefined;
+  let fixture: ThrowawaySchoolFixture | undefined;
 
-  test.beforeEach(async () => {
-    fixture = await seedTimetableRun(SEED_SCHOOL_UUID);
+  test.beforeEach(async ({ context }) => {
+    // roles.lehrer for the timetable stack (which auto-creates a Teacher
+    // bound to the lehrer-Person); roles.eltern + withParentLinks binds
+    // kc-eltern to a Parent → ParentStudent → Student → classIds[0].
+    fixture = await createThrowawaySchool({
+      roles: { lehrer: true, eltern: true },
+      withClasses: 1,
+      withTimetableStack: true,
+      withStudents: [{ firstName: 'Kind', lastName: 'Eltern' }],
+      withParentLinks: { eltern: { studentIndexes: [0] } },
+      namePrefix: 'E2E-TT-ELTERN',
+    });
+    await useThrowawaySchoolHeader(context, fixture.schoolId);
   });
 
   test.afterEach(async () => {
-    if (!fixture) return;
-    await cleanupTimetableRun(fixture);
-    fixture = undefined;
+    if (fixture) {
+      await fixture.cleanup();
+      fixture = undefined;
+    }
   });
 
-  test("TT-VIEW-ELTERN-PARAM: eltern-user lands on perspective=class for the child's class 1A", async ({
+  test("TT-VIEW-ELTERN-PARAM: eltern-user lands on perspective=class for the child's class", async ({
     page,
   }) => {
+    if (!fixture) throw new Error('fixture not seeded');
+    const expectedClassId = fixture.classIds[0];
+
     await loginAsRole(page, 'eltern');
     const url = await captureTimetableViewRequest(page, async () => {
       await page.goto('/timetable');
@@ -92,31 +84,34 @@ test.describe('Issue #86 — Timetable Eltern view (desktop)', () => {
     expect(url.searchParams.get('perspective')).toBe('class');
     expect(
       url.searchParams.get('perspectiveId'),
-      'eltern-user (Franz Huber → Lisa Huber) must request the CHILD\'s class slice — never their own personId or another class',
-    ).toBe(SEED_CLASS_1A_ID);
+      "eltern-user must request the CHILD's class slice — never their own personId or another class",
+    ).toBe(expectedClassId);
 
     await expect(page.getByRole('heading', { name: 'Stundenplan' })).toBeVisible();
   });
 
-  test('TT-VIEW-ELTERN-CELLS: seeded MONDAY/period-1 lesson is visible in the child\'s class grid', async ({
+  test("TT-VIEW-ELTERN-CELLS: seeded MONDAY/period-1 lesson is visible in the child's class grid", async ({
     page,
   }) => {
+    if (!fixture) throw new Error('fixture not seeded');
+
     await loginAsRole(page, 'eltern');
     await page.goto('/timetable');
 
     const grid = page.getByRole('grid', { name: 'Stundenplan' });
     await expect(grid).toBeVisible();
 
-    // The fixture seeds exactly ONE lesson at MONDAY/period-1 in class 1A
-    // (Lisa Huber's class). If childClassId resolution silently breaks —
-    // a class of bug aligned with the silent-omission family in
+    // The fixture seeds exactly ONE lesson at MONDAY/period-1 in the
+    // throwaway class (the child's class via withParentLinks). If
+    // childClassId resolution silently breaks — a class of bug aligned
+    // with the silent-omission family in
     // `project_useClasses_missing_schoolId.md` — this assertion goes red.
     const seededCell = grid.getByRole('gridcell', {
       name: /Montag 1\. Stunde$/,
     });
     await expect(
       seededCell,
-      "eltern-user must see the seeded MONDAY/period-1 lesson in Lisa Huber's class 1A view",
+      "eltern-user must see the seeded MONDAY/period-1 lesson in the child's class view",
     ).toBeVisible();
   });
 });

--- a/apps/web/e2e/timetable-lehrer-view.spec.ts
+++ b/apps/web/e2e/timetable-lehrer-view.spec.ts
@@ -1,11 +1,11 @@
 /**
  * Issue #86 — Stundenplan-Sicht Lehrer.
  *
- * /timetable wird vom Lehrer täglich geöffnet und ist heute nur durch
- * `roles-smoke.spec.ts` abgedeckt (das nur prüft, dass die Seite ohne
- * Crash rendert). Tenant-Leaks an dieser Stelle wären maximal-schmerzhaft
- * — exakt die Pattern-Familie aus `project_useTeachers_tenant_leak.md` /
- * `project_useClasses_missing_schoolId.md`.
+ * Issue #167 (Phase 3.5/6 Batch C) — migrated to throwaway-school per
+ * CLAUDE.md D4. The `active-timetable-run:SEED_SCHOOL_UUID` advisory lock
+ * is gone; each invocation owns its own school. The lehrer-Person is
+ * bound to the kc-lehrer KC user via `roles.lehrer`, and the timetable
+ * stack pins the lone Teacher row to that Person.
  *
  * Test-Strategie — zwei Schichten:
  *
@@ -16,37 +16,18 @@
  *      permissiveness), fällt dieser Test um.
  *
  *   2. Cell-Content-Lock: JEDE gerenderte Cell (role=gridcell) MUSS einen
- *      aria-label enthalten, der "bei Mueller" referenziert. Wäre die
- *      Backend-Response cross-tenant kontaminiert (z.B. weil ein Service
- *      `where: { teacherId: undefined }` baut → "kein Filter"), erschienen
- *      Cells mit fremden Lehrernamen und der Test fiele um.
- *
- * Fixture: `seedTimetableRun()` seedet kc-lehrer (Maria Mueller) als
- * einzigen Lehrer auf MONDAY/period-1 → die Cell-Content-Assertion ist
- * deterministisch.
- *
- * CI/local divergence note: das Standard-`prisma:seed` erzeugt KEINE
- * TimetableLesson-Rows (die kommen aus Solver-Runs, die in CI nicht
- * laufen). Ohne Fixture wäre der /timetable empty-state und der
- * Cell-Content-Lock würde im CI nie greifen. Memory:
- * `feedback_seed_no_timetable_lessons.md`.
- *
- * Race-Family-Achtung: per-test seeding (beforeEach + afterEach), nicht
- * beforeAll — `test.skip(condition, ...)` auf describe-Level gated NICHT
- * `beforeAll` (würde in firefox/mobile-Projects `cleanupTimetableRun(undefined)`
- * → TypeError). Chromium-only-skip + per-test Fixture matchen
- * `admin-timetable-edit-dnd.spec.ts` und das non-admin-views-Original.
+ *      aria-label enthalten, der "bei <eigener Nachname>" referenziert.
+ *      Wäre die Backend-Response cross-tenant kontaminiert (z.B. weil ein
+ *      Service `where: { teacherId: undefined }` baut → "kein Filter"),
+ *      erschienen Cells mit fremden Lehrernamen und der Test fiele um.
  */
 import { test, expect } from '@playwright/test';
 import { loginAsRole } from './helpers/login';
 import {
-  cleanupTimetableRun,
-  seedTimetableRun,
-  type TimetableRunFixture,
-} from './fixtures/timetable-run';
-import { SEED_SCHOOL_UUID } from './fixtures/seed-uuids';
-
-const SEED_TEACHER_KC_LEHRER_UUID = '10000000-0000-4000-8000-000000000001';
+  createThrowawaySchool,
+  type ThrowawaySchoolFixture,
+} from './fixtures/throwaway-school';
+import { useThrowawaySchoolHeader } from './helpers/school-context';
 
 /**
  * Awaits the first outgoing `GET /api/v1/schools/.../timetable/view?...`
@@ -71,27 +52,32 @@ test.describe('Issue #86 — Timetable Lehrer view (desktop)', () => {
     ({ isMobile }) => isMobile,
     'Perspective routing is identical across viewports — desktop only for the first lock.',
   );
-  // Phase 4 of #112: chromium-only-skip removed. The active-TimetableRun
-  // race is now closed by the Postgres advisory lock in seedTimetableRun()
-  // (commit 9991e74). Parallel firefox + chromium workers seeding for the
-  // same seed school serialize at the lock; this spec is read-only after
-  // the lock is held, so cross-project parallelism is safe.
 
-  let fixture: TimetableRunFixture | undefined;
+  let fixture: ThrowawaySchoolFixture | undefined;
 
-  test.beforeEach(async () => {
-    fixture = await seedTimetableRun(SEED_SCHOOL_UUID);
+  test.beforeEach(async ({ context }) => {
+    fixture = await createThrowawaySchool({
+      roles: { lehrer: true },
+      withClasses: 1,
+      withTimetableStack: true,
+      namePrefix: 'E2E-TT-LEHRER',
+    });
+    await useThrowawaySchoolHeader(context, fixture.schoolId);
   });
 
   test.afterEach(async () => {
-    if (!fixture) return;
-    await cleanupTimetableRun(fixture);
-    fixture = undefined;
+    if (fixture) {
+      await fixture.cleanup();
+      fixture = undefined;
+    }
   });
 
   test('TT-VIEW-LEHRER-PARAM: lehrer-user lands on perspective=teacher with own teacherId', async ({
     page,
   }) => {
+    if (!fixture) throw new Error('fixture not seeded');
+    const stack = fixture.timetable!;
+
     await loginAsRole(page, 'lehrer');
     const url = await captureTimetableViewRequest(page, async () => {
       await page.goto('/timetable');
@@ -100,31 +86,37 @@ test.describe('Issue #86 — Timetable Lehrer view (desktop)', () => {
     expect(url.searchParams.get('perspective')).toBe('teacher');
     expect(
       url.searchParams.get('perspectiveId'),
-      'lehrer-user must request their OWN teacherId — never another teacher\'s',
-    ).toBe(SEED_TEACHER_KC_LEHRER_UUID);
+      "lehrer-user must request their OWN teacherId — never another teacher's",
+    ).toBe(stack.teacherId);
 
     await expect(page.getByRole('heading', { name: 'Stundenplan' })).toBeVisible();
   });
 
-  test('TT-VIEW-LEHRER-CELLS: every rendered gridcell is one of Mueller\'s own lessons (tenant-leak guard)', async ({
+  test('TT-VIEW-LEHRER-CELLS: every rendered gridcell references the throwaway lehrer (tenant-leak guard)', async ({
     page,
   }) => {
+    if (!fixture) throw new Error('fixture not seeded');
+    const stack = fixture.timetable!;
+    // teacherDisplayName is `${lastName} ${firstName}`; lastName is the
+    // suffix used in the cell aria-label "bei <surname>".
+    const [tLast] = stack.teacherDisplayName.split(' ');
+    const surnamePattern = new RegExp(`bei ${tLast}\\b`);
+
     await loginAsRole(page, 'lehrer');
     await page.goto('/timetable');
 
     // Wait for the grid to mount. The fixture seeded exactly one lesson at
-    // MONDAY/period-1 for kc-lehrer, so at least one gridcell with the
-    // expected aria-label must appear once the view loads.
+    // MONDAY/period-1 for the throwaway lehrer.
     const grid = page.getByRole('grid', { name: 'Stundenplan' });
     await expect(grid).toBeVisible();
 
     // Tenant-leak guard: every rendered cell aria-label MUST contain
-    // "bei Mueller". The aria-label format is:
+    // "bei <throwaway-surname>". The aria-label format is:
     //   "${subjectName} bei ${teacherSurname} in ${roomName}, ${dayLabel} ${period}. Stunde"
     // (see apps/web/src/components/timetable/TimetableCell.tsx:6).
     //
     // If the backend ever returns a cross-tenant slice (e.g. by ignoring the
-    // perspective filter), foreign teachers' surnames would land in the
+    // perspective filter), a foreign teacher's surname would land in the
     // aria-label and this assertion would fail loudly.
     const cells = grid.getByRole('gridcell');
     await expect(cells.first()).toBeVisible();
@@ -138,8 +130,8 @@ test.describe('Issue #86 — Timetable Lehrer view (desktop)', () => {
     for (const label of labels) {
       expect(
         label,
-        `gridcell aria-label must reference Mueller (the logged-in lehrer); leaked label: ${label}`,
-      ).toMatch(/bei Mueller\b/);
+        `gridcell aria-label must reference the throwaway lehrer surname; leaked label: ${label}`,
+      ).toMatch(surnamePattern);
     }
   });
 });

--- a/apps/web/e2e/timetable-schueler-view.spec.ts
+++ b/apps/web/e2e/timetable-schueler-view.spec.ts
@@ -1,46 +1,31 @@
 /**
  * Issue #86 — Stundenplan-Sicht Schüler.
  *
- * /timetable wird vom Schüler täglich geöffnet und ist heute nur durch
- * `roles-smoke.spec.ts` abgedeckt (das nur prüft, dass die Seite ohne
- * Crash rendert). Cross-Class- oder Cross-Tenant-Leaks an dieser Stelle
- * wären maximal-schmerzhaft — exakt die Pattern-Familie aus
- * `project_useClasses_missing_schoolId.md`.
+ * Issue #167 (Phase 3.5/6 Batch C) — migrated to throwaway-school per
+ * CLAUDE.md D4. The `active-timetable-run:SEED_SCHOOL_UUID` advisory lock
+ * is gone; each invocation owns its own school. The kc-schueler KC user
+ * is bound to a Student row in `classIds[0]` via the new
+ * `withSchuelerEnrollment` option (Issue #167 fixture extension) — so
+ * `/users/me` resolves `classId` for the logged-in schueler and the
+ * frontend picks the class perspective automatically.
  *
  * Test-Strategie — zwei Schichten:
  *
  *   1. URL-Param-Lock: der ausgehende `GET /api/v1/schools/.../timetable/view`
- *      MUSS `perspective=class` + `perspectiveId=seed-class-1a` (Max Hubers
- *      eigene Klasse) haben. Wenn das /timetable jemals einen anderen
- *      Klassen-Slice abfragt (z.B. weil useUserContext einen Sibling-Pointer
- *      misst), fällt dieser Test um.
+ *      MUSS `perspective=class` + `perspectiveId=<throwaway-class>` haben.
+ *      Wenn das /timetable jemals einen anderen Klassen-Slice abfragt
+ *      (z.B. weil useUserContext einen Sibling-Pointer misst), fällt
+ *      dieser Test um.
  *
  *   2. Cell-Render-Lock: die seeded MONDAY/period-1 Cell ist sichtbar.
- *      Eine Cross-Class-Leak würde NICHT zwingend die seeded Cell verstecken,
- *      aber die kombinierte URL+Render-Assertion ist die definitive
- *      Regression-Lock für die "schueler sieht seine Klasse" Anforderung.
- *
- * Fixture: `seedTimetableRun()` seedet eine Lesson für class 1A (Max Hubers
- * Klasse laut seed.ts). Schueler-perspective lehnt sich an `classId` aus
- * useSchoolContext.
- *
- * CI/local divergence note: das Standard-`prisma:seed` erzeugt KEINE
- * TimetableLesson-Rows. Ohne Fixture wäre der /timetable empty-state.
- * Memory: `feedback_seed_no_timetable_lessons.md`.
- *
- * Race-Family-Achtung: per-test seeding + chromium-only-skip (siehe
- * lehrer-view.spec.ts für die ausführliche Begründung).
  */
 import { test, expect } from '@playwright/test';
 import { loginAsRole } from './helpers/login';
 import {
-  cleanupTimetableRun,
-  seedTimetableRun,
-  type TimetableRunFixture,
-} from './fixtures/timetable-run';
-import { SEED_SCHOOL_UUID } from './fixtures/seed-uuids';
-
-const SEED_CLASS_1A_ID = 'seed-class-1a';
+  createThrowawaySchool,
+  type ThrowawaySchoolFixture,
+} from './fixtures/throwaway-school';
+import { useThrowawaySchoolHeader } from './helpers/school-context';
 
 async function captureTimetableViewRequest(
   page: import('@playwright/test').Page,
@@ -60,27 +45,33 @@ test.describe('Issue #86 — Timetable Schüler view (desktop)', () => {
     ({ isMobile }) => isMobile,
     'Perspective routing is identical across viewports — desktop only for the first lock.',
   );
-  // Phase 4 of #112: chromium-only-skip removed. The active-TimetableRun
-  // race is now closed by the Postgres advisory lock in seedTimetableRun()
-  // (commit 9991e74). Parallel firefox + chromium workers seeding for the
-  // same seed school serialize at the lock; this spec is read-only after
-  // the lock is held, so cross-project parallelism is safe.
 
-  let fixture: TimetableRunFixture | undefined;
+  let fixture: ThrowawaySchoolFixture | undefined;
 
-  test.beforeEach(async () => {
-    fixture = await seedTimetableRun(SEED_SCHOOL_UUID);
+  test.beforeEach(async ({ context }) => {
+    fixture = await createThrowawaySchool({
+      roles: { lehrer: true, schueler: true },
+      withClasses: 1,
+      withTimetableStack: true,
+      withSchuelerEnrollment: true,
+      namePrefix: 'E2E-TT-SCH',
+    });
+    await useThrowawaySchoolHeader(context, fixture.schoolId);
   });
 
   test.afterEach(async () => {
-    if (!fixture) return;
-    await cleanupTimetableRun(fixture);
-    fixture = undefined;
+    if (fixture) {
+      await fixture.cleanup();
+      fixture = undefined;
+    }
   });
 
-  test('TT-VIEW-SCHUELER-PARAM: schueler-user lands on perspective=class for own class (1A)', async ({
+  test('TT-VIEW-SCHUELER-PARAM: schueler-user lands on perspective=class for their own class', async ({
     page,
   }) => {
+    if (!fixture) throw new Error('fixture not seeded');
+    const expectedClassId = fixture.classIds[0];
+
     await loginAsRole(page, 'schueler');
     const url = await captureTimetableViewRequest(page, async () => {
       await page.goto('/timetable');
@@ -89,8 +80,8 @@ test.describe('Issue #86 — Timetable Schüler view (desktop)', () => {
     expect(url.searchParams.get('perspective')).toBe('class');
     expect(
       url.searchParams.get('perspectiveId'),
-      'schueler-user (Max Huber) must request the slice for class 1A — never a sibling class or another tenant',
-    ).toBe(SEED_CLASS_1A_ID);
+      'schueler-user must request the slice for their own class — never a sibling class or another tenant',
+    ).toBe(expectedClassId);
 
     await expect(page.getByRole('heading', { name: 'Stundenplan' })).toBeVisible();
   });
@@ -98,29 +89,23 @@ test.describe('Issue #86 — Timetable Schüler view (desktop)', () => {
   test('TT-VIEW-SCHUELER-CELLS: seeded MONDAY/period-1 lesson renders inside the grid', async ({
     page,
   }) => {
+    if (!fixture) throw new Error('fixture not seeded');
+
     await loginAsRole(page, 'schueler');
     await page.goto('/timetable');
 
     const grid = page.getByRole('grid', { name: 'Stundenplan' });
     await expect(grid).toBeVisible();
 
-    // The fixture seeds exactly ONE lesson at MONDAY/period-1 (Mueller).
-    // The aria-label format is:
-    //   "${subjectName} bei Mueller in ${roomName}, Montag 1. Stunde"
-    // (apps/web/src/components/timetable/TimetableCell.tsx:6).
-    //
-    // We do NOT assert "every cell is Mueller's" here (class perspective
-    // may legitimately include lessons from any teacher who teaches 1A —
-    // the seed has only one classSubject seeded against kc-lehrer, but
-    // we keep this loose so the spec doesn't accidentally lock the seed's
-    // teaching-assignment shape). The presence + "Montag 1. Stunde" pin
-    // is the deterministic regression-lock.
+    // The fixture seeds exactly ONE lesson at MONDAY/period-1 for the
+    // throwaway lehrer in the schueler's class. The presence +
+    // "Montag 1. Stunde" pin is the deterministic regression-lock.
     const seededCell = grid.getByRole('gridcell', {
       name: /Montag 1\. Stunde$/,
     });
     await expect(
       seededCell,
-      'schueler-user must see the seeded MONDAY/period-1 lesson in their class 1A view',
+      'schueler-user must see the seeded MONDAY/period-1 lesson in their class view',
     ).toBeVisible();
   });
 });

--- a/apps/web/e2e/timetable-week-navigation.spec.ts
+++ b/apps/web/e2e/timetable-week-navigation.spec.ts
@@ -1,9 +1,14 @@
 /**
  * Issue #86 — Stundenplan Wochen-Navigation.
  *
+ * Issue #167 (Phase 3.5/6 Batch C) — migrated to throwaway-school per
+ * CLAUDE.md D4. The `active-timetable-run:SEED_SCHOOL_UUID` advisory lock
+ * is gone; each invocation owns its own school with MON-FRI schoolDays
+ * activated by the timetable-stack (one of 5 column headers per default).
+ *
  * Vierte Sub-Spec der non-admin Timetable coverage gap (#86). Lockt die
- * "Woche vor/zurück + KW-Anzeige" Anforderung in der heutigen
- * Realität des /timetable Surfaces:
+ * "Woche vor/zurück + KW-Anzeige" Anforderung in der heutigen Realität
+ * des /timetable Surfaces:
  *
  *   - Es gibt KEINE kalendarische "vorige/nächste Woche" Navigation —
  *     der /timetable rendert den aktiven TimetableRun, nicht einen
@@ -12,45 +17,28 @@
  *       (a) Tag/Woche View-Mode-Toggle  → reduziert die Grid-Spalten
  *           auf einen einzigen Tag.
  *       (b) A-Woche/B-Woche Tabs        → sichtbar NUR wenn die Schule
- *           A/B-Wochen-Modus aktiviert hat. Default-Seed: deaktiviert.
+ *           A/B-Wochen-Modus aktiviert hat. Throwaway-Default: deaktiviert.
  *
  * Test-Strategie:
  *
  *   WEEK-NAV-VIEW-TOGGLE-LEHRER:
- *     Default-View-Mode auf Desktop ist 'week' (zustand store
- *     initial value, apps/web/src/stores/timetable-store.ts:32).
- *     Im Week-Mode rendert das Grid 5 Tages-Header (Mo–Fr); nach
- *     Klick auf "Tag" reduziert sich das auf einen einzigen
- *     Tages-Header. Verifiziert dass der DayWeekToggle den Grid-
- *     Render tatsächlich anpasst.
+ *     Default-View-Mode auf Desktop ist 'week' (zustand store initial
+ *     value, apps/web/src/stores/timetable-store.ts:32). Im Week-Mode
+ *     rendert das Grid 5 Tages-Header (Mo–Fr); nach Klick auf "Tag"
+ *     reduziert sich das auf einen einzigen Tages-Header.
  *
  *   WEEK-NAV-AB-HIDDEN-LEHRER:
- *     Seed-Schule hat `abWeekEnabled: false` (Prisma-Default,
- *     apps/api/prisma/schema.prisma, kein Override in seed.ts).
- *     ABWeekTabs returnt `null` wenn `isABMode === false`
- *     (apps/web/src/components/timetable/ABWeekTabs.tsx:14).
- *     Lock: kein "A-Woche" / "B-Woche" Tab im DOM für die
- *     Default-Seed-Schule. Wenn das Frontend jemals den
- *     `abWeekEnabled` Boolean ignoriert und Tabs unkonditional
- *     rendert, fällt diese Assertion um.
- *
- * Fixture: `seedTimetableRun()` seedet eine Lesson (MONDAY/period-1
- * für kc-lehrer). Lehrer-perspective wird automatisch gewählt, das
- * Grid rendert mit den Default-Schultagen Mo–Fr. Ohne Fixture wäre
- * der /timetable im empty-state und das Grid würde gar nicht
- * rendern — Memory `feedback_seed_no_timetable_lessons.md`.
- *
- * Race-Family-Achtung: per-test seeding + chromium-only-skip
- * (siehe lehrer-view.spec.ts).
+ *     Throwaway-Schule hat `abWeekEnabled: false` (Default, kein
+ *     Override im Fixture). ABWeekTabs returnt `null` wenn
+ *     `isABMode === false`. Lock: kein "A-Woche" / "B-Woche" Tab im DOM.
  */
 import { test, expect, type Page } from '@playwright/test';
 import { loginAsRole } from './helpers/login';
 import {
-  cleanupTimetableRun,
-  seedTimetableRun,
-  type TimetableRunFixture,
-} from './fixtures/timetable-run';
-import { SEED_SCHOOL_UUID } from './fixtures/seed-uuids';
+  createThrowawaySchool,
+  type ThrowawaySchoolFixture,
+} from './fixtures/throwaway-school';
+import { useThrowawaySchoolHeader } from './helpers/school-context';
 
 /**
  * Counts leaf-divs inside the timetable grid whose text content is a
@@ -58,11 +46,6 @@ import { SEED_SCHOOL_UUID } from './fixtures/seed-uuids';
  * header row renders exactly one such div per visible day; the count is
  * therefore equal to the number of grid columns excluding the period-
  * label column.
- *
- * Implementation note: we filter on `children.length === 0` to skip
- * any ancestor div that happens to contain the short label as part of
- * its concatenated text content (defensive — not currently the case
- * but a layout refactor could introduce one).
  */
 async function countVisibleDayHeaders(page: Page): Promise<number> {
   return page.evaluate(() => {
@@ -84,22 +67,24 @@ test.describe('Issue #86 — Timetable week navigation (desktop)', () => {
     ({ isMobile }) => isMobile,
     'Mobile forces day view (TimetablePage:118 — effectiveViewMode = isMobile ? "day" : viewMode), so the Tag/Woche toggle is hidden on base/sm. Mobile coverage of the day-selector tabs belongs to its own spec.',
   );
-  // Phase 4 of #112: chromium-only-skip removed. The active-TimetableRun
-  // race is now closed by the Postgres advisory lock in seedTimetableRun()
-  // (commit 9991e74). Parallel firefox + chromium workers seeding for the
-  // same seed school serialize at the lock; this spec is read-only after
-  // the lock is held, so cross-project parallelism is safe.
 
-  let fixture: TimetableRunFixture | undefined;
+  let fixture: ThrowawaySchoolFixture | undefined;
 
-  test.beforeEach(async () => {
-    fixture = await seedTimetableRun(SEED_SCHOOL_UUID);
+  test.beforeEach(async ({ context }) => {
+    fixture = await createThrowawaySchool({
+      roles: { lehrer: true },
+      withClasses: 1,
+      withTimetableStack: true,
+      namePrefix: 'E2E-TT-WEEK',
+    });
+    await useThrowawaySchoolHeader(context, fixture.schoolId);
   });
 
   test.afterEach(async () => {
-    if (!fixture) return;
-    await cleanupTimetableRun(fixture);
-    fixture = undefined;
+    if (fixture) {
+      await fixture.cleanup();
+      fixture = undefined;
+    }
   });
 
   test('WEEK-NAV-VIEW-TOGGLE-LEHRER: Tag/Woche toggle changes the number of visible day columns', async ({
@@ -108,19 +93,19 @@ test.describe('Issue #86 — Timetable week navigation (desktop)', () => {
     await loginAsRole(page, 'lehrer');
     await page.goto('/timetable');
 
-    // Wait for the grid to mount — the fixture's MONDAY/period-1 lesson
+    // Wait for the grid to mount — the throwaway's MONDAY/period-1 lesson
     // gates the `lessons.length > 0` render condition in
     // apps/web/src/routes/_authenticated/timetable/index.tsx:340.
     const grid = page.getByRole('grid', { name: 'Stundenplan' });
     await expect(grid).toBeVisible();
 
     // Default desktop view-mode is "week" (zustand store initial value).
-    // The seed school's schoolDays (Mo–Fr active) project as 5 day
-    // headers in the grid's first row.
+    // The throwaway's schoolDays (Mo–Fr active) project as 5 day headers
+    // in the grid's first row.
     const weekHeaderCount = await countVisibleDayHeaders(page);
     expect(
       weekHeaderCount,
-      'Default desktop week-mode must render exactly 5 day headers (Mo–Fr) for the default seed school',
+      'Default desktop week-mode must render exactly 5 day headers (Mo–Fr) for the throwaway school',
     ).toBe(5);
 
     // Click the "Tag" tab on the DayWeekToggle. Shadcn Tabs exposes
@@ -170,11 +155,10 @@ test.describe('Issue #86 — Timetable week navigation (desktop)', () => {
     await expect(page.getByRole('tab', { name: 'Tag' })).toBeVisible();
     await expect(page.getByRole('tab', { name: 'Woche' })).toBeVisible();
 
-    // Default seed school has abWeekEnabled = false (Prisma schema
-    // default, no override in seed.ts). The fixture's TimetableRun
-    // also has abWeekEnabled: false. ABWeekTabs returns null when
-    // isABMode === false. → No "A-Woche" / "B-Woche" tabs anywhere
-    // on the page.
+    // Throwaway school has abWeekEnabled = false (Prisma schema default,
+    // no override in createThrowawaySchool). The TimetableRun also has
+    // abWeekEnabled: false. ABWeekTabs returns null when isABMode ===
+    // false. → No "A-Woche" / "B-Woche" tabs anywhere on the page.
     await expect(page.getByRole('tab', { name: 'A-Woche' })).toHaveCount(0);
     await expect(page.getByRole('tab', { name: 'B-Woche' })).toHaveCount(0);
   });


### PR DESCRIPTION
Closes #167. Part of #153 (Phase 3.5/6 tracking).

## Summary

- Replaces `seedTimetableRun(SEED_SCHOOL_UUID)` + advisory lock with `createThrowawaySchool({ withTimetableStack: true, ... })` across all 5 specs.
- URL-param + aria-label assertions now read tenant IDs / surnames off the fixture (`fixture.timetable.teacherId`, `fixture.classIds[0]`, throwaway-derived surname pattern). Strict matches replace seed-bound literals (`SEED_TEACHER_KC_LEHRER_UUID`, `seed-class-1a`, `/bei Mueller/`).
- **Throwaway fixture extension:** new `withSchuelerEnrollment: boolean` option that creates a `Student` row binding the kc-schueler Person to `classIds[0]`. Required for kc-schueler's `/users/me` to resolve `classId` (per `user-context.service.ts:88-92`). Validation: requires `roles.schueler && withClasses >= 1`.

## Files migrated

- `apps/web/e2e/timetable-eltern-view.spec.ts` — uses `withParentLinks.eltern`
- `apps/web/e2e/timetable-lehrer-view.spec.ts`
- `apps/web/e2e/timetable-schueler-view.spec.ts` — uses new `withSchuelerEnrollment`
- `apps/web/e2e/timetable-week-navigation.spec.ts`
- `apps/web/e2e/rooms-filter.spec.ts`

## Fixture change

- `apps/web/e2e/fixtures/throwaway-school.ts` — adds `withSchuelerEnrollment` + `schuelerStudentId`. Smoke spec (THROW-01..04) unaffected — it doesn't pass the new option, so behavior is backward-compatible.

## D-Direktiven check

- D3: merge only on full-green CI.
- D4: no new chromium-only race skips. Existing `isMobile` skips stay (viewport gates).
- D5/D6: #167 linked to parent #153 + was blocked-by #166 (now CLOSED).

## Test plan

- [ ] CI cross-project parallel run green (chromium + firefox).
- [ ] All 5 specs run without seed-school references.
- [ ] Throwaway smoke (THROW-01..04) still green — no regression from the fixture extension.
- [ ] `schueler-view` proves the new fixture option resolves classId end-to-end via `/users/me`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)