### PR TITLE
chore(e2e): #168 — migrate 3 substitutions specs to throwaway-school (Batch D of #153)

### DIFF
--- a/apps/web/e2e/helpers/substitutions.ts
+++ b/apps/web/e2e/helpers/substitutions.ts
@@ -15,19 +15,9 @@
  */
 import { expect, type APIRequestContext } from '@playwright/test';
 import { getAdminToken } from './login';
-import { SEED_SCHOOL_UUID } from '../fixtures/seed-uuids';
 
 export const SUBSTITUTIONS_API =
   process.env.E2E_API_URL ?? 'http://localhost:3000/api/v1';
-/**
- * Default school id for the legacy seed-school flow. Specs migrating to
- * throwaway-school (Issue #153 batches A–D) pass `schoolId` explicitly per
- * call; the default stays for any spec still bound to the seed school
- * until its batch lands. The constant + default will be removed alongside
- * the last seed-school caller in Batch D.
- */
-export const SUBSTITUTIONS_SCHOOL_ID =
-  process.env.E2E_SCHOOL_ID ?? SEED_SCHOOL_UUID;
 
 export interface CreateAbsenceInput {
   teacherId: string;
@@ -45,14 +35,11 @@ export interface CreatedAbsence {
 /**
  * POST /absences as admin. Returns the new absence id so afterEach can
  * cancel it (cascade-deletes any auto-generated substitutions).
- *
- * `schoolId` defaults to the legacy seed-school. Throwaway-school specs
- * pass `fixture.schoolId` so the absence lands in the per-spec school.
  */
 export async function createAbsenceViaAPI(
   request: APIRequestContext,
   input: CreateAbsenceInput,
-  schoolId: string = SUBSTITUTIONS_SCHOOL_ID,
+  schoolId: string,
 ): Promise<CreatedAbsence> {
   const token = await getAdminToken(request);
   const res = await request.post(
@@ -96,7 +83,7 @@ export async function createAbsenceViaAPI(
 export async function cancelAbsenceViaAPI(
   request: APIRequestContext,
   absenceId: string,
-  schoolId: string = SUBSTITUTIONS_SCHOOL_ID,
+  schoolId: string,
 ): Promise<void> {
   const token = await getAdminToken(request);
   const res = await request.delete(
@@ -119,7 +106,7 @@ export async function cancelAbsenceViaAPI(
  */
 export async function listSubstitutionsViaAPI(
   request: APIRequestContext,
-  schoolId: string = SUBSTITUTIONS_SCHOOL_ID,
+  schoolId: string,
 ): Promise<
   Array<{
     id: string;
@@ -163,7 +150,7 @@ export async function assignSubstituteViaAPI(
   request: APIRequestContext,
   substitutionId: string,
   candidateTeacherId: string,
-  schoolId: string = SUBSTITUTIONS_SCHOOL_ID,
+  schoolId: string,
 ): Promise<void> {
   const token = await getAdminToken(request);
   const res = await request.post(
@@ -185,7 +172,7 @@ export async function assignSubstituteViaAPI(
 /**
  * Compute the YYYY-MM-DD string for the next MONDAY at-or-after the
  * given anchor date (defaults to today). Used to align test absences
- * with the seedTimetableRun fixture's MONDAY/period-1 lesson so the
+ * with the throwaway timetable stack's MONDAY/period-1 lesson so the
  * absence-expansion algorithm produces exactly one substitution row.
  */
 export function nextMondayISODate(anchor: Date = new Date()): string {

--- a/apps/web/e2e/substitutions-handover.spec.ts
+++ b/apps/web/e2e/substitutions-handover.spec.ts
@@ -1,58 +1,42 @@
 /**
  * Issue #85 — Übergabenotiz (handover note) author flow with attachment.
  *
- * Fifth and final sub-spec of the Substitutions coverage gap. Locks the
- * absent-teacher's path through the `HandoverNoteEditor` dialog:
+ * Issue #168 (Phase 3.5/6 Batch D) — migrated to throwaway-school per
+ * CLAUDE.md D4. The `active-timetable-run:SEED_SCHOOL_UUID` advisory lock
+ * is gone; each invocation owns its own school + ClassBookEntry chain,
+ * so `purgeStaleE2EHandoverNotes` (sweeping leaked notes from killed
+ * runs) is no longer needed. The throwaway cascade also covers the
+ * HandoverNote + HandoverAttachment rows + on-disk attachment files.
  *
- *   1. Seed an active TimetableRun with kc-lehrer's lesson at
- *      MONDAY/period-1.
- *   2. POST an absence for kc-lehrer for next Monday → backend creates
- *      a PENDING Substitution.
+ * Locks the absent-teacher's path through the `HandoverNoteEditor` dialog:
+ *
+ *   1. Throwaway TimetableRun + kc-lehrer's lesson at MONDAY/period-1.
+ *   2. POST an absence for the throwaway lehrer for next Monday →
+ *      backend creates a PENDING Substitution.
  *   3. kc-lehrer logs in → /teacher/substitutions → Section 2 row
  *      "Uebergabenotiz" button visible.
  *   4. Click button → `HandoverNoteEditor` dialog opens. Fill the
- *      content textarea, attach a 4-byte stub PDF (magic bytes only —
- *      handover.service.ts MIME validation looks at the first 4 bytes
- *      and nothing else), click "Uebergabenotiz speichern".
+ *      content textarea, attach a 13-byte stub PDF (magic bytes only),
+ *      click "Uebergabenotiz speichern".
  *   5. Toast "Uebergabenotiz gespeichert" confirms the round-trip
  *      through POST /handover-notes/substitutions/:id + multipart
  *      POST /handover-notes/:noteId/attachments.
  *   6. Re-open the editor — the content persists AND the attachment
- *      surfaces in the "Anhaenge" panel (HandoverNoteEditor.tsx:103),
- *      both of which prove the note actually landed in the DB and is
- *      re-readable by the author (D-15 visibility rule).
- *
- * Why bundle attachment + content in one test: the issue text calls
- * out attachment explicitly ("Eltern lädt PDF hoch ... Lehrer sieht
- * Attachment" but for substitution context), and both legs of the
- * round-trip hit related code paths (createOrUpdateNote +
- * saveAttachment + assertVisible). Splitting into two specs would
- * duplicate the dialog scaffolding for marginal coverage gain.
- *
- * Substitute-side view (substitute teacher reads the note inline on
- * their offer card) is NOT covered here. That requires a second
- * keycloak-mapped teacher to log in as substitute, which the seed
- * doesn't ship. Deferred as a follow-up (the visibility rule itself
- * is locked by handover.service.spec.ts at unit-test level).
- *
- * Chromium-only-skip per the race-family precedent — shared seed-school
- * mutating specs collide on parallel browser projects.
+ *      surfaces in the "Anhaenge" panel, both of which prove the note
+ *      actually landed in the DB and is re-readable by the author.
  */
 import { test, expect } from '@playwright/test';
 import { loginAsRole } from './helpers/login';
 import {
-  cancelAbsenceViaAPI,
   createAbsenceViaAPI,
   nextMondayISODate,
   type CreatedAbsence,
 } from './helpers/substitutions';
 import {
-  cleanupTimetableRun,
-  purgeStaleE2EHandoverNotes,
-  seedTimetableRun,
-  type TimetableRunFixture,
-} from './fixtures/timetable-run';
-import { SEED_SCHOOL_UUID } from './fixtures/seed-uuids';
+  createThrowawaySchool,
+  type ThrowawaySchoolFixture,
+} from './fixtures/throwaway-school';
+import { useThrowawaySchoolHeader } from './helpers/school-context';
 
 // Stub PDF whose first 4 bytes are the PDF magic signature
 // (handover.service.ts:38 MAGIC_BYTES['application/pdf']). Magic-byte
@@ -65,27 +49,32 @@ const STUB_PDF = Buffer.from('%PDF-1.4 test', 'utf-8');
 test.describe('Issue #85 — Uebergabenotiz author flow + attachment (desktop)', () => {
   test.skip(
     ({ isMobile }) => isMobile,
-    'HandoverNoteEditor dialog is desktop-prioritised; mobile layout is a follow-up audit once the dialog\'s textarea height is mobile-tuned.',
+    "HandoverNoteEditor dialog is desktop-prioritised; mobile layout is a follow-up audit once the dialog's textarea height is mobile-tuned.",
   );
 
-  let fixture: TimetableRunFixture | undefined;
+  let fixture: ThrowawaySchoolFixture | undefined;
   let absence: CreatedAbsence | undefined;
 
-  test.beforeEach(async ({ page, request }) => {
-    // Wipe leftover E2E handover notes from previously-crashed runs so
-    // Section 2's "Notiz bearbeiten" `.first()` deterministically
-    // resolves to the row OUR test will save on (see
-    // `purgeStaleE2EHandoverNotes` for the full failure mode).
-    await purgeStaleE2EHandoverNotes();
-    fixture = await seedTimetableRun(SEED_SCHOOL_UUID);
+  test.beforeEach(async ({ context, page, request }) => {
+    fixture = await createThrowawaySchool({
+      roles: { admin: true, lehrer: true },
+      withClasses: 1,
+      withTimetableStack: true,
+      namePrefix: 'E2E-SUB-HANDOVER',
+    });
+    await useThrowawaySchoolHeader(context, fixture.schoolId);
 
     const monday = nextMondayISODate();
-    absence = await createAbsenceViaAPI(request, {
-      teacherId: fixture.teacherId, // kc-lehrer absent → kc-lehrer becomes the note author
-      dateFrom: monday,
-      dateTo: monday,
-      reason: 'KRANK',
-    });
+    absence = await createAbsenceViaAPI(
+      request,
+      {
+        teacherId: fixture.timetable!.teacherId, // throwaway lehrer absent → becomes note author
+        dateFrom: monday,
+        dateTo: monday,
+        reason: 'KRANK',
+      },
+      fixture.schoolId,
+    );
     expect(
       absence.affectedLessonCount ?? 0,
       'absence-expansion must produce one PENDING substitution row for the author to attach the note to',
@@ -94,18 +83,11 @@ test.describe('Issue #85 — Uebergabenotiz author flow + attachment (desktop)',
     await loginAsRole(page, 'lehrer');
   });
 
-  test.afterEach(async ({ request }) => {
-    if (absence) {
-      // Substitution is still PENDING (no admin assigned a substitute)
-      // → cancelAbsenceViaAPI's deleteMany(PENDING) sweeps it,
-      // cascading the HandoverNote + HandoverAttachment rows + the
-      // on-disk file (HandoverService.delete unlinks attachments).
-      await cancelAbsenceViaAPI(request, absence.id);
-      absence = undefined;
-    }
+  test.afterEach(async () => {
     if (fixture) {
-      await cleanupTimetableRun(fixture);
+      await fixture.cleanup();
       fixture = undefined;
+      absence = undefined;
     }
   });
 
@@ -126,11 +108,10 @@ test.describe('Issue #85 — Uebergabenotiz author flow + attachment (desktop)',
     ).toBeVisible();
 
     // No-handover-note button label is the default "Uebergabenotiz"
-    // (substitutions.tsx:111). `.first()` covers race-family parallel
-    // absences for kc-lehrer.
+    // (substitutions.tsx:111). Per-school isolation makes `.first()`
+    // race-guards unnecessary.
     await page
       .getByRole('button', { name: 'Uebergabenotiz' })
-      .first()
       .click();
 
     // Editor dialog mounts. Title verbatim from
@@ -177,7 +158,7 @@ test.describe('Issue #85 — Uebergabenotiz author flow + attachment (desktop)',
     // after the mutation, and the persisted note is reachable from
     // the list view.
     await expect(
-      page.getByRole('button', { name: 'Notiz bearbeiten' }).first(),
+      page.getByRole('button', { name: 'Notiz bearbeiten' }),
       'after save, the button must flip to "Notiz bearbeiten" — proves hasHandoverNote refresh',
     ).toBeVisible();
 
@@ -185,7 +166,6 @@ test.describe('Issue #85 — Uebergabenotiz author flow + attachment (desktop)',
     // attachment (HandoverNoteEditor.tsx:103-111).
     await page
       .getByRole('button', { name: 'Notiz bearbeiten' })
-      .first()
       .click();
     await expect(
       page.locator('textarea#handover-content'),
@@ -193,7 +173,7 @@ test.describe('Issue #85 — Uebergabenotiz author flow + attachment (desktop)',
     ).toHaveValue(noteContent);
     await expect(
       page.getByText(attachmentName),
-      'attachment filename must appear in the dialog\'s Anhaenge panel after reopen',
+      "attachment filename must appear in the dialog's Anhaenge panel after reopen",
     ).toBeVisible();
   });
 });

--- a/apps/web/e2e/teacher-substitutions-incoming.spec.ts
+++ b/apps/web/e2e/teacher-substitutions-incoming.spec.ts
@@ -1,39 +1,34 @@
 /**
  * Issue #85 — Teacher "Offene Anfragen" Section 1 (incoming offer).
  *
- * Fourth sub-spec of the Substitutions coverage gap. Locks the
- * substitute-teacher's view of an OFFERED substitution on
+ * Issue #168 (Phase 3.5/6 Batch D) — migrated to throwaway-school per
+ * CLAUDE.md D4. The `active-timetable-run:SEED_SCHOOL_UUID` advisory lock
+ * is gone; each invocation owns its own school. The throwaway timetable
+ * stack + `withSecondTeacherLesson: true` provide both kc-lehrer's lesson
+ * at MONDAY/period-1 and the second lehrer's lesson at MONDAY/period-2
+ * (the substitute-source slot the original spec needed).
+ *
+ * Locks the substitute-teacher's view of an OFFERED substitution on
  * /teacher/substitutions Section 1 — the "Du vertrittst heute…" flow
  * the issue text calls out and PR #94 explicitly deferred.
  *
- *   1. Seed an active TimetableRun with kc-lehrer's lesson at
- *      MONDAY/period-1 + Anna Lehrerin's lesson at MONDAY/period-2
- *      (added via seedSecondTeacherLesson on the SAME run).
- *   2. POST an absence for Anna for next Monday → backend creates a
- *      PENDING Substitution with originalTeacher=Anna.
+ *   1. Throwaway TimetableRun + kc-lehrer's lesson at MONDAY/period-1 +
+ *      a second lehrer's lesson at MONDAY/period-2 (via
+ *      `withSecondTeacherLesson: true`).
+ *   2. POST an absence for the SECOND lehrer for next Monday → backend
+ *      creates a PENDING Substitution with originalTeacher = second lehrer.
  *   3. POST /substitutions/:id/assign with candidateTeacherId =
  *      kc-lehrer.teacher.id → status flips to OFFERED.
  *   4. kc-lehrer logs in → /teacher/substitutions →
  *      `SubstituteOfferCard` renders the offer with
- *      "Vertretung fuer: Anna Lehrerin", an "Angeboten" badge, and
- *      Akzeptieren / Ablehnen CTAs.
+ *      "Vertretung fuer: <second-lehrer-name>", an "Angeboten" badge,
+ *      and Akzeptieren / Ablehnen CTAs.
  *
- * Why this slice was deferred from PR #94: the substitute-side view
- * requires a DIFFERENT teacher's lesson to be the absence target (so
- * kc-lehrer can be the substitute, not the absentee). The previous
- * `seedTimetableRun` fixture only seeded kc-lehrer's lesson, so an
- * absence against any other teacher would expand to zero rows. This
- * PR introduces `seedSecondTeacherLesson` to plug that gap on the
- * SAME TimetableRun (avoids the "multiple active runs" race the prod
- * `activateRun` transaction prevents).
- *
- * Why MONDAY/period-2 for Anna's lesson: kc-lehrer's seed lesson is
- * MONDAY/period-1, so kc-lehrer is FREE at period-2 — the Pitfall-2
- * conflict guard in `substitution.service.ts:91-108` accepts the
- * assign. A colliding slot would 409.
- *
- * Chromium-only-skip per the race-family precedent — shared seed-school
- * mutating specs collide on parallel browser projects.
+ * Why MONDAY/period-2 for the second lehrer's lesson: kc-lehrer's
+ * throwaway lesson is at MONDAY/period-1, so kc-lehrer is FREE at
+ * period-2 — the Pitfall-2 conflict guard in
+ * `substitution.service.ts:91-108` accepts the assign. A colliding
+ * slot would 409.
  */
 import { test, expect } from '@playwright/test';
 import { loginAsRole } from './helpers/login';
@@ -45,17 +40,10 @@ import {
   type CreatedAbsence,
 } from './helpers/substitutions';
 import {
-  cleanupTimetableRun,
-  purgeAbsenceViaPrisma,
-  seedSecondTeacherLesson,
-  seedTimetableRun,
-  type SecondTeacherLessonFixture,
-  type TimetableRunFixture,
-} from './fixtures/timetable-run';
-import {
-  SEED_SCHOOL_UUID,
-  SEED_TEACHER_KC_LEHRER_UUID,
-} from './fixtures/seed-uuids';
+  createThrowawaySchool,
+  type ThrowawaySchoolFixture,
+} from './fixtures/throwaway-school';
+import { useThrowawaySchoolHeader } from './helpers/school-context';
 
 test.describe('Issue #85 — Teacher Offene Anfragen Section 1 (desktop)', () => {
   test.skip(
@@ -63,72 +51,80 @@ test.describe('Issue #85 — Teacher Offene Anfragen Section 1 (desktop)', () =>
     'Section-1 rendering is desktop-only for the first lock; mobile is a follow-up if the SubstituteOfferCard layout drifts.',
   );
 
-  let fixture: TimetableRunFixture | undefined;
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  let second: SecondTeacherLessonFixture | undefined;
+  let fixture: ThrowawaySchoolFixture | undefined;
   let absence: CreatedAbsence | undefined;
-  // OFFERED substitutions are NOT cleaned up by `cancelAbsenceViaAPI`
-  // (the API cancel-handler only deletes PENDING rows — see
-  // teacher-absence.service.ts:253). Track the absence id so afterEach
-  // hard-deletes via Prisma + cascade.
-  let absenceIdForCleanup: string | undefined;
 
-  test.beforeEach(async ({ request }) => {
-    fixture = await seedTimetableRun(SEED_SCHOOL_UUID);
-    second = await seedSecondTeacherLesson(fixture);
+  test.beforeEach(async ({ context, request }) => {
+    fixture = await createThrowawaySchool({
+      roles: { admin: true, lehrer: true },
+      withClasses: 1,
+      withTimetableStack: true,
+      withSecondTeacherLesson: true,
+      namePrefix: 'E2E-SUB-INCOMING',
+    });
+    await useThrowawaySchoolHeader(context, fixture.schoolId);
+
+    const stack = fixture.timetable!;
+    const second = fixture.secondTeacher!;
 
     const monday = nextMondayISODate();
-    absence = await createAbsenceViaAPI(request, {
-      teacherId: second.teacherId, // Anna — NOT kc-lehrer
-      dateFrom: monday,
-      dateTo: monday,
-      reason: 'KRANK',
-    });
-    absenceIdForCleanup = absence.id;
+    absence = await createAbsenceViaAPI(
+      request,
+      {
+        teacherId: second.teacherId, // second lehrer — NOT kc-lehrer
+        dateFrom: monday,
+        dateTo: monday,
+        reason: 'KRANK',
+      },
+      fixture.schoolId,
+    );
     expect(
       absence.affectedLessonCount ?? 0,
-      'absence-expansion must produce one substitution row for Anna\'s MONDAY/period-2 lesson',
+      "absence-expansion must produce one substitution row for the second lehrer's MONDAY/period-2 lesson",
     ).toBeGreaterThan(0);
 
-    // Resolve the PENDING substitution id, then assign kc-lehrer as the
-    // candidate substitute. Both happen as admin (the candidate has no
-    // permission to assign themselves).
-    const subs = await listSubstitutionsViaAPI(request);
+    // Resolve the PENDING substitution id, then assign kc-lehrer (the
+    // throwaway primary teacher) as the candidate substitute.
+    const subs = await listSubstitutionsViaAPI(request, fixture.schoolId);
     const pending = subs.find(
       (s) =>
-        s.originalTeacherId === second!.teacherId &&
+        s.originalTeacherId === second.teacherId &&
         s.dayOfWeek === 'MONDAY' &&
         s.periodNumber === 2 &&
         s.status === 'PENDING',
     );
     expect(
       pending,
-      'admin substitutions list must contain the PENDING row for Anna\'s absence',
+      "admin substitutions list must contain the PENDING row for the second lehrer's absence",
     ).toBeTruthy();
     await assignSubstituteViaAPI(
       request,
       pending!.id,
-      SEED_TEACHER_KC_LEHRER_UUID,
+      stack.teacherId,
+      fixture.schoolId,
     );
   });
 
   test.afterEach(async () => {
-    if (absenceIdForCleanup) {
-      await purgeAbsenceViaPrisma(absenceIdForCleanup);
-      absenceIdForCleanup = undefined;
-      absence = undefined;
-    }
+    // Throwaway-school cleanup cascades the OFFERED Substitution +
+    // TeacherAbsence along with the school — purgeAbsenceViaPrisma is
+    // no longer needed.
     if (fixture) {
-      await cleanupTimetableRun(fixture);
+      await fixture.cleanup();
       fixture = undefined;
-      second = undefined;
+      absence = undefined;
     }
   });
 
-  test('SUB-LEHRER-INCOMING-01: kc-lehrer sees Anna\'s absence as an OFFERED substitution in Section 1 with Accept/Decline CTAs', async ({
+  test("SUB-LEHRER-INCOMING-01: kc-lehrer sees the second lehrer's absence as an OFFERED substitution in Section 1 with Accept/Decline CTAs", async ({
     page,
   }) => {
     if (!fixture) throw new Error('fixture not seeded');
+    const second = fixture.secondTeacher!;
+    // SubstituteOfferCard renders the second teacher's name in
+    // "{firstName} {lastName}" order; `teacherFullName` is the throwaway
+    // fixture's matching alias to that exact format.
+    const expectedName = second.teacherFullName;
 
     await loginAsRole(page, 'lehrer');
     await page.goto('/teacher/substitutions');
@@ -147,19 +143,19 @@ test.describe('Issue #85 — Teacher Offene Anfragen Section 1 (desktop)', () =>
     ).toHaveCount(0);
 
     // SubstituteOfferCard renders "Vertretung fuer: <strong>{name}</strong>"
-    // (SubstituteOfferCard.tsx:117). Anna Lehrerin is the original
-    // teacher of the absence we created above. `.first()` covers the
-    // race-family case where another spec leaks an OFFERED row to
-    // kc-lehrer with the same originalTeacher.
+    // (SubstituteOfferCard.tsx:117). Per-school isolation removes the
+    // need for `.first()` race-guards.
     await expect(
-      page.getByText(/Vertretung fuer:\s*Anna Lehrerin/).first(),
-      'card must show the absent teacher\'s name as the offer subject',
+      page.getByText(
+        new RegExp(`Vertretung fuer:\\s*${expectedName.replace(/ /g, '\\s+')}`),
+      ),
+      "card must show the absent teacher's name as the offer subject",
     ).toBeVisible();
 
     // "Angeboten" badge on the card proves the row's status flipped to
     // OFFERED (SubstituteOfferCard.tsx:121).
     await expect(
-      page.getByText('Angeboten').first(),
+      page.getByText('Angeboten'),
       'OFFERED badge must render — guards against the row leaking as PENDING/CONFIRMED',
     ).toBeVisible();
 
@@ -167,10 +163,10 @@ test.describe('Issue #85 — Teacher Offene Anfragen Section 1 (desktop)', () =>
     // a confirm dialog; we only verify presence here — the
     // accept/decline mutation is a separate slice.)
     await expect(
-      page.getByRole('button', { name: 'Akzeptieren' }).first(),
+      page.getByRole('button', { name: 'Akzeptieren' }),
     ).toBeVisible();
     await expect(
-      page.getByRole('button', { name: 'Ablehnen' }).first(),
+      page.getByRole('button', { name: 'Ablehnen' }),
     ).toBeVisible();
   });
 });

--- a/apps/web/e2e/teacher-substitutions-my-absences.spec.ts
+++ b/apps/web/e2e/teacher-substitutions-my-absences.spec.ts
@@ -1,45 +1,40 @@
 /**
  * Issue #85 — Teacher "Meine Abwesenheiten" view.
  *
- * Second sub-spec of the Substitutions coverage gap. Locks the absent-
- * teacher's view of their auto-generated substitution rows on
- * /teacher/substitutions:
+ * Issue #168 (Phase 3.5/6 Batch D) — migrated to throwaway-school per
+ * CLAUDE.md D4. The `active-timetable-run:SEED_SCHOOL_UUID` advisory lock
+ * is gone; each invocation owns its own school. The class name override
+ * (`classNames: ['1A']`) keeps the row-text assertion stable since the
+ * substitution panel renders `<subjectAbbreviation> · <className>`.
  *
- *   1. Seed an active TimetableRun with one lesson at MONDAY/period-1
- *      for class 1A, taught by kc-lehrer (Maria Mueller).
- *   2. POST an absence for kc-lehrer covering the upcoming Monday →
- *      backend auto-expands to one Substitution row with
- *      originalTeacherId = kc-lehrer.teacher.id.
- *   3. kc-lehrer logs in → /teacher/substitutions → Section 2
- *      ("Meine Abwesenheiten") surfaces the row with subject + class +
- *      period + a PENDING status badge.
+ * Locks the absent-teacher's view of their auto-generated substitution
+ * rows on /teacher/substitutions:
  *
- * Why this slice: it exercises GET /substitutions/my-absences
- * (substitution.controller.ts:43) and the SubstitutionDto join chain
- * (subjectAbbreviation, className, periodNumber), plus the
- * useMyAbsenceSubstitutions hook + the page's Section-2 render
- * branch. Section 1 ("Offene Anfragen" / OFFERED to me) is deferred to
- * a follow-up sub-spec — that requires a second teacher with their own
- * lesson + an admin assigning kc-lehrer as substitute, which is
- * out-of-scope for this PR's seed surface.
+ *   1. Throwaway TimetableRun + one lesson at MONDAY/period-1 for the
+ *      throwaway lehrer (bound to kc-lehrer's KC user).
+ *   2. POST an absence for the throwaway lehrer covering the upcoming
+ *      Monday → backend auto-expands to one Substitution row.
+ *   3. kc-lehrer logs in → /teacher/substitutions → Section 2 ("Meine
+ *      Abwesenheiten") surfaces the row with subject + class + period
+ *      + a PENDING status badge.
  *
- * Chromium-only-skip per the race-family precedent — shared seed-school
- * mutating specs collide on parallel browser projects.
+ * Exercises GET /substitutions/my-absences (substitution.controller.ts:43)
+ * and the SubstitutionDto join chain (subjectAbbreviation, className,
+ * periodNumber), plus the useMyAbsenceSubstitutions hook + the page's
+ * Section-2 render branch.
  */
 import { test, expect } from '@playwright/test';
 import { loginAsRole } from './helpers/login';
 import {
-  cancelAbsenceViaAPI,
   createAbsenceViaAPI,
   nextMondayISODate,
   type CreatedAbsence,
 } from './helpers/substitutions';
 import {
-  cleanupTimetableRun,
-  seedTimetableRun,
-  type TimetableRunFixture,
-} from './fixtures/timetable-run';
-import { SEED_SCHOOL_UUID } from './fixtures/seed-uuids';
+  createThrowawaySchool,
+  type ThrowawaySchoolFixture,
+} from './fixtures/throwaway-school';
+import { useThrowawaySchoolHeader } from './helpers/school-context';
 
 test.describe('Issue #85 — Teacher Meine Abwesenheiten (desktop)', () => {
   test.skip(
@@ -47,26 +42,33 @@ test.describe('Issue #85 — Teacher Meine Abwesenheiten (desktop)', () => {
     'Section-2 rendering is identical across viewports — desktop only for the first lock.',
   );
 
-  // Per-test seed; describe-level test.skip does NOT gate beforeAll/afterAll
-  // (lesson from #86 / #81). Per-test hooks ARE gated; the if-guard belts-and-
-  // braces against half-applied state from a failed seed.
-  let fixture: TimetableRunFixture | undefined;
+  let fixture: ThrowawaySchoolFixture | undefined;
   let absence: CreatedAbsence | undefined;
 
-  test.beforeEach(async ({ page, request }) => {
-    fixture = await seedTimetableRun(SEED_SCHOOL_UUID);
+  test.beforeEach(async ({ context, page, request }) => {
+    fixture = await createThrowawaySchool({
+      roles: { admin: true, lehrer: true },
+      withClasses: 1,
+      classNames: ['1A'],
+      withTimetableStack: true,
+      namePrefix: 'E2E-SUB-LEHRER',
+    });
+    await useThrowawaySchoolHeader(context, fixture.schoolId);
 
     // Seed the absence BEFORE the lehrer logs in — the admin token comes
     // from request.context (helpers/login.getAdminToken) and is independent
-    // of the page's Keycloak session. Doing this in beforeEach keeps the
-    // test body focused on the rendered UI.
+    // of the page's Keycloak session.
     const monday = nextMondayISODate();
-    absence = await createAbsenceViaAPI(request, {
-      teacherId: fixture.teacherId,
-      dateFrom: monday,
-      dateTo: monday,
-      reason: 'KRANK',
-    });
+    absence = await createAbsenceViaAPI(
+      request,
+      {
+        teacherId: fixture.timetable!.teacherId,
+        dateFrom: monday,
+        dateTo: monday,
+        reason: 'KRANK',
+      },
+      fixture.schoolId,
+    );
     expect(
       absence.affectedLessonCount ?? 0,
       'absence-expansion must create at least one substitution row',
@@ -75,14 +77,13 @@ test.describe('Issue #85 — Teacher Meine Abwesenheiten (desktop)', () => {
     await loginAsRole(page, 'lehrer');
   });
 
-  test.afterEach(async ({ request }) => {
-    if (absence) {
-      await cancelAbsenceViaAPI(request, absence.id);
-      absence = undefined;
-    }
+  test.afterEach(async () => {
+    // Throwaway-school cleanup cascades through TeacherAbsence +
+    // Substitution + HandoverNote rows — no explicit cancel needed.
     if (fixture) {
-      await cleanupTimetableRun(fixture);
+      await fixture.cleanup();
       fixture = undefined;
+      absence = undefined;
     }
   });
 
@@ -90,6 +91,7 @@ test.describe('Issue #85 — Teacher Meine Abwesenheiten (desktop)', () => {
     page,
   }) => {
     if (!fixture) throw new Error('fixture not seeded');
+    const stack = fixture.timetable!;
 
     await page.goto('/teacher/substitutions');
 
@@ -105,30 +107,23 @@ test.describe('Issue #85 — Teacher Meine Abwesenheiten (desktop)', () => {
     ).toBeVisible();
 
     // The Section-2 empty state must NOT appear — our admin-created
-    // absence for kc-lehrer should populate this section. (Section-1
-    // empty state "Keine offenen Vertretungsanfragen" may legitimately
-    // still appear because no admin has assigned kc-lehrer as a
-    // substitute in this spec — that's the SUB-LEHRER-02 slice.)
+    // absence for the throwaway lehrer should populate this section.
     await expect(
       page.getByText('Keine aktiven Abwesenheiten'),
       'Section-2 empty state must not appear when the absent teacher has at least one substitution row',
     ).toHaveCount(0);
 
     // Substitution row data — assert on the period + subject from the
-    // seedTimetableRun fixture. The "X. Stunde" rendering is on
+    // throwaway timetable stack. The "X. Stunde" rendering is on
     // substitutions.tsx:93; subjectAbbreviation comes from the join in
     // findByAbsentUser (substitution.service.ts) and surfaces as
     // SubstitutionDto.subjectAbbreviation.
     await expect(
-      page
-        .getByText(/1\.\s*Stunde/)
-        .first(),
-      'fixture seeds MONDAY/period-1 — the row must render "1. Stunde"',
+      page.getByText(/1\.\s*Stunde/),
+      'throwaway seeds MONDAY/period-1 — the row must render "1. Stunde"',
     ).toBeVisible();
     await expect(
-      page
-        .getByText(new RegExp(`${fixture.subjectAbbreviation}\\s*·\\s*1A`))
-        .first(),
+      page.getByText(new RegExp(`${stack.subjectAbbreviation}\\s*·\\s*1A`)),
       'row must render "<subjectAbbreviation> · <className>" from the join',
     ).toBeVisible();
 
@@ -137,17 +132,16 @@ test.describe('Issue #85 — Teacher Meine Abwesenheiten (desktop)', () => {
     // stays at PENDING. Badge text comes from SubstitutionDto.status
     // verbatim (substitutions.tsx:98).
     await expect(
-      page.getByText('PENDING').first(),
+      page.getByText('PENDING'),
       'newly-generated substitution must render the PENDING status badge in Section 2',
     ).toBeVisible();
 
     // "Uebergabenotiz" button — when no handover note exists yet, the
     // button label is the German default (substitutions.tsx:111). This
     // both locks the no-note state AND verifies the button is reachable
-    // from this view (SUB-LEHRER-HANDOVER follow-up spec drives the
-    // editor open and asserts the saved note round-trips).
+    // from this view.
     await expect(
-      page.getByRole('button', { name: 'Uebergabenotiz' }).first(),
+      page.getByRole('button', { name: 'Uebergabenotiz' }),
       'no-handover-note button label must be "Uebergabenotiz" by default',
     ).toBeVisible();
   });


### PR DESCRIPTION
Closes #168. Closes #153 (Phase 3.5/6 tracking) — final batch.

## Summary

- Migrates `substitutions-handover`, `teacher-substitutions-my-absences`, and `teacher-substitutions-incoming` to `createThrowawaySchool({ withTimetableStack: true, withSecondTeacherLesson? })`.
- The `incoming` spec uses `withSecondTeacherLesson: true` — the fixture's mirror of the legacy `seedSecondTeacherLesson` companion (same Run + ClassSubject + Room + MONDAY/period-2 lesson).
- `helpers/substitutions.ts`: `SUBSTITUTIONS_SCHOOL_ID` constant + default-param values are removed. All 5 callers across Batches A + D now pass `fixture.schoolId` explicitly.
- Per-school isolation drops the legacy cleanup machinery: `purgeStaleE2EHandoverNotes`, `purgeAbsenceViaPrisma`, and the `cancelAbsenceViaAPI` belt-and-braces calls are gone — the throwaway-school cascade-delete covers everything.

## Files migrated

- `apps/web/e2e/substitutions-handover.spec.ts`
- `apps/web/e2e/teacher-substitutions-my-absences.spec.ts`
- `apps/web/e2e/teacher-substitutions-incoming.spec.ts`

## Helper change

- `apps/web/e2e/helpers/substitutions.ts` — drops `SUBSTITUTIONS_SCHOOL_ID` + defaults; all 4 exported helpers now require an explicit `schoolId` argument. Migrated Batch A callers already passed it; this PR makes the signature required.

## fixtures/timetable-run.ts

`grep` across `apps/web/e2e/` confirms ZERO runtime importers of `seedTimetableRun`, `cleanupTimetableRun`, `seedSecondTeacherLesson`, `purgeStaleE2EHandoverNotes`, `purgeAbsenceViaPrisma`, `seedTimetableEdit`, `cleanupTimetableEdit`, or any of the matching type exports. Only docstring/comment references remain (intentional — they describe the historical race-pattern). The file is now dead code; deletion is staged for **#155** (Phase 3.5/8) alongside the advisory-lock helper + e2e-sweep-canary retirement.

## D-Direktiven check

- D3: merge only on full-green CI.
- D4: no new chromium-only race skips. Existing `isMobile` viewport skips stay.
- D5/D6: #168 linked to parent #153 + was blocked-by #167 (now CLOSED).

## Test plan

- [ ] CI cross-project parallel run green (chromium + firefox).
- [ ] `helpers/substitutions.ts` runtime callers all pass explicit `schoolId` (verified via grep — no fallbacks remain).
- [ ] `fixtures/timetable-run.ts` is import-free across the spec tree (verified via grep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)