### PR TITLE
feat(seed): #175 — Demo-Seed mit realer Datendichte (12 Klassen / 336 Schüler / 622 Eltern / 32 Lehrer)

### DIFF
--- a/apps/api/prisma/__tests__/seed-data.spec.ts
+++ b/apps/api/prisma/__tests__/seed-data.spec.ts
@@ -1,0 +1,198 @@
+/**
+ * #175 — Sanity tests for the deterministic seed-data module.
+ *
+ * No DB / no Keycloak — pure-function checks that:
+ *   - Counts match testdaten.md (336 students, 311 families, 32 teachers, …)
+ *   - UUIDs are unique across the module
+ *   - Group memberships sum to the expected 12 × 28 × 2 = 672
+ *   - Family-IDs cover every student exactly once
+ *   - ClassSubject count and group-split math agree with testdaten.md
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  buildBulkSchoolData,
+  getBulkClasses,
+  getBulkClassSubjects,
+  getBulkRooms,
+  getBulkSchulleitung,
+  getBulkSubjects,
+  getBulkTeacherAbsences,
+  getBulkTeachers,
+  getParallelLegacyUsers,
+} from '../seed-data';
+
+describe('#175 seed-data — counts match testdaten.md', () => {
+  it('19 rooms', () => {
+    expect(getBulkRooms()).toHaveLength(19);
+  });
+
+  it('12 classes', () => {
+    expect(getBulkClasses()).toHaveLength(12);
+  });
+
+  it('14 subjects', () => {
+    expect(getBulkSubjects()).toHaveLength(14);
+  });
+
+  it('32 bulk teachers', () => {
+    expect(getBulkTeachers()).toHaveLength(32);
+  });
+
+  it('336 bulk students (28 per class × 12 classes)', () => {
+    const { students } = buildBulkSchoolData();
+    expect(students).toHaveLength(336);
+    // 28 per class
+    const byClass = new Map<number, number>();
+    for (const s of students) {
+      byClass.set(s.classIndex, (byClass.get(s.classIndex) ?? 0) + 1);
+    }
+    for (const [, count] of byClass) expect(count).toBe(28);
+  });
+
+  it('311 families (286 single + 25 sibling pairs)', () => {
+    const { families } = buildBulkSchoolData();
+    expect(families).toHaveLength(311);
+    const singles = families.filter((f) => f.childGlobalIndexes.length === 1);
+    const pairs   = families.filter((f) => f.childGlobalIndexes.length === 2);
+    expect(singles).toHaveLength(286);
+    expect(pairs).toHaveLength(25);
+  });
+
+  it('5 parallel-legacy users (kc-admin/lehrer/eltern/schueler/schulleitung)', () => {
+    const users = getParallelLegacyUsers();
+    expect(users).toHaveLength(5);
+    expect(users.map((u) => u.kcUsername).sort()).toEqual(
+      ['kc-admin', 'kc-eltern', 'kc-lehrer', 'kc-schueler', 'kc-schulleitung'],
+    );
+  });
+
+  it('1 schulleitung-01', () => {
+    expect(getBulkSchulleitung().kcUsername).toBe('schulleitung-01');
+  });
+
+  it('3 teacher absences', () => {
+    expect(getBulkTeacherAbsences()).toHaveLength(3);
+  });
+});
+
+describe('#175 seed-data — UUID uniqueness', () => {
+  it('all KC-User UUIDs are globally distinct', () => {
+    const { students, families } = buildBulkSchoolData();
+    const all: string[] = [];
+    all.push(...students.map((s) => s.kcUuid));
+    for (const f of families) all.push(f.mother.kcUuid, f.father.kcUuid);
+    all.push(...getBulkTeachers().map((t) => t.kcUuid));
+    all.push(getBulkSchulleitung().kcUuid);
+    all.push(...getParallelLegacyUsers().map((u) => u.kcUuid));
+    expect(new Set(all).size).toBe(all.length);
+  });
+
+  it('all Person UUIDs distinct', () => {
+    const { students, families } = buildBulkSchoolData();
+    const all: string[] = [];
+    all.push(...students.map((s) => s.personUuid));
+    for (const f of families) all.push(f.mother.personUuid, f.father.personUuid);
+    all.push(...getBulkTeachers().map((t) => t.personUuid));
+    all.push(getBulkSchulleitung().personUuid);
+    all.push(...getParallelLegacyUsers().map((u) => u.personUuid));
+    expect(new Set(all).size).toBe(all.length);
+  });
+
+  it('all room UUIDs distinct', () => {
+    const ids = getBulkRooms().map((r) => r.uuid);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe('#175 seed-data — family / sibling integrity', () => {
+  it('every student belongs to exactly one family', () => {
+    const { students, families } = buildBulkSchoolData();
+    const owned = new Map<number, number>();
+    for (const f of families) {
+      for (const gi of f.childGlobalIndexes) {
+        if (owned.has(gi)) throw new Error(`Student ${gi} in two families`);
+        owned.set(gi, f.familyId);
+      }
+    }
+    expect(owned.size).toBe(336);
+    for (const s of students) expect(owned.get(s.globalIndex)).toBe(s.familyId);
+  });
+
+  it('sibling pairs share lastName + are in different stages', () => {
+    const { students, families } = buildBulkSchoolData();
+    const pairs = families.filter((f) => f.childGlobalIndexes.length === 2);
+    for (const f of pairs) {
+      const [aIdx, bIdx] = f.childGlobalIndexes;
+      const a = students.find((s) => s.globalIndex === aIdx)!;
+      const b = students.find((s) => s.globalIndex === bIdx)!;
+      expect(a.lastName).toBe(b.lastName);
+      expect(a.yearLevel).not.toBe(b.yearLevel);
+    }
+  });
+});
+
+describe('#175 seed-data — ClassSubject math', () => {
+  it('174 total class-subject rows', () => {
+    const cs = getBulkClassSubjects(
+      getBulkClasses(),
+      getBulkSubjects(),
+      getBulkTeachers(),
+    );
+    expect(cs).toHaveLength(174);
+  });
+
+  it('each E ClassSubject has a LANGUAGE group', () => {
+    const cs = getBulkClassSubjects(
+      getBulkClasses(),
+      getBulkSubjects(),
+      getBulkTeachers(),
+    );
+    const e = cs.filter((r) => r.subjectShort === 'E');
+    expect(e).toHaveLength(24);  // 12 classes × 2 groups
+    for (const r of e) {
+      expect(r.groupName === 'E-Gruppe-1' || r.groupName === 'E-Gruppe-2').toBe(true);
+    }
+  });
+
+  it('each RE ClassSubject has a RELIGION group and the assigned teacher matches', () => {
+    const cs = getBulkClassSubjects(
+      getBulkClasses(),
+      getBulkSubjects(),
+      getBulkTeachers(),
+    );
+    const re = cs.filter((r) => r.subjectShort === 'RE');
+    expect(re).toHaveLength(24); // 12 classes × 2 groups
+    const teachers = getBulkTeachers();
+    const reKat = teachers.find((t) => t.kcUsername === 'l-re-01')!.index;
+    const reEv  = teachers.find((t) => t.kcUsername === 'l-re-02')!.index;
+    for (const r of re) {
+      if (r.groupName === 'RE-katholisch')  expect(r.teacherIndex).toBe(reKat);
+      if (r.groupName === 'RE-evangelisch') expect(r.teacherIndex).toBe(reEv);
+    }
+  });
+
+  it('GS is absent for stage-5 classes (1A/B/C)', () => {
+    const cs = getBulkClassSubjects(
+      getBulkClasses(),
+      getBulkSubjects(),
+      getBulkTeachers(),
+    );
+    const classes = getBulkClasses();
+    const stage5Indexes = new Set(classes.filter((c) => c.yearLevel === 5).map((c) => c.index));
+    const gsForStage5 = cs.filter((r) => r.subjectShort === 'GS' && stage5Indexes.has(r.classIndex));
+    expect(gsForStage5).toHaveLength(0);
+  });
+
+  it('CH appears only for stage-8 classes (4A/B/C)', () => {
+    const cs = getBulkClassSubjects(
+      getBulkClasses(),
+      getBulkSubjects(),
+      getBulkTeachers(),
+    );
+    const classes = getBulkClasses();
+    const stage8Indexes = new Set(classes.filter((c) => c.yearLevel === 8).map((c) => c.index));
+    const ch = cs.filter((r) => r.subjectShort === 'CH');
+    expect(ch).toHaveLength(3);
+    for (const r of ch) expect(stage8Indexes.has(r.classIndex)).toBe(true);
+  });
+});

--- a/apps/api/prisma/seed-data.ts
+++ b/apps/api/prisma/seed-data.ts
@@ -1,0 +1,882 @@
+/**
+ * Demo-Seed Daten-Modul (#175) — Single source of truth.
+ *
+ * Spec: /testdaten.md. Konsumenten:
+ *   - apps/api/prisma/seed.ts → DB-Seeding (Persons, Teachers, Students,
+ *     Parents, ParentStudent, SchoolClasses, Rooms, Subjects, ClassSubjects,
+ *     Groups, GroupMemberships, TeacherAbsences).
+ *   - scripts/generate-realm-users.ts → Generiert den `users[]`-Block in
+ *     docker/keycloak/realm-export.json.
+ *
+ * Determinismus:
+ *   - Alle Listen sind aus festen Indexen + Pools aufgebaut → identische
+ *     Reihenfolge & UUIDs über Re-Seed-Cycles.
+ *   - UUID-Schema dokumentiert in `UUID_PREFIX_*` Konstanten unten.
+ *
+ * Backward-Compat:
+ *   - Die 5 echten Legacy-KC-User (admin-user / lehrer-user / eltern-user /
+ *     schueler-user / schulleitung-user mit UUIDs `00000000-0000-0000-0000-
+ *     00000000000{1..5}`) sind NICHT Teil dieses Moduls — sie bleiben
+ *     direkt in seed.ts + realm-export.json unverändert.
+ *   - Die 5 zusätzlichen `kc-*` Parallel-User aus testdaten.md
+ *     (kc-admin / kc-lehrer / kc-eltern / kc-schueler / kc-schulleitung)
+ *     werden hier definiert und kommen PARALLEL zu den Legacy-5 hinzu.
+ */
+
+// =====================================================
+// UUID-Schema
+// =====================================================
+//
+// KC-User-UUIDs (gehen in realm-export.json + werden in Person.keycloakUserId
+// gespiegelt):
+//   `aaaaaaaa-0000-4000-8000-00000000000{1..5}` → kc-* Parallel-Legacy
+//   `bbbb0000-0000-4000-8000-000000000001`       → schulleitung-01
+//   `bbbb1000-0000-4000-8000-{nr 1..32}`         → Bulk-Lehrer
+//   `cccc0000-0000-4000-8000-{nr 1..336}`        → Bulk-Schüler
+//   `dddd0000-0000-4000-8000-{nr 1..622}`        → Bulk-Eltern
+//
+// Person.id (DB):
+//   `b1000000-0000-4000-8000-{nr 1..32}` → Bulk-Lehrer-Person
+//   `b2000000-0000-4000-8000-000000000001` → Schulleitung-01-Person
+//   `c1000000-0000-4000-8000-{nr 1..336}` → Bulk-Schüler-Person
+//   `c2000000-0000-4000-8000-{nr 1..622}` → Bulk-Eltern-Person
+//   `d1000000-0000-4000-8000-{nr 1..5}`   → Parallel-kc-* Person
+//
+// Teacher.id:
+//   `f1000000-0000-4000-8000-{nr 1..32}`  → Bulk-Lehrer
+//   `f2000000-0000-4000-8000-000000000001` → Schulleitung-01-Teacher
+//
+// Student.id: `e1000000-0000-4000-8000-{nr 1..336}`
+// Parent.id:  `c3000000-0000-4000-8000-{nr 1..622}`
+// ParentStudent.id: `c4000000-0000-4000-8000-{nr 1..~1500}`
+//
+// Room.id (neu 19): `31000000-0000-4000-8000-{nr 1..19}`
+// SchoolClass.id (10 neue 2A-4C): `21000000-0000-4000-8000-{nr 1..10}`
+//   (Existierende 1A/1B-Klassen behalten slug-IDs `seed-class-1a`/`seed-class-1b`)
+// Subject.id (10 neue): `22000000-0000-4000-8000-{nr 1..10}`
+//   (Existierende D/M/E/BSP behalten slug-IDs `seed-subject-{d,m,e,bsp}`)
+// Group.id: `23000000-0000-4000-8000-{nr 1..48}` (12 Klassen × 4 Gruppen)
+// GroupMembership.id: `24000000-0000-4000-8000-{nr 1..672}` (12×28×2)
+// ClassSubject.id: `25000000-0000-4000-8000-{nr 1..~174}`
+// TeacherAbsence.id: `26000000-0000-4000-8000-{nr 1..3}`
+// Parallel-kc-* Person/Teacher-Records: `11000000-0000-4000-8000-{nr 1..N}`
+//   (Legacy-Familie `10000000-*` ist für die 5 echten Legacy-User reserviert.)
+
+// =====================================================
+// Helpers
+// =====================================================
+
+/** Format integer as 12-digit zero-padded suffix for UUID v4 layout. */
+function nr12(n: number): string {
+  return String(n).padStart(12, '0');
+}
+
+function uuid(prefix: string, n: number): string {
+  // UUID v4 layout = 8-4-4-4-12. Suffix is the 12-char block, so the
+  // prefix MUST be exactly 8+1+4+1+4+1+4+1 = 24 chars ("xxxxxxxx-xxxx-4xxx-8xxx-").
+  if (prefix.length !== 24) {
+    throw new Error(
+      `UUID prefix must be exactly 24 chars (e.g. "b1000000-0000-4000-8000-"), got "${prefix}" (${prefix.length} chars)`,
+    );
+  }
+  return `${prefix}${nr12(n)}`;
+}
+
+// 4-block prefixes for KC-User-UUIDs (8-4-4-4 = 23 chars + dash)
+const KC_PARALLEL_PREFIX     = 'aaaaaaaa-0000-4000-8000-';
+const KC_SCHULLEITUNG_PREFIX = 'bbbb0000-0000-4000-8000-';
+const KC_BULK_LEHRER_PREFIX  = 'bbbb1000-0000-4000-8000-';
+const KC_BULK_SCHUELER_PREFIX = 'cccc0000-0000-4000-8000-';
+const KC_BULK_ELTERN_PREFIX  = 'dddd0000-0000-4000-8000-';
+
+// 4-block prefixes for DB-Record-UUIDs
+const PERSON_BULK_LEHRER_PREFIX     = 'b1000000-0000-4000-8000-';
+const PERSON_SCHULLEITUNG_PREFIX    = 'b2000000-0000-4000-8000-';
+const PERSON_BULK_SCHUELER_PREFIX   = 'c1000000-0000-4000-8000-';
+const PERSON_BULK_ELTERN_PREFIX     = 'c2000000-0000-4000-8000-';
+const PERSON_PARALLEL_KC_PREFIX     = 'd1000000-0000-4000-8000-';
+
+const TEACHER_BULK_PREFIX           = 'f1000000-0000-4000-8000-';
+const TEACHER_SCHULLEITUNG_PREFIX   = 'f2000000-0000-4000-8000-';
+const STUDENT_BULK_PREFIX           = 'e1000000-0000-4000-8000-';
+const PARENT_BULK_PREFIX            = 'c3000000-0000-4000-8000-';
+const PARENT_STUDENT_BULK_PREFIX    = 'c4000000-0000-4000-8000-';
+
+const ROOM_NEW_PREFIX               = '31000000-0000-4000-8000-';
+const CLASS_NEW_PREFIX              = '21000000-0000-4000-8000-';
+const SUBJECT_NEW_PREFIX            = '22000000-0000-4000-8000-';
+const GROUP_PREFIX                  = '23000000-0000-4000-8000-';
+const GROUP_MEMBERSHIP_PREFIX       = '24000000-0000-4000-8000-';
+const CLASS_SUBJECT_PREFIX          = '25000000-0000-4000-8000-';
+const TEACHER_ABSENCE_PREFIX        = '26000000-0000-4000-8000-';
+const PARALLEL_KC_TEACHER_PREFIX    = '11000000-0000-4000-8000-';
+const PARALLEL_KC_PARENT_PREFIX     = '11000000-0000-4000-8000-';
+// Parallel-kc-* Student / Parent / ParentStudent share the 11* family —
+// distinct sub-ranges (see SHADOW_*_OFFSET below).
+
+// Offsets within the `11000000-*` family for parallel-kc-* records.
+// Layout: 1..10 for teachers/schulleitung, 100+ for students, 200+ for
+// parents, 300+ for parent-student joins. Keeps each subrange comfortably
+// distinct from each other and from any future expansion.
+const SHADOW_TEACHER_OFFSET = 0;     // 1..5
+const SHADOW_STUDENT_OFFSET = 100;   // 101+
+const SHADOW_PARENT_OFFSET  = 200;   // 201+
+
+/**
+ * Date helpers (used by TeacherAbsence — must always be "in the future"
+ * across re-seeds).
+ */
+function nextMondayDate(anchor: Date = new Date()): Date {
+  const d = new Date(anchor);
+  const jsDay = d.getDay(); // 0=Sun..6=Sat
+  const offset = jsDay === 1 ? 0 : (8 - jsDay) % 7;
+  d.setDate(d.getDate() + offset);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+function addDays(d: Date, n: number): Date {
+  const r = new Date(d);
+  r.setDate(r.getDate() + n);
+  return r;
+}
+
+// =====================================================
+// Rooms (19 Stück, testdaten.md §Räume)
+// =====================================================
+
+export interface BulkRoom {
+  index: number;            // 1..19
+  uuid: string;
+  name: string;
+  roomType: 'KLASSENZIMMER' | 'TURNSAAL' | 'EDV_RAUM' | 'LABOR';
+  capacity: number;
+  equipment: string[];
+}
+
+export function getBulkRooms(): BulkRoom[] {
+  const rooms: BulkRoom[] = [];
+  // 12 Klassenzimmer (1A-4C)
+  const classRoomNames = [
+    'Klassenzimmer 1A','Klassenzimmer 1B','Klassenzimmer 1C',
+    'Klassenzimmer 2A','Klassenzimmer 2B','Klassenzimmer 2C',
+    'Klassenzimmer 3A','Klassenzimmer 3B','Klassenzimmer 3C',
+    'Klassenzimmer 4A','Klassenzimmer 4B','Klassenzimmer 4C',
+  ];
+  for (let i = 0; i < classRoomNames.length; i++) {
+    rooms.push({
+      index: i + 1,
+      uuid: uuid(ROOM_NEW_PREFIX, i + 1),
+      name: classRoomNames[i],
+      roomType: 'KLASSENZIMMER',
+      capacity: 30,
+      equipment: ['Overheadprojektor'],
+    });
+  }
+  // 2 Turnsäle
+  rooms.push(
+    { index: 13, uuid: uuid(ROOM_NEW_PREFIX, 13), name: 'Turnsaal 1', roomType: 'TURNSAAL', capacity: 60, equipment: ['Sportgeräte'] },
+    { index: 14, uuid: uuid(ROOM_NEW_PREFIX, 14), name: 'Turnsaal 2', roomType: 'TURNSAAL', capacity: 60, equipment: ['Sportgeräte'] },
+  );
+  // 3 Labors (Bio/Chemie/Physik)
+  rooms.push(
+    { index: 15, uuid: uuid(ROOM_NEW_PREFIX, 15), name: 'Biologiesaal', roomType: 'LABOR', capacity: 30, equipment: ['Overheadprojektor','Mikroskope','Modelle'] },
+    { index: 16, uuid: uuid(ROOM_NEW_PREFIX, 16), name: 'Chemiesaal',   roomType: 'LABOR', capacity: 30, equipment: ['Overheadprojektor','Abzug','Bunsenbrenner'] },
+    { index: 17, uuid: uuid(ROOM_NEW_PREFIX, 17), name: 'Physiksaal',   roomType: 'LABOR', capacity: 30, equipment: ['Overheadprojektor','Experimentier-Set','Stromversorgung'] },
+  );
+  // 2 Computersäle
+  rooms.push(
+    { index: 18, uuid: uuid(ROOM_NEW_PREFIX, 18), name: 'Computersaal 1', roomType: 'EDV_RAUM', capacity: 28, equipment: ['28 PCs','Beamer','Whiteboard'] },
+    { index: 19, uuid: uuid(ROOM_NEW_PREFIX, 19), name: 'Computersaal 2', roomType: 'EDV_RAUM', capacity: 28, equipment: ['28 PCs','Beamer','Whiteboard'] },
+  );
+  return rooms;
+}
+
+// =====================================================
+// Classes (12 Stück, testdaten.md §Klassen)
+// =====================================================
+
+export interface BulkClass {
+  index: number;            // 1..12
+  /** UUID for the 10 NEW classes (2A-4C). For 1A/1B the existing slug IDs
+   *  `seed-class-1a` / `seed-class-1b` are used — this field carries
+   *  that slug for 1A/1B (no `uuid` generation). */
+  id: string;
+  name: string;             // "1A".."4C"
+  yearLevel: number;        // 5..8
+  homeRoomIndex: number;    // → BulkRoom.index (1..12)
+  /** 1-based BulkTeacher.index of the Klassenvorstand. */
+  kvTeacherIndex: number;
+}
+
+export function getBulkClasses(): BulkClass[] {
+  const classNames = ['1A','1B','1C','2A','2B','2C','3A','3B','3C','4A','4B','4C'];
+  // testdaten.md §Klassen — KV-Mapping:
+  //  1A→l-d-01 (#1), 1B→l-m-01 (#4), 1C→l-e-01 (#7),
+  //  2A→l-d-02 (#2), 2B→l-m-02 (#5), 2C→l-e-02 (#8),
+  //  3A→l-d-03 (#3), 3B→l-m-03 (#6), 3C→l-e-03 (#9),
+  //  4A→l-gw-01 (#10), 4B→l-gs-01 (#11), 4C→l-bu-01 (#12)
+  const kvIndexes = [1, 4, 7, 2, 5, 8, 3, 6, 9, 10, 11, 12];
+  return classNames.map((name, i) => {
+    const yearLevel = 5 + Math.floor(i / 3); // 1A/B/C=5, 2A/B/C=6, ...
+    // 1A and 1B retain the slug IDs from the pre-#175 seed (referenced
+    // by SEED_PERSON_KC_SCHUELER / 6 legacy students in class1A/1B).
+    const id = name === '1A' ? 'seed-class-1a'
+             : name === '1B' ? 'seed-class-1b'
+             : uuid(CLASS_NEW_PREFIX, i + 1 - 2); // 1C is #3 → uuid index 1, 2A is #4 → 2, ... 4C is #12 → 10
+    return {
+      index: i + 1,
+      id,
+      name,
+      yearLevel,
+      homeRoomIndex: i + 1, // 1A→Klassenzimmer 1A is room.index 1
+      kvTeacherIndex: kvIndexes[i],
+    };
+  });
+}
+
+// =====================================================
+// Subjects (14 Stück, testdaten.md §Fächer + Stundentafel)
+// =====================================================
+
+export type SubjectShort =
+  | 'D' | 'M' | 'E' | 'GW' | 'GS' | 'BE' | 'ME' | 'BU'
+  | 'PH' | 'CH' | 'INF' | 'BSP' | 'RE' | 'WE';
+
+export interface BulkSubject {
+  shortName: SubjectShort;
+  fullName: string;
+  /** Slug for D/M/E/BSP (matches legacy seed), UUID for the 10 new ones. */
+  id: string;
+  weeklyHours: number;
+  yearLevels: number[];     // [5,6,7,8] or subset
+  requiredRoomType: 'KLASSENZIMMER' | 'TURNSAAL' | 'EDV_RAUM' | 'LABOR' | null;
+  /** Defined → 2 groups per class; null → 1 ClassSubject without groupId. */
+  groupSplit: 'LANGUAGE' | 'RELIGION' | null;
+  lehrverpflichtungsgruppe: string | null;
+  werteinheitenFactor: number | null;
+}
+
+export function getBulkSubjects(): BulkSubject[] {
+  const subjects: BulkSubject[] = [
+    { shortName: 'D',   fullName: 'Deutsch',                       id: 'seed-subject-d',                    weeklyHours: 4, yearLevels: [5,6,7,8], requiredRoomType: null,           groupSplit: null,       lehrverpflichtungsgruppe: 'I',   werteinheitenFactor: 1.105 },
+    { shortName: 'M',   fullName: 'Mathematik',                    id: 'seed-subject-m',                    weeklyHours: 4, yearLevels: [5,6,7,8], requiredRoomType: null,           groupSplit: null,       lehrverpflichtungsgruppe: 'II',  werteinheitenFactor: 1.0   },
+    { shortName: 'E',   fullName: 'Englisch',                      id: 'seed-subject-e',                    weeklyHours: 4, yearLevels: [5,6,7,8], requiredRoomType: null,           groupSplit: 'LANGUAGE', lehrverpflichtungsgruppe: 'I',   werteinheitenFactor: 1.105 },
+    { shortName: 'GW',  fullName: 'Geographie und Wirtschaftskunde',id: uuid(SUBJECT_NEW_PREFIX, 1),         weeklyHours: 2, yearLevels: [5,6,7,8], requiredRoomType: null,           groupSplit: null,       lehrverpflichtungsgruppe: 'III', werteinheitenFactor: 1.0   },
+    { shortName: 'GS',  fullName: 'Geschichte und Sozialkunde',    id: uuid(SUBJECT_NEW_PREFIX, 2),          weeklyHours: 2, yearLevels: [6,7,8],   requiredRoomType: null,           groupSplit: null,       lehrverpflichtungsgruppe: 'III', werteinheitenFactor: 1.0   },
+    { shortName: 'BE',  fullName: 'Bildnerische Erziehung',        id: uuid(SUBJECT_NEW_PREFIX, 3),          weeklyHours: 2, yearLevels: [5,6,7,8], requiredRoomType: null,           groupSplit: null,       lehrverpflichtungsgruppe: 'IVb', werteinheitenFactor: 0.882 },
+    { shortName: 'ME',  fullName: 'Musikerziehung',                id: uuid(SUBJECT_NEW_PREFIX, 4),          weeklyHours: 2, yearLevels: [5,6,7,8], requiredRoomType: null,           groupSplit: null,       lehrverpflichtungsgruppe: 'IVb', werteinheitenFactor: 0.882 },
+    { shortName: 'BU',  fullName: 'Biologie und Umweltkunde',      id: uuid(SUBJECT_NEW_PREFIX, 5),          weeklyHours: 2, yearLevels: [5,6,7,8], requiredRoomType: 'LABOR',         groupSplit: null,       lehrverpflichtungsgruppe: 'III', werteinheitenFactor: 1.0   },
+    { shortName: 'PH',  fullName: 'Physik',                        id: uuid(SUBJECT_NEW_PREFIX, 6),          weeklyHours: 2, yearLevels: [7,8],     requiredRoomType: 'LABOR',         groupSplit: null,       lehrverpflichtungsgruppe: 'III', werteinheitenFactor: 1.0   },
+    { shortName: 'CH',  fullName: 'Chemie',                        id: uuid(SUBJECT_NEW_PREFIX, 7),          weeklyHours: 2, yearLevels: [8],       requiredRoomType: 'LABOR',         groupSplit: null,       lehrverpflichtungsgruppe: 'III', werteinheitenFactor: 1.0   },
+    { shortName: 'INF', fullName: 'Informatik',                    id: uuid(SUBJECT_NEW_PREFIX, 8),          weeklyHours: 1, yearLevels: [5,6,7,8], requiredRoomType: 'EDV_RAUM',      groupSplit: null,       lehrverpflichtungsgruppe: 'III', werteinheitenFactor: 1.0   },
+    { shortName: 'BSP', fullName: 'Bewegung und Sport',            id: 'seed-subject-bsp',                  weeklyHours: 4, yearLevels: [5,6,7,8], requiredRoomType: 'TURNSAAL',      groupSplit: null,       lehrverpflichtungsgruppe: 'IVa', werteinheitenFactor: 0.857 },
+    { shortName: 'RE',  fullName: 'Religion',                      id: uuid(SUBJECT_NEW_PREFIX, 9),          weeklyHours: 2, yearLevels: [5,6,7,8], requiredRoomType: null,           groupSplit: 'RELIGION', lehrverpflichtungsgruppe: 'III', werteinheitenFactor: 1.0   },
+    { shortName: 'WE',  fullName: 'Werken',                        id: uuid(SUBJECT_NEW_PREFIX, 10),         weeklyHours: 2, yearLevels: [5,6,7,8], requiredRoomType: null,           groupSplit: null,       lehrverpflichtungsgruppe: 'IVa', werteinheitenFactor: 0.857 },
+  ];
+  return subjects;
+}
+
+// =====================================================
+// Teachers (32 Bulk + 1 Schulleitung, testdaten.md §Lehrer)
+// =====================================================
+
+export interface BulkTeacher {
+  index: number;               // 1..32
+  kcUsername: string;          // "l-d-01"
+  kcUuid: string;
+  personUuid: string;
+  teacherUuid: string;
+  firstName: string;
+  lastName: string;
+  subjects: SubjectShort[];    // 1-2 entries
+}
+
+export interface BulkSchulleitung {
+  kcUsername: string;          // "schulleitung-01"
+  kcUuid: string;
+  personUuid: string;
+  teacherUuid: string;
+  firstName: string;
+  lastName: string;
+}
+
+const TEACHER_TABLE: Array<{
+  username: string;
+  firstName: string;
+  lastName: string;
+  subjects: SubjectShort[];
+}> = [
+  { username: 'l-d-01',   firstName: 'Maria',      lastName: 'Huber',      subjects: ['D','GS'] },
+  { username: 'l-d-02',   firstName: 'Thomas',     lastName: 'Gruber',     subjects: ['D','RE'] },
+  { username: 'l-d-03',   firstName: 'Anna',       lastName: 'Maier',      subjects: ['D','E']  },
+  { username: 'l-m-01',   firstName: 'Stefan',     lastName: 'Bauer',      subjects: ['M','PH'] },
+  { username: 'l-m-02',   firstName: 'Julia',      lastName: 'Berger',     subjects: ['M','INF']},
+  { username: 'l-m-03',   firstName: 'Lukas',      lastName: 'Hofer',      subjects: ['M','CH'] },
+  { username: 'l-e-01',   firstName: 'Sabine',     lastName: 'Wagner',     subjects: ['E','BE'] },
+  { username: 'l-e-02',   firstName: 'Markus',     lastName: 'Pichler',    subjects: ['E','GW'] },
+  { username: 'l-e-03',   firstName: 'Christina',  lastName: 'Schwarz',    subjects: ['E','ME'] },
+  { username: 'l-gw-01',  firstName: 'Peter',      lastName: 'Lechner',    subjects: ['GW','GS']},
+  { username: 'l-gs-01',  firstName: 'Eva',        lastName: 'Reiter',     subjects: ['GS','D'] },
+  { username: 'l-bu-01',  firstName: 'Manuel',     lastName: 'Steiner',    subjects: ['BU','CH']},
+  { username: 'l-be-01',  firstName: 'Sophie',     lastName: 'Mayer',      subjects: ['BE','WE']},
+  { username: 'l-be-02',  firstName: 'David',      lastName: 'Aigner',     subjects: ['BE','ME']},
+  { username: 'l-me-01',  firstName: 'Lisa',       lastName: 'Wolf',       subjects: ['ME','RE']},
+  { username: 'l-me-02',  firstName: 'Andreas',    lastName: 'Köhler',     subjects: ['ME','D'] },
+  { username: 'l-bu-02',  firstName: 'Katharina',  lastName: 'Brunner',    subjects: ['BU','PH']},
+  { username: 'l-ph-01',  firstName: 'Michael',    lastName: 'Fischer',    subjects: ['PH','M'] },
+  { username: 'l-ph-02',  firstName: 'Sandra',     lastName: 'Holzer',     subjects: ['PH','INF']},
+  { username: 'l-ch-01',  firstName: 'Daniel',     lastName: 'Weber',      subjects: ['CH','BU']},
+  { username: 'l-inf-01', firstName: 'Tobias',     lastName: 'Hartl',      subjects: ['INF','M']},
+  { username: 'l-inf-02', firstName: 'Marlene',    lastName: 'Eder',       subjects: ['INF','PH']},
+  { username: 'l-bsp-01', firstName: 'Felix',      lastName: 'Riedl',      subjects: ['BSP']    },
+  { username: 'l-bsp-02', firstName: 'Christoph',  lastName: 'Stadler',    subjects: ['BSP']    },
+  { username: 'l-bsp-03', firstName: 'Tanja',      lastName: 'Lang',       subjects: ['BSP']    },
+  { username: 'l-bsp-04', firstName: 'Birgit',     lastName: 'Köberl',     subjects: ['BSP']    },
+  { username: 'l-re-01',  firstName: 'Pater',      lastName: 'Albrecht',   subjects: ['RE']     },
+  { username: 'l-re-02',  firstName: 'Hannah',     lastName: 'Mayrhofer',  subjects: ['RE']     },
+  { username: 'l-we-01',  firstName: 'Roland',     lastName: 'Köhler',     subjects: ['WE','BE']},
+  { username: 'l-we-02',  firstName: 'Verena',     lastName: 'Wallner',    subjects: ['WE','INF']},
+  { username: 'l-d-04',   firstName: 'Beatrix',    lastName: 'Strasser',   subjects: ['D','BE'] },
+  { username: 'l-m-04',   firstName: 'Alexander',  lastName: 'Linder',     subjects: ['M','PH'] },
+];
+
+export function getBulkTeachers(): BulkTeacher[] {
+  return TEACHER_TABLE.map((t, i) => ({
+    index: i + 1,
+    kcUsername: t.username,
+    kcUuid: uuid(KC_BULK_LEHRER_PREFIX, i + 1),
+    personUuid: uuid(PERSON_BULK_LEHRER_PREFIX, i + 1),
+    teacherUuid: uuid(TEACHER_BULK_PREFIX, i + 1),
+    firstName: t.firstName,
+    lastName: t.lastName,
+    subjects: t.subjects,
+  }));
+}
+
+export function getBulkSchulleitung(): BulkSchulleitung {
+  return {
+    kcUsername: 'schulleitung-01',
+    kcUuid: uuid(KC_SCHULLEITUNG_PREFIX, 1),
+    personUuid: uuid(PERSON_SCHULLEITUNG_PREFIX, 1),
+    teacherUuid: uuid(TEACHER_SCHULLEITUNG_PREFIX, 1),
+    firstName: 'Karl-Heinz',
+    lastName: 'Direktor',
+  };
+}
+
+// =====================================================
+// Parallel "kc-*" Legacy-Mirror Users (5 zusätzliche User)
+// =====================================================
+// testdaten.md "Backward-Compatibility (Hard Rule)" listet kc-admin / kc-lehrer
+// etc. Diese sind ZUSÄTZLICH zu den echten 5 Legacy-Usern (admin-user etc.)
+// und werden hier parallel mitgeführt, damit das Spec wörtlich umgesetzt ist.
+
+export type ParallelLegacyRole = 'admin' | 'lehrer' | 'eltern' | 'schueler' | 'schulleitung';
+
+export interface ParallelLegacyUser {
+  role: ParallelLegacyRole;
+  kcUsername: string;
+  kcUuid: string;
+  personUuid: string;
+  /** For lehrer/schulleitung → Teacher.id. For schueler → Student.id. For eltern → Parent.id. */
+  recordUuid: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+}
+
+export function getParallelLegacyUsers(): ParallelLegacyUser[] {
+  // Demo names — distinct from the existing 5 legacy users to avoid PII
+  // overlap. Email uses .demo TLD to make grep'ing them trivial.
+  return [
+    { role: 'admin',        kcUsername: 'kc-admin',        kcUuid: uuid(KC_PARALLEL_PREFIX, 1), personUuid: uuid(PERSON_PARALLEL_KC_PREFIX, 1), recordUuid: uuid(PARALLEL_KC_TEACHER_PREFIX, SHADOW_TEACHER_OFFSET + 1), firstName: 'Demo',  lastName: 'AdminShadow',        email: 'kc-admin@schoolflow.demo' },
+    { role: 'lehrer',       kcUsername: 'kc-lehrer',       kcUuid: uuid(KC_PARALLEL_PREFIX, 2), personUuid: uuid(PERSON_PARALLEL_KC_PREFIX, 2), recordUuid: uuid(PARALLEL_KC_TEACHER_PREFIX, SHADOW_TEACHER_OFFSET + 2), firstName: 'Demo',  lastName: 'LehrerShadow',       email: 'kc-lehrer@schoolflow.demo' },
+    { role: 'eltern',       kcUsername: 'kc-eltern',       kcUuid: uuid(KC_PARALLEL_PREFIX, 3), personUuid: uuid(PERSON_PARALLEL_KC_PREFIX, 3), recordUuid: uuid(PARALLEL_KC_PARENT_PREFIX, SHADOW_PARENT_OFFSET + 1), firstName: 'Demo',  lastName: 'ElternShadow',       email: 'kc-eltern@schoolflow.demo' },
+    { role: 'schueler',     kcUsername: 'kc-schueler',     kcUuid: uuid(KC_PARALLEL_PREFIX, 4), personUuid: uuid(PERSON_PARALLEL_KC_PREFIX, 4), recordUuid: uuid(PARALLEL_KC_TEACHER_PREFIX, SHADOW_STUDENT_OFFSET + 1), firstName: 'Demo',  lastName: 'SchuelerShadow',     email: 'kc-schueler@schoolflow.demo' },
+    { role: 'schulleitung', kcUsername: 'kc-schulleitung', kcUuid: uuid(KC_PARALLEL_PREFIX, 5), personUuid: uuid(PERSON_PARALLEL_KC_PREFIX, 5), recordUuid: uuid(PARALLEL_KC_TEACHER_PREFIX, SHADOW_TEACHER_OFFSET + 3), firstName: 'Demo',  lastName: 'SchulleitungShadow', email: 'kc-schulleitung@schoolflow.demo' },
+  ];
+}
+
+// =====================================================
+// Students (336, testdaten.md §Schüler)
+// =====================================================
+
+const STUDENT_FIRST_NAMES_M = [
+  'Anton','Benjamin','Christian','David','Elias','Felix','Georg','Hannes',
+  'Ivan','Jakob','Konstantin','Lukas','Maximilian','Nico','Oliver','Paul',
+  'Quirin','Richard','Stefan','Tobias','Ulrich','Valentin','Wolfgang','Xaver',
+  'Yannick','Zacharias','Andreas','Bernhard','Clemens','Dominik',
+];
+
+const STUDENT_FIRST_NAMES_F = [
+  'Anna','Bianca','Clara','Daniela','Emma','Franziska','Greta','Hanna',
+  'Iris','Johanna','Katharina','Lena','Maria','Nina','Olivia','Paula',
+  'Rebecca','Sophie','Theresa','Ursula','Valentina','Wilma','Yasmin','Zoe',
+  'Amelie','Bernadette','Charlotte','Diana','Elena','Fiona',
+];
+
+const STUDENT_LAST_NAMES = [
+  'Aigner','Bauer','Brunner','Eder','Fischer','Gruber','Hofer','Holzer',
+  'Huber','Köhler','Köberl','Kogler','Lang','Lechner','Linder','Maier',
+  'Mayer','Mayerhofer','Pichler','Reiter','Riedl','Schwarz','Stadler','Steiner',
+  'Strasser','Wagner','Wallner','Weber','Wolf','Berger',
+];
+
+export interface BulkStudent {
+  /** Global 1-based index across all 336 students. */
+  globalIndex: number;
+  /** 1..12 (1A=1, 1B=2, ..., 4C=12). */
+  classIndex: number;
+  className: string;
+  yearLevel: number;
+  /** 1..28 within the class. */
+  nrInClass: number;
+  kcUsername: string;       // "s-1a-01"
+  kcUuid: string;
+  personUuid: string;
+  studentUuid: string;
+  firstName: string;
+  lastName: string;
+  gender: 'm' | 'f';
+  dateOfBirth: string;      // YYYY-MM-DD
+  /** 1..311 — assigned by getBulkFamilies(). */
+  familyId: number;
+  /** "E-Gruppe-1" | "E-Gruppe-2". */
+  eGroup: 'E-Gruppe-1' | 'E-Gruppe-2';
+  /** "RE-katholisch" | "RE-evangelisch". */
+  reGroup: 'RE-katholisch' | 'RE-evangelisch';
+}
+
+/** Birth-year per yearLevel (testdaten.md §Schüler):
+ *  Stufe 5 = 2016-Geboren, Stufe 6 = 2015, Stufe 7 = 2014, Stufe 8 = 2013. */
+function birthYearForLevel(level: number): number {
+  return 2021 - level; // 5→2016, 6→2015, 7→2014, 8→2013
+}
+
+/**
+ * Build the 336 students with familyId=0 placeholder. Use
+ * `buildBulkSchoolData()` to get students + families coherently —
+ * calling this raw function and then `getBulkFamilies(students)`
+ * works but the helper avoids double-call mistakes.
+ */
+export function getBulkStudents(): BulkStudent[] {
+  const students: BulkStudent[] = [];
+  const classes = getBulkClasses();
+  let globalIndex = 0;
+  for (const cls of classes) {
+    for (let nr = 1; nr <= 28; nr++) {
+      globalIndex++;
+      const classOrdinal = cls.index - 1; // 0..11
+      // Vornamen-Pool: 1A startet bei Index 0, 1B bei 28 mod 30 = 28 (continuation).
+      // testdaten.md §Zuordnung: "Schüler s-1b-XX setzt Vornamen-Pool ab Index 28 fort".
+      const firstNameIndex = (classOrdinal * 28 + (nr - 1)) % 30;
+      const lastNameIndex  = (classOrdinal * 14 + (nr - 1)) % STUDENT_LAST_NAMES.length;
+      const gender: 'm' | 'f' = nr % 2 === 0 ? 'm' : 'f';
+      const firstName = gender === 'm'
+        ? STUDENT_FIRST_NAMES_M[firstNameIndex]
+        : STUDENT_FIRST_NAMES_F[firstNameIndex];
+      const lastName = STUDENT_LAST_NAMES[lastNameIndex];
+      // Group assignments per testdaten.md §Group-Memberships pro Schüler
+      const eGroup: 'E-Gruppe-1' | 'E-Gruppe-2' = nr <= 14 ? 'E-Gruppe-1' : 'E-Gruppe-2';
+      const reGroup: 'RE-katholisch' | 'RE-evangelisch' = nr <= 22 ? 'RE-katholisch' : 'RE-evangelisch';
+      // Birthday: birthYearForLevel, deterministic month/day from nr
+      const birthYear = birthYearForLevel(cls.yearLevel);
+      const month = ((nr - 1) % 12) + 1;
+      const day = (((nr - 1) * 7) % 28) + 1;
+      const dateOfBirth = `${birthYear}-${String(month).padStart(2,'0')}-${String(day).padStart(2,'0')}`;
+      students.push({
+        globalIndex,
+        classIndex: cls.index,
+        className: cls.name,
+        yearLevel: cls.yearLevel,
+        nrInClass: nr,
+        kcUsername: `s-${cls.name.toLowerCase()}-${String(nr).padStart(2,'0')}`,
+        kcUuid: uuid(KC_BULK_SCHUELER_PREFIX, globalIndex),
+        personUuid: uuid(PERSON_BULK_SCHUELER_PREFIX, globalIndex),
+        studentUuid: uuid(STUDENT_BULK_PREFIX, globalIndex),
+        firstName,
+        lastName,
+        gender,
+        dateOfBirth,
+        familyId: 0, // filled in by getBulkFamilies()
+        eGroup,
+        reGroup,
+      });
+    }
+  }
+  return students;
+}
+
+/**
+ * Atomic builder: returns students + families consistently — both
+ * fully populated (students.familyId set, families.childGlobalIndexes
+ * pointing back). Recommended entry point for consumers.
+ */
+export function buildBulkSchoolData(): {
+  students: BulkStudent[];
+  families: BulkFamily[];
+} {
+  const students = getBulkStudents();
+  const families = getBulkFamilies(students);
+  if (families.length !== 311) {
+    throw new Error(`Family count drift: expected 311, got ${families.length}`);
+  }
+  return { students, families };
+}
+
+// =====================================================
+// Families & Parents (~311 Familien, ~622 Eltern, testdaten.md §Eltern)
+// =====================================================
+
+const PARENT_NAME_PAIRS: Array<{ mother: string; father: string }> = [
+  // testdaten.md §Eltern-Accounts: erste 16 Paare, zyklisch verlängert
+  { mother: 'Maria',     father: 'Stefan' },
+  { mother: 'Andrea',    father: 'Thomas' },
+  { mother: 'Sabine',    father: 'Markus' },
+  { mother: 'Christina', father: 'Peter' },
+  { mother: 'Eva',       father: 'Manuel' },
+  { mother: 'Sophia',    father: 'David' },
+  { mother: 'Lisa',      father: 'Andreas' },
+  { mother: 'Katharina', father: 'Michael' },
+  { mother: 'Sandra',    father: 'Daniel' },
+  { mother: 'Marlene',   father: 'Tobias' },
+  { mother: 'Birgit',    father: 'Christoph' },
+  { mother: 'Tanja',     father: 'Felix' },
+  { mother: 'Hannah',    father: 'Roland' },
+  { mother: 'Verena',    father: 'Alexander' },
+  { mother: 'Beatrix',   father: 'Karl-Heinz' },
+  { mother: 'Julia',     father: 'Lukas' },
+  { mother: 'Elena',     father: 'Bernhard' },
+  { mother: 'Greta',     father: 'Wolfgang' },
+  { mother: 'Iris',      father: 'Konstantin' },
+  { mother: 'Johanna',   father: 'Jakob' },
+];
+
+export interface BulkFamily {
+  familyId: number;          // 1..311
+  /** Mutter (e-fam-NNN-a) und Vater (e-fam-NNN-b). */
+  mother: BulkParent;
+  father: BulkParent;
+  /** 1 or 2 — Indizes ins students-Array (globalIndex 1..336). */
+  childGlobalIndexes: number[];
+}
+
+export interface BulkParent {
+  kcUsername: string;        // "e-fam-001-a"
+  kcUuid: string;
+  personUuid: string;
+  parentUuid: string;
+  firstName: string;
+  lastName: string;          // = lastName des/der Kinder
+}
+
+/**
+ * Build 311 families. Mutates `students` to set familyId.
+ *
+ * Algorithm:
+ *  - 25 Geschwisterpaare (familyIds 287..311). Each pair links 2 students
+ *    across different classes — deterministic spread via `siblingPairs[]`.
+ *  - 286 Einzelkind-Familien (familyIds 1..286). Remaining 286 students
+ *    each get their own family.
+ *
+ * Eltern-Vornamen: zyklisch aus PARENT_NAME_PAIRS, indiziert via familyId.
+ * Eltern-Nachname: Nachname des/der Kinder (für Geschwister: Nachname von
+ * Kind A — sind ohnehin identisch da Schüler-Nachname-Pool deterministisch
+ * geteilt wird zwischen Geschwistern via shared lastName? Spec sagt
+ * "Eltern-Nachname = Nachname des/der Kinder" — die Kinder können
+ * unterschiedliche Nachnamen haben, also patchen wir auch den Nachnamen
+ * des Geschwister-Schülers auf den des Erstgeborenen, damit's konsistent
+ * bleibt).
+ */
+export function getBulkFamilies(students: BulkStudent[]): BulkFamily[] {
+  if (students.length !== 336) {
+    throw new Error(`getBulkFamilies expects 336 students, got ${students.length}`);
+  }
+  // Deterministic sibling pairs across classes/stages. 25 pairs.
+  // (className, nrInClass) tuples — must reference DISTINCT students.
+  // Spread across stages (testdaten.md: "immer in unterschiedlichen Klassenstufen").
+  const SIBLING_PAIRS: Array<[string, number, string, number]> = [
+    // Stage 5 ↔ Stage 7
+    ['1A', 15, '3A',  8],
+    ['1A', 22, '4B', 11],
+    ['1B',  4, '2C', 19],
+    ['1B', 12, '3B',  7],
+    ['1C',  3, '4A', 14],
+    ['1C', 18, '2B', 25],
+    // Stage 5 ↔ Stage 8
+    ['1A',  5, '4C',  9],
+    ['1B', 27, '4A',  3],
+    ['1C', 11, '4B', 21],
+    // Stage 6 ↔ Stage 8
+    ['2A',  1, '4C', 17],
+    ['2A', 16, '4B',  5],
+    ['2B',  9, '4A', 27],
+    ['2C', 13, '4C', 25],
+    // Stage 6 ↔ Stage 7
+    ['2A',  8, '3C', 12],
+    ['2B',  2, '3A', 19],
+    ['2C', 20, '3B', 14],
+    // Stage 7 ↔ Stage 8
+    ['3A', 25, '4B', 28],
+    ['3B', 22, '4A', 18],
+    ['3C',  6, '4C',  4],
+    // Stage 5 ↔ Stage 6
+    ['1A',  7, '2C',  3],
+    ['1B', 19, '2A', 22],
+    ['1C', 26, '2B', 13],
+    // 3 more for total 25
+    ['2A', 11, '3C', 23],
+    ['3A',  1, '4B',  7],
+    ['1A', 28, '4C', 28],
+  ];
+  if (SIBLING_PAIRS.length !== 25) {
+    throw new Error(`SIBLING_PAIRS must have 25 entries, got ${SIBLING_PAIRS.length}`);
+  }
+
+  const findStudent = (className: string, nr: number): BulkStudent => {
+    const s = students.find((x) => x.className === className && x.nrInClass === nr);
+    if (!s) throw new Error(`Sibling lookup miss: ${className}-${nr}`);
+    return s;
+  };
+
+  const families: BulkFamily[] = [];
+
+  // 25 sibling-pair families (IDs 287..311)
+  let pairIdx = 0;
+  for (const [classA, nrA, classB, nrB] of SIBLING_PAIRS) {
+    pairIdx++;
+    const familyId = 286 + pairIdx; // 287..311
+    const sA = findStudent(classA, nrA);
+    const sB = findStudent(classB, nrB);
+    if (sA.familyId !== 0 || sB.familyId !== 0) {
+      throw new Error(`Sibling-pair collision at familyId=${familyId}: ${classA}-${nrA} or ${classB}-${nrB} already assigned`);
+    }
+    sA.familyId = familyId;
+    sB.familyId = familyId;
+    // Patch the younger sibling's lastName to match older's so parents have
+    // a single coherent surname.
+    sB.lastName = sA.lastName;
+    families.push(buildFamily(familyId, sA.lastName, [sA.globalIndex, sB.globalIndex]));
+  }
+
+  // 286 single-child families (IDs 1..286)
+  let singleId = 0;
+  for (const s of students) {
+    if (s.familyId !== 0) continue; // already in sibling pair
+    singleId++;
+    s.familyId = singleId;
+    families.push(buildFamily(singleId, s.lastName, [s.globalIndex]));
+  }
+  if (singleId !== 286) {
+    throw new Error(`Expected 286 single-child families, got ${singleId}`);
+  }
+
+  // Sort by familyId for stable downstream iteration
+  families.sort((a, b) => a.familyId - b.familyId);
+  return families;
+}
+
+function buildFamily(familyId: number, surname: string, childGlobalIndexes: number[]): BulkFamily {
+  const pair = PARENT_NAME_PAIRS[(familyId - 1) % PARENT_NAME_PAIRS.length];
+  // Mother KC index = (familyId * 2) - 1, Father = familyId * 2. So family 1
+  // owns Eltern-KC #1 and #2, family 2 owns #3 and #4, etc.
+  const motherKcIdx = (familyId - 1) * 2 + 1;
+  const fatherKcIdx = (familyId - 1) * 2 + 2;
+  const motherFamilyIndex = familyId; // 1-based; Parent.id uses same number, mother gets 2*N-1
+  const mother: BulkParent = {
+    kcUsername: `e-fam-${String(familyId).padStart(3,'0')}-a`,
+    kcUuid:     uuid(KC_BULK_ELTERN_PREFIX, motherKcIdx),
+    personUuid: uuid(PERSON_BULK_ELTERN_PREFIX, motherKcIdx),
+    parentUuid: uuid(PARENT_BULK_PREFIX, motherKcIdx),
+    firstName:  pair.mother,
+    lastName:   surname,
+  };
+  const father: BulkParent = {
+    kcUsername: `e-fam-${String(familyId).padStart(3,'0')}-b`,
+    kcUuid:     uuid(KC_BULK_ELTERN_PREFIX, fatherKcIdx),
+    personUuid: uuid(PERSON_BULK_ELTERN_PREFIX, fatherKcIdx),
+    parentUuid: uuid(PARENT_BULK_PREFIX, fatherKcIdx),
+    firstName:  pair.father,
+    lastName:   surname,
+  };
+  void motherFamilyIndex;
+  return { familyId, mother, father, childGlobalIndexes };
+}
+
+// =====================================================
+// ClassSubjects (174 Rows mit deterministischer Lehrer-Zuweisung)
+// =====================================================
+
+export interface BulkClassSubject {
+  id: string;                  // UUID
+  classIndex: number;          // 1..12
+  subjectShort: SubjectShort;
+  /** undefined for non-split subjects; else "E-Gruppe-1"/"E-Gruppe-2"/"RE-katholisch"/"RE-evangelisch". */
+  groupName: 'E-Gruppe-1' | 'E-Gruppe-2' | 'RE-katholisch' | 'RE-evangelisch' | null;
+  weeklyHours: number;
+  /** 1..32 — index into BulkTeacher[]. */
+  teacherIndex: number;
+}
+
+/**
+ * Round-robin Lehrer-Zuweisung über alle ClassSubject-Slots, gemäß
+ * testdaten.md §Lehrer-Zuweisungs-Regeln.
+ *
+ * Vereinfachte Heuristik (Spec sagt explizit "Detailliertes Mapping…wird
+ * beim Seed-Implement deterministisch generiert (Modulo-Index)"):
+ *   - Pro Fach: Liste der qualifizierten Lehrer (subjects[] enthält Kurzform)
+ *   - Klassen sortiert nach classIndex
+ *   - Modulo-Verteilung: i-tes ClassSubject geht an
+ *     qualifiedTeachers[i % qualifiedTeachers.length]
+ *
+ * Für RE: kath. → l-re-01, evang. → l-re-02 (hardcoded laut Spec).
+ * Für E mit Gruppen: beide Gruppen einer Klasse können denselben Lehrer
+ * haben oder unterschiedliche — Modulo-Verteilung über 24 Slots.
+ */
+export function getBulkClassSubjects(
+  classes: BulkClass[],
+  subjects: BulkSubject[],
+  teachers: BulkTeacher[],
+): BulkClassSubject[] {
+  const subjectsByShort = new Map(subjects.map((s) => [s.shortName, s]));
+  // Build qualifiedTeachers map: subjectShort → BulkTeacher[]
+  const qualifiedByShort = new Map<SubjectShort, BulkTeacher[]>();
+  for (const t of teachers) {
+    for (const subjShort of t.subjects) {
+      if (!qualifiedByShort.has(subjShort)) qualifiedByShort.set(subjShort, []);
+      qualifiedByShort.get(subjShort)!.push(t);
+    }
+  }
+  // RE special-case: katholisch → l-re-01 (index 27), evangelisch → l-re-02 (index 28)
+  const teacherByUsername = new Map(teachers.map((t) => [t.kcUsername, t]));
+  const re01 = teacherByUsername.get('l-re-01');
+  const re02 = teacherByUsername.get('l-re-02');
+  if (!re01 || !re02) throw new Error('Required RE teachers (l-re-01/l-re-02) missing');
+
+  const rows: BulkClassSubject[] = [];
+  let csCounter = 0;
+  // Stable iteration: per subject (in shortName order), per class (in classIndex order)
+  const sortedSubjects = [...subjects].sort((a, b) => a.shortName.localeCompare(b.shortName));
+  for (const subj of sortedSubjects) {
+    const applicableClasses = classes.filter((c) => subj.yearLevels.includes(c.yearLevel));
+    if (subj.groupSplit === 'LANGUAGE') {
+      // 2 groups per applicable class, both teachers from qualifiedByShort['E']
+      const qts = qualifiedByShort.get(subj.shortName) ?? [];
+      if (qts.length === 0) throw new Error(`No teachers for ${subj.shortName}`);
+      let i = 0;
+      for (const cls of applicableClasses) {
+        for (const groupName of ['E-Gruppe-1', 'E-Gruppe-2'] as const) {
+          csCounter++;
+          const t = qts[i % qts.length];
+          i++;
+          rows.push({
+            id: uuid(CLASS_SUBJECT_PREFIX, csCounter),
+            classIndex: cls.index,
+            subjectShort: subj.shortName,
+            groupName,
+            weeklyHours: subj.weeklyHours,
+            teacherIndex: t.index,
+          });
+        }
+      }
+    } else if (subj.groupSplit === 'RELIGION') {
+      for (const cls of applicableClasses) {
+        for (const groupName of ['RE-katholisch', 'RE-evangelisch'] as const) {
+          csCounter++;
+          const t = groupName === 'RE-katholisch' ? re01 : re02;
+          rows.push({
+            id: uuid(CLASS_SUBJECT_PREFIX, csCounter),
+            classIndex: cls.index,
+            subjectShort: subj.shortName,
+            groupName,
+            weeklyHours: subj.weeklyHours,
+            teacherIndex: t.index,
+          });
+        }
+      }
+    } else {
+      // No split — 1 row per applicable class
+      const qts = qualifiedByShort.get(subj.shortName) ?? [];
+      if (qts.length === 0) throw new Error(`No teachers for ${subj.shortName}`);
+      let i = 0;
+      for (const cls of applicableClasses) {
+        csCounter++;
+        const t = qts[i % qts.length];
+        i++;
+        rows.push({
+          id: uuid(CLASS_SUBJECT_PREFIX, csCounter),
+          classIndex: cls.index,
+          subjectShort: subj.shortName,
+          groupName: null,
+          weeklyHours: subj.weeklyHours,
+          teacherIndex: t.index,
+        });
+      }
+    }
+  }
+  void subjectsByShort; // future use
+  return rows;
+}
+
+// =====================================================
+// TeacherAbsences (3 zukünftige Krank-Meldungen, testdaten.md §TeacherAbsence)
+// =====================================================
+
+export interface BulkTeacherAbsence {
+  id: string;
+  /** kcUsername of the absent teacher. */
+  teacherKcUsername: string;
+  dateFrom: Date;
+  dateTo: Date;
+  reason: 'KRANK';
+  note: string | null;
+}
+
+export function getBulkTeacherAbsences(anchor: Date = new Date()): BulkTeacherAbsence[] {
+  const nextMon = nextMondayDate(anchor);
+  // #1: l-d-02 (Thomas Gruber), nächster Montag–Mittwoch (3 Tage)
+  const a1From = nextMon;
+  const a1To   = addDays(nextMon, 2); // Mon, Tue, Wed
+  // #2: l-m-03 (Lukas Hofer), übermorgen (1 Tag)
+  const a2 = addDays(anchor, 2);
+  a2.setHours(0, 0, 0, 0);
+  // #3: l-bsp-01 (Felix Riedl), in 14 Tagen Mo-Fr (5 Tage)
+  const a3From = addDays(nextMon, 14);
+  const a3To   = addDays(a3From, 4); // Mon..Fri
+  return [
+    { id: uuid(TEACHER_ABSENCE_PREFIX, 1), teacherKcUsername: 'l-d-02',   dateFrom: a1From, dateTo: a1To, reason: 'KRANK', note: 'Demo-Seed: Grippe' },
+    { id: uuid(TEACHER_ABSENCE_PREFIX, 2), teacherKcUsername: 'l-m-03',   dateFrom: a2,     dateTo: a2,   reason: 'KRANK', note: 'Demo-Seed: Erkältung' },
+    { id: uuid(TEACHER_ABSENCE_PREFIX, 3), teacherKcUsername: 'l-bsp-01', dateFrom: a3From, dateTo: a3To, reason: 'KRANK', note: 'Demo-Seed: Längere Krankheit' },
+  ];
+}
+
+// =====================================================
+// Aggregate counts (for sanity-check tests)
+// =====================================================
+
+export function getBulkUserCount(): {
+  schueler: number;
+  eltern:   number;
+  lehrer:   number;
+  schulleitung: number;
+  parallelLegacy: number;
+  total:    number;
+} {
+  const { students, families } = buildBulkSchoolData();
+  const teachers = getBulkTeachers();
+  const schulleitung = 1;
+  const parallelLegacy = getParallelLegacyUsers().length;
+  return {
+    schueler: students.length,
+    eltern:   families.length * 2,
+    lehrer:   teachers.length,
+    schulleitung,
+    parallelLegacy,
+    total:    students.length + families.length * 2 + teachers.length + schulleitung + parallelLegacy,
+  };
+}
+
+// Re-exports for consumers
+export const DEMO_PASSWORD = 'Demo1234!';
+export const DEMO_SCHOOL_NAME = 'SchoolFlow Demo-Gymnasium';

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -1,5 +1,16 @@
 import { PrismaPg } from '@prisma/adapter-pg';
 import { PrismaClient } from '../src/config/database/generated/client.js';
+import {
+  buildBulkSchoolData,
+  getBulkClasses,
+  getBulkClassSubjects,
+  getBulkRooms,
+  getBulkSchulleitung,
+  getBulkSubjects,
+  getBulkTeacherAbsences,
+  getBulkTeachers,
+  getParallelLegacyUsers,
+} from './seed-data.js';
 
 const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL! });
 const prisma = new PrismaClient({ adapter });
@@ -501,10 +512,14 @@ async function main() {
       // mount, and `useBlocker` opened the unsaved-changes dialog on the
       // first tab switch. Repair existing rows too.
       schoolType: 'AHS',
+      // Issue #175: Rename to SchoolFlow Demo-Gymnasium (the demo-seed
+      // expansion adds 12 classes, 336 students, 622 parents, 32 teachers
+      // — see testdaten.md + seed-data.ts + Section 175 below).
+      name: 'SchoolFlow Demo-Gymnasium',
     },
     create: {
       id: SEED_SCHOOL_UUID,
-      name: 'BG/BRG Musterstadt',
+      name: 'SchoolFlow Demo-Gymnasium',
       schoolType: 'AHS',
       address: { street: 'Schulstrasse 1', zip: '1010', city: 'Wien' },
     },
@@ -1119,10 +1134,435 @@ async function main() {
     data: { homeRoomId: SEED_ROOM_K_2A_UUID },
   });
 
+  // =====================================================
+  // Section 175: Demo-Seed Bulk Data (testdaten.md)
+  // =====================================================
+  // Adds the AHS-Unterstufe demo data on top of the legacy seed:
+  //   - 19 additional rooms (Klassenzimmer 1A-4C, 2 Turnsäle, Bio/Chem/Phys, 2 Computersäle)
+  //   - 10 additional subjects (GW/GS/BE/ME/BU/PH/CH/INF/RE/WE)
+  //   - 5 parallel-legacy `kc-*` mirror users (kc-admin/lehrer/eltern/schueler/schulleitung)
+  //   - 1 schulleitung-01 + 32 bulk teachers (l-d-01 .. l-m-04)
+  //   - 10 additional classes (2A-4C); existing 1A/1B keep their slug-IDs but
+  //     receive new homeRoom + Klassenvorstand per testdaten.md
+  //   - 336 students (s-1a-01 .. s-4c-28) + 622 parents (e-fam-001-a/b .. -311-b)
+  //   - 48 Groups + 672 GroupMemberships (E + RE splits per testdaten.md)
+  //   - 174 ClassSubjects with deterministic teacher assignments
+  //   - 3 TeacherAbsences (anchored to nextMonday so they stay in the future)
+  //
+  // Idempotency: legacy seed school's groups, group memberships, class subjects
+  // and seed-managed TeacherAbsences are deleted then recreated. Upserts use
+  // the deterministic UUIDs from seed-data.ts so re-runs are no-ops.
+
+  const bulkRooms = getBulkRooms();
+  for (const r of bulkRooms) {
+    await prisma.room.upsert({
+      where: { id: r.uuid },
+      update: { name: r.name, roomType: r.roomType, capacity: r.capacity, equipment: r.equipment },
+      create: {
+        id: r.uuid,
+        schoolId: school.id,
+        name: r.name,
+        roomType: r.roomType,
+        capacity: r.capacity,
+        equipment: r.equipment,
+      },
+    });
+  }
+
+  const bulkSubjects = getBulkSubjects();
+  for (const subj of bulkSubjects) {
+    await prisma.subject.upsert({
+      where: { schoolId_shortName: { schoolId: school.id, shortName: subj.shortName } },
+      update: {
+        name: subj.fullName,
+        requiredRoomType: subj.requiredRoomType,
+      },
+      create: {
+        id: subj.id,
+        schoolId: school.id,
+        name: subj.fullName,
+        shortName: subj.shortName,
+        subjectType: 'PFLICHT',
+        lehrverpflichtungsgruppe: subj.lehrverpflichtungsgruppe,
+        werteinheitenFactor: subj.werteinheitenFactor,
+        requiredRoomType: subj.requiredRoomType,
+      },
+    });
+  }
+
+  // Reload subjects so we have the actual DB rows (the legacy 4 use slug
+  // ids, but Subject.id from seed-data may have been overwritten in an
+  // earlier seed run that hit the slug branch — we trust the schoolId +
+  // shortName composite key).
+  const subjectByShort = new Map<string, { id: string; shortName: string }>();
+  const dbSubjects = await prisma.subject.findMany({ where: { schoolId: school.id } });
+  for (const s of dbSubjects) subjectByShort.set(s.shortName, s);
+
+  // --- Bulk Teachers (32 + 1 Schulleitung) ---
+  const bulkTeachers = getBulkTeachers();
+  const teacherByUsername = new Map<string, { id: string }>();
+  for (const t of bulkTeachers) {
+    await prisma.person.upsert({
+      where: { id: t.personUuid },
+      update: {
+        keycloakUserId: t.kcUuid,
+        firstName: t.firstName,
+        lastName: t.lastName,
+        email: `${t.kcUsername}@demo.schoolflow.dev`,
+      },
+      create: {
+        id: t.personUuid,
+        schoolId: school.id,
+        personType: 'TEACHER',
+        firstName: t.firstName,
+        lastName: t.lastName,
+        email: `${t.kcUsername}@demo.schoolflow.dev`,
+        keycloakUserId: t.kcUuid,
+      },
+    });
+    await prisma.teacher.upsert({
+      where: { id: t.teacherUuid },
+      update: {},
+      create: {
+        id: t.teacherUuid,
+        personId: t.personUuid,
+        schoolId: school.id,
+        employmentPercentage: 100,
+        werteinheitenTarget: 20,
+        isPermanent: true,
+      },
+    });
+    teacherByUsername.set(t.kcUsername, { id: t.teacherUuid });
+    // TeacherSubjects (qualifications)
+    for (const subjShort of t.subjects) {
+      const subj = subjectByShort.get(subjShort);
+      if (!subj) {
+        throw new Error(`Subject ${subjShort} not found for teacher ${t.kcUsername}`);
+      }
+      await prisma.teacherSubject.upsert({
+        where: { teacherId_subjectId: { teacherId: t.teacherUuid, subjectId: subj.id } },
+        update: {},
+        create: { teacherId: t.teacherUuid, subjectId: subj.id },
+      });
+    }
+  }
+
+  const sl = getBulkSchulleitung();
+  await prisma.person.upsert({
+    where: { id: sl.personUuid },
+    update: {
+      keycloakUserId: sl.kcUuid,
+      firstName: sl.firstName,
+      lastName: sl.lastName,
+      email: `${sl.kcUsername}@demo.schoolflow.dev`,
+    },
+    create: {
+      id: sl.personUuid,
+      schoolId: school.id,
+      personType: 'TEACHER',
+      firstName: sl.firstName,
+      lastName: sl.lastName,
+      email: `${sl.kcUsername}@demo.schoolflow.dev`,
+      keycloakUserId: sl.kcUuid,
+    },
+  });
+  await prisma.teacher.upsert({
+    where: { id: sl.teacherUuid },
+    update: {},
+    create: {
+      id: sl.teacherUuid,
+      personId: sl.personUuid,
+      schoolId: school.id,
+      employmentPercentage: 100,
+      werteinheitenTarget: 10,
+      isPermanent: true,
+    },
+  });
+
+  // --- Parallel kc-* Legacy Mirror Users (5) ---
+  // Each carries a Person plus a record (Teacher / Student / Parent)
+  // depending on role. They live in the demo school PARALLEL to the
+  // existing 5 real legacy users (admin-user / lehrer-user / etc.) so the
+  // testdaten.md "kc-*" usernames are honored without disrupting the
+  // existing E2E contract.
+  const parallel = getParallelLegacyUsers();
+  for (const u of parallel) {
+    const personType: 'TEACHER' | 'STUDENT' | 'PARENT' =
+      u.role === 'eltern'   ? 'PARENT'  :
+      u.role === 'schueler' ? 'STUDENT' :
+                              'TEACHER';
+    await prisma.person.upsert({
+      where: { id: u.personUuid },
+      update: {
+        keycloakUserId: u.kcUuid,
+        firstName: u.firstName,
+        lastName: u.lastName,
+        email: u.email,
+      },
+      create: {
+        id: u.personUuid,
+        schoolId: school.id,
+        personType,
+        firstName: u.firstName,
+        lastName: u.lastName,
+        email: u.email,
+        keycloakUserId: u.kcUuid,
+      },
+    });
+    if (u.role === 'eltern') {
+      await prisma.parent.upsert({
+        where: { id: u.recordUuid },
+        update: {},
+        create: { id: u.recordUuid, personId: u.personUuid, schoolId: school.id },
+      });
+    } else if (u.role === 'schueler') {
+      await prisma.student.upsert({
+        where: { id: u.recordUuid },
+        update: {},
+        create: {
+          id: u.recordUuid,
+          personId: u.personUuid,
+          schoolId: school.id,
+          classId: class1A.id,
+          studentNumber: u.kcUsername,
+          enrollmentDate: new Date('2025-09-01'),
+        },
+      });
+    } else {
+      // admin / lehrer / schulleitung → Teacher record
+      await prisma.teacher.upsert({
+        where: { id: u.recordUuid },
+        update: {},
+        create: {
+          id: u.recordUuid,
+          personId: u.personUuid,
+          schoolId: school.id,
+          employmentPercentage: 100,
+          werteinheitenTarget: 20,
+          isPermanent: true,
+        },
+      });
+    }
+  }
+
+  // --- Bulk SchoolClasses (1A/1B update; 2A-4C upsert) ---
+  const bulkClasses = getBulkClasses();
+  const classIdByName = new Map<string, string>();
+  const roomByIndex = new Map(bulkRooms.map((r) => [r.index, r]));
+  for (const cls of bulkClasses) {
+    const homeRoomId = roomByIndex.get(cls.homeRoomIndex)!.uuid;
+    const kvTeacher = teacherByUsername.get(bulkTeachers[cls.kvTeacherIndex - 1].kcUsername)!;
+    if (cls.name === '1A' || cls.name === '1B') {
+      // Legacy slug-id class — update homeRoom + KV per testdaten.md
+      await prisma.schoolClass.update({
+        where: { id: cls.id },
+        data: { homeRoomId, klassenvorstandId: kvTeacher.id },
+      });
+    } else {
+      await prisma.schoolClass.upsert({
+        where: { id: cls.id },
+        update: { homeRoomId, klassenvorstandId: kvTeacher.id },
+        create: {
+          id: cls.id,
+          schoolId: school.id,
+          name: cls.name,
+          yearLevel: cls.yearLevel,
+          schoolYearId: schoolYear.id,
+          homeRoomId,
+          klassenvorstandId: kvTeacher.id,
+        },
+      });
+    }
+    classIdByName.set(cls.name, cls.id);
+  }
+
+  // --- Bulk Students + Parents ---
+  const { students, families } = buildBulkSchoolData();
+  for (const s of students) {
+    await prisma.person.upsert({
+      where: { id: s.personUuid },
+      update: {
+        keycloakUserId: s.kcUuid,
+        firstName: s.firstName,
+        lastName: s.lastName,
+        email: `${s.kcUsername}@demo.schoolflow.dev`,
+      },
+      create: {
+        id: s.personUuid,
+        schoolId: school.id,
+        personType: 'STUDENT',
+        firstName: s.firstName,
+        lastName: s.lastName,
+        email: `${s.kcUsername}@demo.schoolflow.dev`,
+        dateOfBirth: s.dateOfBirth,
+        keycloakUserId: s.kcUuid,
+      },
+    });
+    await prisma.student.upsert({
+      where: { id: s.studentUuid },
+      update: { classId: classIdByName.get(s.className)! },
+      create: {
+        id: s.studentUuid,
+        personId: s.personUuid,
+        schoolId: school.id,
+        classId: classIdByName.get(s.className)!,
+        studentNumber: s.kcUsername,
+        enrollmentDate: new Date('2025-09-01'),
+      },
+    });
+  }
+
+  for (const f of families) {
+    for (const p of [f.mother, f.father]) {
+      await prisma.person.upsert({
+        where: { id: p.personUuid },
+        update: {
+          keycloakUserId: p.kcUuid,
+          firstName: p.firstName,
+          lastName: p.lastName,
+          email: `${p.kcUsername}@demo.schoolflow.dev`,
+        },
+        create: {
+          id: p.personUuid,
+          schoolId: school.id,
+          personType: 'PARENT',
+          firstName: p.firstName,
+          lastName: p.lastName,
+          email: `${p.kcUsername}@demo.schoolflow.dev`,
+          keycloakUserId: p.kcUuid,
+        },
+      });
+      await prisma.parent.upsert({
+        where: { id: p.parentUuid },
+        update: {},
+        create: { id: p.parentUuid, personId: p.personUuid, schoolId: school.id },
+      });
+      for (const childGi of f.childGlobalIndexes) {
+        const child = students.find((s) => s.globalIndex === childGi)!;
+        await prisma.parentStudent.upsert({
+          where: { parentId_studentId: { parentId: p.parentUuid, studentId: child.studentUuid } },
+          update: {},
+          create: { parentId: p.parentUuid, studentId: child.studentUuid },
+        });
+      }
+    }
+  }
+
+  // --- Reset + recreate Groups / GroupMemberships / ClassSubjects ---
+  // The legacy seed block above created 8 ClassSubjects (4 subjects × 2 classes)
+  // without group splits. Section 175 needs 174 with E/RE group splits; the
+  // simplest path is a clean delete + insert for the demo school.
+  await prisma.groupMembership.deleteMany({
+    where: { group: { class: { schoolId: school.id } } },
+  });
+  await prisma.group.deleteMany({
+    where: { class: { schoolId: school.id } },
+  });
+  await prisma.classSubject.deleteMany({
+    where: { schoolClass: { schoolId: school.id } },
+  });
+
+  // 48 Groups: 12 classes × 4 (E-1, E-2, RE-katholisch, RE-evangelisch)
+  const groupIdByKey = new Map<string, string>();
+  let groupCounter = 0;
+  for (const cls of bulkClasses) {
+    const groupDefs: Array<{ name: 'E-Gruppe-1' | 'E-Gruppe-2' | 'RE-katholisch' | 'RE-evangelisch'; type: 'LANGUAGE' | 'RELIGION'; subjectShort: 'E' | 'RE' }> = [
+      { name: 'E-Gruppe-1',    type: 'LANGUAGE', subjectShort: 'E' },
+      { name: 'E-Gruppe-2',    type: 'LANGUAGE', subjectShort: 'E' },
+      { name: 'RE-katholisch', type: 'RELIGION', subjectShort: 'RE' },
+      { name: 'RE-evangelisch',type: 'RELIGION', subjectShort: 'RE' },
+    ];
+    for (const def of groupDefs) {
+      groupCounter++;
+      const id = `23000000-0000-4000-8000-${String(groupCounter).padStart(12, '0')}`;
+      const subj = subjectByShort.get(def.subjectShort)!;
+      await prisma.group.create({
+        data: {
+          id,
+          classId: classIdByName.get(cls.name)!,
+          name: def.name,
+          groupType: def.type,
+          subjectId: subj.id,
+        },
+      });
+      groupIdByKey.set(`${cls.name}|${def.name}`, id);
+    }
+  }
+
+  // 672 GroupMemberships: each student in 1 E-group + 1 RE-group
+  let gmCounter = 0;
+  for (const s of students) {
+    for (const grpName of [s.eGroup, s.reGroup]) {
+      gmCounter++;
+      const id = `24000000-0000-4000-8000-${String(gmCounter).padStart(12, '0')}`;
+      await prisma.groupMembership.create({
+        data: {
+          id,
+          groupId: groupIdByKey.get(`${s.className}|${grpName}`)!,
+          studentId: s.studentUuid,
+        },
+      });
+    }
+  }
+
+  // 174 ClassSubjects with deterministic teacher assignment
+  const bulkCs = getBulkClassSubjects(bulkClasses, bulkSubjects, bulkTeachers);
+  for (const r of bulkCs) {
+    const cls = bulkClasses.find((c) => c.index === r.classIndex)!;
+    const teacher = bulkTeachers.find((t) => t.index === r.teacherIndex)!;
+    const subj = subjectByShort.get(r.subjectShort)!;
+    const groupId = r.groupName
+      ? groupIdByKey.get(`${cls.name}|${r.groupName}`) ?? null
+      : null;
+    await prisma.classSubject.create({
+      data: {
+        id: r.id,
+        classId: classIdByName.get(cls.name)!,
+        subjectId: subj.id,
+        teacherId: teacher.teacherUuid,
+        groupId,
+        weeklyHours: r.weeklyHours,
+        isCustomized: false,
+      },
+    });
+  }
+
+  // --- TeacherAbsences (3 zukünftige) ---
+  const bulkAbsences = getBulkTeacherAbsences();
+  await prisma.teacherAbsence.deleteMany({
+    where: { id: { in: bulkAbsences.map((a) => a.id) } },
+  });
+  // createdBy must reference an existing Person.id — pick the kc-admin
+  // parallel-legacy person we just upserted.
+  const kcAdmin = parallel.find((u) => u.role === 'admin')!;
+  for (const a of bulkAbsences) {
+    const t = bulkTeachers.find((bt) => bt.kcUsername === a.teacherKcUsername)!;
+    await prisma.teacherAbsence.create({
+      data: {
+        id: a.id,
+        schoolId: school.id,
+        teacherId: t.teacherUuid,
+        dateFrom: a.dateFrom,
+        dateTo: a.dateTo,
+        reason: a.reason,
+        note: a.note,
+        status: 'ACTIVE',
+        createdBy: kcAdmin.personUuid,
+      },
+    });
+  }
+
   console.log(`Seeded ${roles.length} roles and ${allPermissions.length} default permissions`);
   console.log(`Seeded sample school: ${school.name} (${school.schoolType})`);
   console.log(`Seeded 3 teachers, 6 students, 4 subjects, 2 classes, ${seedRooms.length} rooms, 7 retention policies`);
   console.log('Linked 5 Keycloak test users to Person records with Klassenvorstand assignment');
+  console.log(
+    `#175 demo data: 19+${seedRooms.length} rooms, ${bulkClasses.length} classes (10 new), ` +
+    `${bulkTeachers.length} bulk teachers + 1 schulleitung-01 + ${parallel.length} parallel-kc-* users, ` +
+    `${students.length} students, ${families.length * 2} parents, ` +
+    `${bulkCs.length} class-subjects, ${groupCounter} groups, ${gmCounter} group-memberships, ` +
+    `${bulkAbsences.length} teacher-absences.`,
+  );
 }
 
 main()

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -1353,10 +1353,16 @@ async function main() {
     const homeRoomId = roomByIndex.get(cls.homeRoomIndex)!.uuid;
     const kvTeacher = teacherByUsername.get(bulkTeachers[cls.kvTeacherIndex - 1].kcUsername)!;
     if (cls.name === '1A' || cls.name === '1B') {
-      // Legacy slug-id class — update homeRoom + KV per testdaten.md
+      // Legacy slug-id class — update ONLY homeRoom per testdaten.md.
+      // klassenvorstandId is intentionally not touched: class1A already has
+      // Maria Mueller assigned by the legacy KC-linkage section above, and
+      // E2E specs (messaging-polls MSG-POLL-01, excuses-teacher-review) rely
+      // on kc-lehrer seeing CLASS-scoped messages for 1A. The KV spec values
+      // from testdaten.md (l-d-01 for 1A, l-m-01 for 1B) only apply to the
+      // new 2A-4C classes.
       await prisma.schoolClass.update({
         where: { id: cls.id },
-        data: { homeRoomId, klassenvorstandId: kvTeacher.id },
+        data: { homeRoomId },
       });
     } else {
       await prisma.schoolClass.upsert({

--- a/apps/api/src/modules/timetable/timetable.service.spec.ts
+++ b/apps/api/src/modules/timetable/timetable.service.spec.ts
@@ -317,6 +317,76 @@ describe('TimetableService', () => {
 
       expect(prismaService.timetableLesson.createMany).not.toHaveBeenCalled();
     });
+
+    // Regression for issue #175 demo-seed bug: solver returns near-optimal
+    // result (hardScore=-1) that satisfies its internal teacherConflict model
+    // but trips the strict DB @@unique([runId, teacherId, dayOfWeek,
+    // periodNumber, weekType]). Pre-fix: createMany threw → run record was
+    // already updated to COMPLETED → admin activated an empty timetable.
+    // Post-fix: catch + flip run to FAILED + record errorReason.
+    it('should mark run FAILED + record errorReason when createMany trips a DB unique-constraint', async () => {
+      const result: SolveResultDto = {
+        runId: 'run-1',
+        status: 'COMPLETED',
+        hardScore: -1,
+        softScore: -773,
+        elapsedSeconds: 300,
+        lessons: [
+          {
+            lessonId: 'cs-1-0-BOTH',
+            timeslotId: 'ts-1',
+            roomId: 'room-1',
+            dayOfWeek: 'MONDAY',
+            periodNumber: 1,
+            weekType: 'BOTH',
+          },
+          {
+            // same teacher (cs-1 → teacher-1), same slot → DB rejects
+            lessonId: 'cs-1-1-BOTH',
+            timeslotId: 'ts-1',
+            roomId: 'room-2',
+            dayOfWeek: 'MONDAY',
+            periodNumber: 1,
+            weekType: 'BOTH',
+          },
+        ],
+        violations: [],
+      };
+
+      // Reset the createMany mock from beforeEach (defaults to resolved) and
+      // make it throw the Prisma unique-constraint error verbatim.
+      prismaService.timetableLesson.createMany.mockRejectedValueOnce(
+        new Error(
+          'Unique constraint failed on the fields: (`run_id`, `teacher_id`, `day_of_week`, `period_number`, `week_type`)',
+        ),
+      );
+      // Suppress the expected error log so vitest output stays clean.
+      const errSpy = vi
+        .spyOn(service['logger'], 'error')
+        .mockImplementation(() => undefined);
+
+      // Must NOT throw — the controller would otherwise return 500 to the
+      // solver-sidecar which retries the same failing payload.
+      await expect(service.handleCompletion('run-1', result)).resolves.toBeUndefined();
+
+      // First update: solver result with status=COMPLETED.
+      // Second update: failure remediation with FAILED + isActive=false + errorReason.
+      const updateCalls = (prismaService.timetableRun.update as any).mock.calls;
+      const failedUpdate = updateCalls.find(
+        ([arg]: [{ data: { status?: string } }]) => arg.data.status === 'FAILED',
+      );
+      expect(failedUpdate, 'expected a second timetableRun.update with status=FAILED').toBeDefined();
+      expect(failedUpdate[0]).toMatchObject({
+        where: { id: 'run-1' },
+        data: {
+          status: 'FAILED',
+          isActive: false,
+          errorReason: expect.stringContaining('Lesson persistence failed'),
+        },
+      });
+
+      errSpy.mockRestore();
+    });
   });
 
   describe('stopSolve', () => {

--- a/apps/api/src/modules/timetable/timetable.service.ts
+++ b/apps/api/src/modules/timetable/timetable.service.ts
@@ -233,11 +233,38 @@ export class TimetableService {
             data: lessonRecords,
           });
         } catch (err) {
+          // Issue #175: Solver may return a near-optimal solution with a
+          // residual hard violation (hardScore = -1) that satisfies its
+          // internal model but trips the strict DB unique-constraint on
+          // (run_id, teacher_id, day, period, week_type) or the analogous
+          // room constraint. The original code threw — but the run record
+          // was already updated to COMPLETED above, leaving the user with
+          // a "successful" run that has 0 lessons and silently activates
+          // to an empty timetable.
+          //
+          // Now: flip the run to FAILED + record errorReason so the UI can
+          // surface the failure card (TimetableService.startSolve already
+          // primes the same code path for sidecar 5xx / watchdog timeouts).
+          // Also defensively flip isActive=false so the admin can't activate
+          // an empty run via stale UI state.
+          const message = (err as Error).message;
           this.logger.error(
-            `createMany failed for run ${runId} (${lessonRecords.length} records): ${(err as Error).message}`,
+            `createMany failed for run ${runId} (${lessonRecords.length} records): ${message}`,
             (err as Error).stack,
           );
-          throw err;
+          await this.prisma.timetableRun.update({
+            where: { id: runId },
+            data: {
+              status: 'FAILED',
+              isActive: false,
+              errorReason: `Lesson persistence failed: ${message.split('\n')[0]}`,
+            },
+          });
+          // Do not rethrow: the solver-sidecar callback has done its job
+          // (delivered the result), and a 500 response would only trigger a
+          // retry that fails the same way. The run is now FAILED in the DB,
+          // which is the observable outcome the UI needs.
+          return;
         }
       }
 

--- a/apps/web/e2e/admin-students-archive.spec.ts
+++ b/apps/web/e2e/admin-students-archive.spec.ts
@@ -134,6 +134,10 @@ test.describe('Phase 12 — Admin Students Archive + Restore (desktop)', () => {
     // filtered list is now empty, the filter bar hides per students.index.tsx).
     // Switch to the default (active) list via URL to re-verify.
     await page.goto('/admin/students');
+    // #175: 336 demo students push the restored row out of page 1 by default.
+    await page
+      .getByRole('searchbox', { name: 'Nach Name oder E-Mail suchen' })
+      .fill(vorname);
 
     const activeRow = page.locator('tr').filter({ hasText: vorname });
     await expect(activeRow).toBeVisible();

--- a/apps/web/e2e/admin-students-archive.spec.ts
+++ b/apps/web/e2e/admin-students-archive.spec.ts
@@ -136,7 +136,7 @@ test.describe('Phase 12 — Admin Students Archive + Restore (desktop)', () => {
     await page.goto('/admin/students');
     // #175: 336 demo students push the restored row out of page 1 by default.
     await page
-      .getByRole('searchbox', { name: 'Nach Name oder E-Mail suchen' })
+      .getByLabel('Nach Name oder E-Mail suchen')
       .fill(vorname);
 
     const activeRow = page.locator('tr').filter({ hasText: vorname });

--- a/apps/web/e2e/admin-students-crud.mobile.spec.ts
+++ b/apps/web/e2e/admin-students-crud.mobile.spec.ts
@@ -65,7 +65,7 @@ test.describe('Phase 12 — Admin Students CRUD (mobile-375, mobile-chrome/Pixel
     await page.goto('/admin/students');
     // #175: 336 demo students require filtering to scope the list.
     await page
-      .getByRole('searchbox', { name: 'Nach Name oder E-Mail suchen' })
+      .getByLabel('Nach Name oder E-Mail suchen')
       .fill(vorname);
     const anyVorname = page.getByText(vorname);
     await expect(async () => {
@@ -118,7 +118,7 @@ test.describe('Phase 12 — Admin Students CRUD (mobile-375, mobile-chrome/Pixel
     await page.goto('/admin/students');
     // #175: 336 demo students require filtering to scope the list.
     await page
-      .getByRole('searchbox', { name: 'Nach Name oder E-Mail suchen' })
+      .getByLabel('Nach Name oder E-Mail suchen')
       .fill(vorname);
 
     // Phase 17 Plan 17-04: StudentMobileCards + StudentListTable were merged

--- a/apps/web/e2e/admin-students-crud.mobile.spec.ts
+++ b/apps/web/e2e/admin-students-crud.mobile.spec.ts
@@ -63,6 +63,10 @@ test.describe('Phase 12 — Admin Students CRUD (mobile-375, mobile-chrome/Pixel
     // Back to list — confirm the mobile-cards (or table — both in DOM)
     // render the new row.
     await page.goto('/admin/students');
+    // #175: 336 demo students require filtering to scope the list.
+    await page
+      .getByRole('searchbox', { name: 'Nach Name oder E-Mail suchen' })
+      .fill(vorname);
     const anyVorname = page.getByText(vorname);
     await expect(async () => {
       const count = await anyVorname.count();
@@ -112,6 +116,10 @@ test.describe('Phase 12 — Admin Students CRUD (mobile-375, mobile-chrome/Pixel
     });
 
     await page.goto('/admin/students');
+    // #175: 336 demo students require filtering to scope the list.
+    await page
+      .getByRole('searchbox', { name: 'Nach Name oder E-Mail suchen' })
+      .fill(vorname);
 
     // Phase 17 Plan 17-04: StudentMobileCards + StudentListTable were merged
     // into a shared `<DataList>`-backed `StudentList`. DataList applies the

--- a/apps/web/e2e/admin-students-crud.spec.ts
+++ b/apps/web/e2e/admin-students-crud.spec.ts
@@ -81,6 +81,11 @@ test.describe('Phase 12 — Admin Students CRUD (desktop)', () => {
     // (StudentCreateDialog.tsx:44-48). Go back to the list and confirm the
     // row renders — proves the POST persisted AND invalidateQueries refetched.
     await page.goto('/admin/students');
+    // #175 demo seed adds 336 students to the seed school; the new row is no
+    // longer guaranteed to be on the first page of 100. Filter to scope.
+    await page
+      .getByRole('searchbox', { name: 'Nach Name oder E-Mail suchen' })
+      .fill(vorname);
     // `.first()` because the desktop table AND mobile cards both render at
     // any viewport (the `hidden md:block` / `md:hidden` split is visual only).
     await expect(page.getByText(vorname).first()).toBeVisible();

--- a/apps/web/e2e/admin-students-crud.spec.ts
+++ b/apps/web/e2e/admin-students-crud.spec.ts
@@ -84,7 +84,7 @@ test.describe('Phase 12 — Admin Students CRUD (desktop)', () => {
     // #175 demo seed adds 336 students to the seed school; the new row is no
     // longer guaranteed to be on the first page of 100. Filter to scope.
     await page
-      .getByRole('searchbox', { name: 'Nach Name oder E-Mail suchen' })
+      .getByLabel('Nach Name oder E-Mail suchen')
       .fill(vorname);
     // `.first()` because the desktop table AND mobile cards both render at
     // any viewport (the `hidden md:block` / `md:hidden` split is visual only).

--- a/docker/keycloak/realm-export.json
+++ b/docker/keycloak/realm-export.json
@@ -343,6 +343,23910 @@
           "view-clients"
         ]
       }
+    },
+    {
+      "id": "aaaaaaaa-0000-4000-8000-000000000001",
+      "username": "kc-admin",
+      "email": "kc-admin@schoolflow.demo",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Demo",
+      "lastName": "AdminShadow",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "admin"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "aaaaaaaa-0000-4000-8000-000000000002",
+      "username": "kc-lehrer",
+      "email": "kc-lehrer@schoolflow.demo",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Demo",
+      "lastName": "LehrerShadow",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "lehrer"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "aaaaaaaa-0000-4000-8000-000000000003",
+      "username": "kc-eltern",
+      "email": "kc-eltern@schoolflow.demo",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Demo",
+      "lastName": "ElternShadow",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "aaaaaaaa-0000-4000-8000-000000000004",
+      "username": "kc-schueler",
+      "email": "kc-schueler@schoolflow.demo",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Demo",
+      "lastName": "SchuelerShadow",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "aaaaaaaa-0000-4000-8000-000000000005",
+      "username": "kc-schulleitung",
+      "email": "kc-schulleitung@schoolflow.demo",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Demo",
+      "lastName": "SchulleitungShadow",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schulleitung"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "bbbb0000-0000-4000-8000-000000000001",
+      "username": "schulleitung-01",
+      "email": "schulleitung-01@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Karl-Heinz",
+      "lastName": "Direktor",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schulleitung"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "bbbb1000-0000-4000-8000-000000000001",
+      "username": "l-d-01",
+      "email": "l-d-01@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Maria",
+      "lastName": "Huber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "lehrer"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "bbbb1000-0000-4000-8000-000000000002",
+      "username": "l-d-02",
+      "email": "l-d-02@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Thomas",
+      "lastName": "Gruber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "lehrer"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "bbbb1000-0000-4000-8000-000000000003",
+      "username": "l-d-03",
+      "email": "l-d-03@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Anna",
+      "lastName": "Maier",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "lehrer"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "bbbb1000-0000-4000-8000-000000000004",
+      "username": "l-m-01",
+      "email": "l-m-01@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Stefan",
+      "lastName": "Bauer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "lehrer"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "bbbb1000-0000-4000-8000-000000000005",
+      "username": "l-m-02",
+      "email": "l-m-02@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Julia",
+      "lastName": "Berger",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "lehrer"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "bbbb1000-0000-4000-8000-000000000006",
+      "username": "l-m-03",
+      "email": "l-m-03@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Lukas",
+      "lastName": "Hofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "lehrer"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "bbbb1000-0000-4000-8000-000000000007",
+      "username": "l-e-01",
+      "email": "l-e-01@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Sabine",
+      "lastName": "Wagner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "lehrer"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "bbbb1000-0000-4000-8000-000000000008",
+      "username": "l-e-02",
+      "email": "l-e-02@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Markus",
+      "lastName": "Pichler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "lehrer"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "bbbb1000-0000-4000-8000-000000000009",
+      "username": "l-e-03",
+      "email": "l-e-03@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Christina",
+      "lastName": "Schwarz",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "lehrer"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "bbbb1000-0000-4000-8000-000000000010",
+      "username": "l-gw-01",
+      "email": "l-gw-01@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Peter",
+      "lastName": "Lechner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "lehrer"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "bbbb1000-0000-4000-8000-000000000011",
+      "username": "l-gs-01",
+      "email": "l-gs-01@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Eva",
+      "lastName": "Reiter",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "lehrer"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "bbbb1000-0000-4000-8000-000000000012",
+      "username": "l-bu-01",
+      "email": "l-bu-01@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Manuel",
+      "lastName": "Steiner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "lehrer"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "bbbb1000-0000-4000-8000-000000000013",
+      "username": "l-be-01",
+      "email": "l-be-01@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Sophie",
+      "lastName": "Mayer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "lehrer"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "bbbb1000-0000-4000-8000-000000000014",
+      "username": "l-be-02",
+      "email": "l-be-02@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "David",
+      "lastName": "Aigner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "lehrer"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "bbbb1000-0000-4000-8000-000000000015",
+      "username": "l-me-01",
+      "email": "l-me-01@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Lisa",
+      "lastName": "Wolf",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "lehrer"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "bbbb1000-0000-4000-8000-000000000016",
+      "username": "l-me-02",
+      "email": "l-me-02@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Andreas",
+      "lastName": "Köhler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "lehrer"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "bbbb1000-0000-4000-8000-000000000017",
+      "username": "l-bu-02",
+      "email": "l-bu-02@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Katharina",
+      "lastName": "Brunner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "lehrer"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "bbbb1000-0000-4000-8000-000000000018",
+      "username": "l-ph-01",
+      "email": "l-ph-01@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Michael",
+      "lastName": "Fischer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "lehrer"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "bbbb1000-0000-4000-8000-000000000019",
+      "username": "l-ph-02",
+      "email": "l-ph-02@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Sandra",
+      "lastName": "Holzer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "lehrer"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "bbbb1000-0000-4000-8000-000000000020",
+      "username": "l-ch-01",
+      "email": "l-ch-01@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Daniel",
+      "lastName": "Weber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "lehrer"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "bbbb1000-0000-4000-8000-000000000021",
+      "username": "l-inf-01",
+      "email": "l-inf-01@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Tobias",
+      "lastName": "Hartl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "lehrer"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "bbbb1000-0000-4000-8000-000000000022",
+      "username": "l-inf-02",
+      "email": "l-inf-02@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Marlene",
+      "lastName": "Eder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "lehrer"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "bbbb1000-0000-4000-8000-000000000023",
+      "username": "l-bsp-01",
+      "email": "l-bsp-01@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Felix",
+      "lastName": "Riedl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "lehrer"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "bbbb1000-0000-4000-8000-000000000024",
+      "username": "l-bsp-02",
+      "email": "l-bsp-02@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Christoph",
+      "lastName": "Stadler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "lehrer"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "bbbb1000-0000-4000-8000-000000000025",
+      "username": "l-bsp-03",
+      "email": "l-bsp-03@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Tanja",
+      "lastName": "Lang",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "lehrer"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "bbbb1000-0000-4000-8000-000000000026",
+      "username": "l-bsp-04",
+      "email": "l-bsp-04@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Birgit",
+      "lastName": "Köberl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "lehrer"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "bbbb1000-0000-4000-8000-000000000027",
+      "username": "l-re-01",
+      "email": "l-re-01@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Pater",
+      "lastName": "Albrecht",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "lehrer"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "bbbb1000-0000-4000-8000-000000000028",
+      "username": "l-re-02",
+      "email": "l-re-02@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Hannah",
+      "lastName": "Mayrhofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "lehrer"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "bbbb1000-0000-4000-8000-000000000029",
+      "username": "l-we-01",
+      "email": "l-we-01@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Roland",
+      "lastName": "Köhler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "lehrer"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "bbbb1000-0000-4000-8000-000000000030",
+      "username": "l-we-02",
+      "email": "l-we-02@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Verena",
+      "lastName": "Wallner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "lehrer"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "bbbb1000-0000-4000-8000-000000000031",
+      "username": "l-d-04",
+      "email": "l-d-04@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Beatrix",
+      "lastName": "Strasser",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "lehrer"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "bbbb1000-0000-4000-8000-000000000032",
+      "username": "l-m-04",
+      "email": "l-m-04@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Alexander",
+      "lastName": "Linder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "lehrer"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000001",
+      "username": "s-1a-01",
+      "email": "s-1a-01@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Anna",
+      "lastName": "Aigner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000002",
+      "username": "s-1a-02",
+      "email": "s-1a-02@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Benjamin",
+      "lastName": "Bauer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000003",
+      "username": "s-1a-03",
+      "email": "s-1a-03@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Clara",
+      "lastName": "Brunner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000004",
+      "username": "s-1a-04",
+      "email": "s-1a-04@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "David",
+      "lastName": "Eder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000005",
+      "username": "s-1a-05",
+      "email": "s-1a-05@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Emma",
+      "lastName": "Fischer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000006",
+      "username": "s-1a-06",
+      "email": "s-1a-06@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Felix",
+      "lastName": "Gruber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000007",
+      "username": "s-1a-07",
+      "email": "s-1a-07@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Greta",
+      "lastName": "Hofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000008",
+      "username": "s-1a-08",
+      "email": "s-1a-08@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Hannes",
+      "lastName": "Holzer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000009",
+      "username": "s-1a-09",
+      "email": "s-1a-09@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Iris",
+      "lastName": "Huber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000010",
+      "username": "s-1a-10",
+      "email": "s-1a-10@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Jakob",
+      "lastName": "Köhler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000011",
+      "username": "s-1a-11",
+      "email": "s-1a-11@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Katharina",
+      "lastName": "Köberl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000012",
+      "username": "s-1a-12",
+      "email": "s-1a-12@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Lukas",
+      "lastName": "Kogler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000013",
+      "username": "s-1a-13",
+      "email": "s-1a-13@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Maria",
+      "lastName": "Lang",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000014",
+      "username": "s-1a-14",
+      "email": "s-1a-14@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Nico",
+      "lastName": "Lechner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000015",
+      "username": "s-1a-15",
+      "email": "s-1a-15@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Olivia",
+      "lastName": "Linder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000016",
+      "username": "s-1a-16",
+      "email": "s-1a-16@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Paul",
+      "lastName": "Maier",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000017",
+      "username": "s-1a-17",
+      "email": "s-1a-17@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Rebecca",
+      "lastName": "Mayer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000018",
+      "username": "s-1a-18",
+      "email": "s-1a-18@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Richard",
+      "lastName": "Mayerhofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000019",
+      "username": "s-1a-19",
+      "email": "s-1a-19@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Theresa",
+      "lastName": "Pichler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000020",
+      "username": "s-1a-20",
+      "email": "s-1a-20@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Tobias",
+      "lastName": "Reiter",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000021",
+      "username": "s-1a-21",
+      "email": "s-1a-21@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Valentina",
+      "lastName": "Riedl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000022",
+      "username": "s-1a-22",
+      "email": "s-1a-22@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Valentin",
+      "lastName": "Schwarz",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000023",
+      "username": "s-1a-23",
+      "email": "s-1a-23@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Yasmin",
+      "lastName": "Stadler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000024",
+      "username": "s-1a-24",
+      "email": "s-1a-24@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Xaver",
+      "lastName": "Steiner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000025",
+      "username": "s-1a-25",
+      "email": "s-1a-25@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Amelie",
+      "lastName": "Strasser",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000026",
+      "username": "s-1a-26",
+      "email": "s-1a-26@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Zacharias",
+      "lastName": "Wagner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000027",
+      "username": "s-1a-27",
+      "email": "s-1a-27@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Charlotte",
+      "lastName": "Wallner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000028",
+      "username": "s-1a-28",
+      "email": "s-1a-28@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Bernhard",
+      "lastName": "Weber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000029",
+      "username": "s-1b-01",
+      "email": "s-1b-01@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Elena",
+      "lastName": "Linder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000030",
+      "username": "s-1b-02",
+      "email": "s-1b-02@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Dominik",
+      "lastName": "Maier",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000031",
+      "username": "s-1b-03",
+      "email": "s-1b-03@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Anna",
+      "lastName": "Mayer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000032",
+      "username": "s-1b-04",
+      "email": "s-1b-04@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Benjamin",
+      "lastName": "Mayerhofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000033",
+      "username": "s-1b-05",
+      "email": "s-1b-05@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Clara",
+      "lastName": "Pichler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000034",
+      "username": "s-1b-06",
+      "email": "s-1b-06@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "David",
+      "lastName": "Reiter",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000035",
+      "username": "s-1b-07",
+      "email": "s-1b-07@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Emma",
+      "lastName": "Riedl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000036",
+      "username": "s-1b-08",
+      "email": "s-1b-08@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Felix",
+      "lastName": "Schwarz",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000037",
+      "username": "s-1b-09",
+      "email": "s-1b-09@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Greta",
+      "lastName": "Stadler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000038",
+      "username": "s-1b-10",
+      "email": "s-1b-10@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Hannes",
+      "lastName": "Steiner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000039",
+      "username": "s-1b-11",
+      "email": "s-1b-11@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Iris",
+      "lastName": "Strasser",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000040",
+      "username": "s-1b-12",
+      "email": "s-1b-12@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Jakob",
+      "lastName": "Wagner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000041",
+      "username": "s-1b-13",
+      "email": "s-1b-13@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Katharina",
+      "lastName": "Wallner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000042",
+      "username": "s-1b-14",
+      "email": "s-1b-14@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Lukas",
+      "lastName": "Weber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000043",
+      "username": "s-1b-15",
+      "email": "s-1b-15@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Maria",
+      "lastName": "Wolf",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000044",
+      "username": "s-1b-16",
+      "email": "s-1b-16@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Nico",
+      "lastName": "Berger",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000045",
+      "username": "s-1b-17",
+      "email": "s-1b-17@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Olivia",
+      "lastName": "Aigner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000046",
+      "username": "s-1b-18",
+      "email": "s-1b-18@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Paul",
+      "lastName": "Bauer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000047",
+      "username": "s-1b-19",
+      "email": "s-1b-19@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Rebecca",
+      "lastName": "Brunner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000048",
+      "username": "s-1b-20",
+      "email": "s-1b-20@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Richard",
+      "lastName": "Eder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000049",
+      "username": "s-1b-21",
+      "email": "s-1b-21@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Theresa",
+      "lastName": "Fischer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000050",
+      "username": "s-1b-22",
+      "email": "s-1b-22@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Tobias",
+      "lastName": "Gruber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000051",
+      "username": "s-1b-23",
+      "email": "s-1b-23@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Valentina",
+      "lastName": "Hofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000052",
+      "username": "s-1b-24",
+      "email": "s-1b-24@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Valentin",
+      "lastName": "Holzer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000053",
+      "username": "s-1b-25",
+      "email": "s-1b-25@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Yasmin",
+      "lastName": "Huber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000054",
+      "username": "s-1b-26",
+      "email": "s-1b-26@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Xaver",
+      "lastName": "Köhler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000055",
+      "username": "s-1b-27",
+      "email": "s-1b-27@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Amelie",
+      "lastName": "Köberl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000056",
+      "username": "s-1b-28",
+      "email": "s-1b-28@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Zacharias",
+      "lastName": "Kogler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000057",
+      "username": "s-1c-01",
+      "email": "s-1c-01@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Charlotte",
+      "lastName": "Wolf",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000058",
+      "username": "s-1c-02",
+      "email": "s-1c-02@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Bernhard",
+      "lastName": "Berger",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000059",
+      "username": "s-1c-03",
+      "email": "s-1c-03@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Elena",
+      "lastName": "Aigner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000060",
+      "username": "s-1c-04",
+      "email": "s-1c-04@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Dominik",
+      "lastName": "Bauer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000061",
+      "username": "s-1c-05",
+      "email": "s-1c-05@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Anna",
+      "lastName": "Brunner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000062",
+      "username": "s-1c-06",
+      "email": "s-1c-06@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Benjamin",
+      "lastName": "Eder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000063",
+      "username": "s-1c-07",
+      "email": "s-1c-07@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Clara",
+      "lastName": "Fischer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000064",
+      "username": "s-1c-08",
+      "email": "s-1c-08@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "David",
+      "lastName": "Gruber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000065",
+      "username": "s-1c-09",
+      "email": "s-1c-09@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Emma",
+      "lastName": "Hofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000066",
+      "username": "s-1c-10",
+      "email": "s-1c-10@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Felix",
+      "lastName": "Holzer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000067",
+      "username": "s-1c-11",
+      "email": "s-1c-11@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Greta",
+      "lastName": "Huber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000068",
+      "username": "s-1c-12",
+      "email": "s-1c-12@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Hannes",
+      "lastName": "Köhler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000069",
+      "username": "s-1c-13",
+      "email": "s-1c-13@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Iris",
+      "lastName": "Köberl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000070",
+      "username": "s-1c-14",
+      "email": "s-1c-14@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Jakob",
+      "lastName": "Kogler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000071",
+      "username": "s-1c-15",
+      "email": "s-1c-15@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Katharina",
+      "lastName": "Lang",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000072",
+      "username": "s-1c-16",
+      "email": "s-1c-16@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Lukas",
+      "lastName": "Lechner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000073",
+      "username": "s-1c-17",
+      "email": "s-1c-17@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Maria",
+      "lastName": "Linder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000074",
+      "username": "s-1c-18",
+      "email": "s-1c-18@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Nico",
+      "lastName": "Maier",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000075",
+      "username": "s-1c-19",
+      "email": "s-1c-19@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Olivia",
+      "lastName": "Mayer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000076",
+      "username": "s-1c-20",
+      "email": "s-1c-20@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Paul",
+      "lastName": "Mayerhofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000077",
+      "username": "s-1c-21",
+      "email": "s-1c-21@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Rebecca",
+      "lastName": "Pichler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000078",
+      "username": "s-1c-22",
+      "email": "s-1c-22@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Richard",
+      "lastName": "Reiter",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000079",
+      "username": "s-1c-23",
+      "email": "s-1c-23@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Theresa",
+      "lastName": "Riedl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000080",
+      "username": "s-1c-24",
+      "email": "s-1c-24@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Tobias",
+      "lastName": "Schwarz",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000081",
+      "username": "s-1c-25",
+      "email": "s-1c-25@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Valentina",
+      "lastName": "Stadler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000082",
+      "username": "s-1c-26",
+      "email": "s-1c-26@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Valentin",
+      "lastName": "Steiner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000083",
+      "username": "s-1c-27",
+      "email": "s-1c-27@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Yasmin",
+      "lastName": "Strasser",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000084",
+      "username": "s-1c-28",
+      "email": "s-1c-28@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Xaver",
+      "lastName": "Wagner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000085",
+      "username": "s-2a-01",
+      "email": "s-2a-01@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Amelie",
+      "lastName": "Lang",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000086",
+      "username": "s-2a-02",
+      "email": "s-2a-02@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Zacharias",
+      "lastName": "Lechner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000087",
+      "username": "s-2a-03",
+      "email": "s-2a-03@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Charlotte",
+      "lastName": "Linder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000088",
+      "username": "s-2a-04",
+      "email": "s-2a-04@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Bernhard",
+      "lastName": "Maier",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000089",
+      "username": "s-2a-05",
+      "email": "s-2a-05@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Elena",
+      "lastName": "Mayer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000090",
+      "username": "s-2a-06",
+      "email": "s-2a-06@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Dominik",
+      "lastName": "Mayerhofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000091",
+      "username": "s-2a-07",
+      "email": "s-2a-07@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Anna",
+      "lastName": "Pichler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000092",
+      "username": "s-2a-08",
+      "email": "s-2a-08@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Benjamin",
+      "lastName": "Reiter",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000093",
+      "username": "s-2a-09",
+      "email": "s-2a-09@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Clara",
+      "lastName": "Riedl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000094",
+      "username": "s-2a-10",
+      "email": "s-2a-10@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "David",
+      "lastName": "Schwarz",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000095",
+      "username": "s-2a-11",
+      "email": "s-2a-11@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Emma",
+      "lastName": "Stadler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000096",
+      "username": "s-2a-12",
+      "email": "s-2a-12@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Felix",
+      "lastName": "Steiner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000097",
+      "username": "s-2a-13",
+      "email": "s-2a-13@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Greta",
+      "lastName": "Strasser",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000098",
+      "username": "s-2a-14",
+      "email": "s-2a-14@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Hannes",
+      "lastName": "Wagner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000099",
+      "username": "s-2a-15",
+      "email": "s-2a-15@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Iris",
+      "lastName": "Wallner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000100",
+      "username": "s-2a-16",
+      "email": "s-2a-16@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Jakob",
+      "lastName": "Weber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000101",
+      "username": "s-2a-17",
+      "email": "s-2a-17@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Katharina",
+      "lastName": "Wolf",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000102",
+      "username": "s-2a-18",
+      "email": "s-2a-18@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Lukas",
+      "lastName": "Berger",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000103",
+      "username": "s-2a-19",
+      "email": "s-2a-19@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Maria",
+      "lastName": "Aigner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000104",
+      "username": "s-2a-20",
+      "email": "s-2a-20@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Nico",
+      "lastName": "Bauer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000105",
+      "username": "s-2a-21",
+      "email": "s-2a-21@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Olivia",
+      "lastName": "Brunner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000106",
+      "username": "s-2a-22",
+      "email": "s-2a-22@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Paul",
+      "lastName": "Brunner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000107",
+      "username": "s-2a-23",
+      "email": "s-2a-23@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Rebecca",
+      "lastName": "Fischer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000108",
+      "username": "s-2a-24",
+      "email": "s-2a-24@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Richard",
+      "lastName": "Gruber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000109",
+      "username": "s-2a-25",
+      "email": "s-2a-25@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Theresa",
+      "lastName": "Hofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000110",
+      "username": "s-2a-26",
+      "email": "s-2a-26@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Tobias",
+      "lastName": "Holzer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000111",
+      "username": "s-2a-27",
+      "email": "s-2a-27@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Valentina",
+      "lastName": "Huber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000112",
+      "username": "s-2a-28",
+      "email": "s-2a-28@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Valentin",
+      "lastName": "Köhler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000113",
+      "username": "s-2b-01",
+      "email": "s-2b-01@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Yasmin",
+      "lastName": "Wallner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000114",
+      "username": "s-2b-02",
+      "email": "s-2b-02@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Xaver",
+      "lastName": "Weber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000115",
+      "username": "s-2b-03",
+      "email": "s-2b-03@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Amelie",
+      "lastName": "Wolf",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000116",
+      "username": "s-2b-04",
+      "email": "s-2b-04@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Zacharias",
+      "lastName": "Berger",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000117",
+      "username": "s-2b-05",
+      "email": "s-2b-05@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Charlotte",
+      "lastName": "Aigner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000118",
+      "username": "s-2b-06",
+      "email": "s-2b-06@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Bernhard",
+      "lastName": "Bauer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000119",
+      "username": "s-2b-07",
+      "email": "s-2b-07@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Elena",
+      "lastName": "Brunner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000120",
+      "username": "s-2b-08",
+      "email": "s-2b-08@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Dominik",
+      "lastName": "Eder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000121",
+      "username": "s-2b-09",
+      "email": "s-2b-09@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Anna",
+      "lastName": "Fischer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000122",
+      "username": "s-2b-10",
+      "email": "s-2b-10@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Benjamin",
+      "lastName": "Gruber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000123",
+      "username": "s-2b-11",
+      "email": "s-2b-11@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Clara",
+      "lastName": "Hofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000124",
+      "username": "s-2b-12",
+      "email": "s-2b-12@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "David",
+      "lastName": "Holzer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000125",
+      "username": "s-2b-13",
+      "email": "s-2b-13@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Emma",
+      "lastName": "Steiner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000126",
+      "username": "s-2b-14",
+      "email": "s-2b-14@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Felix",
+      "lastName": "Köhler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000127",
+      "username": "s-2b-15",
+      "email": "s-2b-15@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Greta",
+      "lastName": "Köberl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000128",
+      "username": "s-2b-16",
+      "email": "s-2b-16@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Hannes",
+      "lastName": "Kogler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000129",
+      "username": "s-2b-17",
+      "email": "s-2b-17@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Iris",
+      "lastName": "Lang",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000130",
+      "username": "s-2b-18",
+      "email": "s-2b-18@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Jakob",
+      "lastName": "Lechner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000131",
+      "username": "s-2b-19",
+      "email": "s-2b-19@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Katharina",
+      "lastName": "Linder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000132",
+      "username": "s-2b-20",
+      "email": "s-2b-20@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Lukas",
+      "lastName": "Maier",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000133",
+      "username": "s-2b-21",
+      "email": "s-2b-21@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Maria",
+      "lastName": "Mayer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000134",
+      "username": "s-2b-22",
+      "email": "s-2b-22@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Nico",
+      "lastName": "Mayerhofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000135",
+      "username": "s-2b-23",
+      "email": "s-2b-23@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Olivia",
+      "lastName": "Pichler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000136",
+      "username": "s-2b-24",
+      "email": "s-2b-24@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Paul",
+      "lastName": "Reiter",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000137",
+      "username": "s-2b-25",
+      "email": "s-2b-25@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Rebecca",
+      "lastName": "Maier",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000138",
+      "username": "s-2b-26",
+      "email": "s-2b-26@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Richard",
+      "lastName": "Schwarz",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000139",
+      "username": "s-2b-27",
+      "email": "s-2b-27@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Theresa",
+      "lastName": "Stadler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000140",
+      "username": "s-2b-28",
+      "email": "s-2b-28@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Tobias",
+      "lastName": "Steiner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000141",
+      "username": "s-2c-01",
+      "email": "s-2c-01@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Valentina",
+      "lastName": "Köberl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000142",
+      "username": "s-2c-02",
+      "email": "s-2c-02@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Valentin",
+      "lastName": "Kogler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000143",
+      "username": "s-2c-03",
+      "email": "s-2c-03@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Yasmin",
+      "lastName": "Hofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000144",
+      "username": "s-2c-04",
+      "email": "s-2c-04@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Xaver",
+      "lastName": "Lechner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000145",
+      "username": "s-2c-05",
+      "email": "s-2c-05@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Amelie",
+      "lastName": "Linder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000146",
+      "username": "s-2c-06",
+      "email": "s-2c-06@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Zacharias",
+      "lastName": "Maier",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000147",
+      "username": "s-2c-07",
+      "email": "s-2c-07@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Charlotte",
+      "lastName": "Mayer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000148",
+      "username": "s-2c-08",
+      "email": "s-2c-08@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Bernhard",
+      "lastName": "Mayerhofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000149",
+      "username": "s-2c-09",
+      "email": "s-2c-09@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Elena",
+      "lastName": "Pichler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000150",
+      "username": "s-2c-10",
+      "email": "s-2c-10@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Dominik",
+      "lastName": "Reiter",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000151",
+      "username": "s-2c-11",
+      "email": "s-2c-11@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Anna",
+      "lastName": "Riedl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000152",
+      "username": "s-2c-12",
+      "email": "s-2c-12@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Benjamin",
+      "lastName": "Schwarz",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000153",
+      "username": "s-2c-13",
+      "email": "s-2c-13@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Clara",
+      "lastName": "Stadler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000154",
+      "username": "s-2c-14",
+      "email": "s-2c-14@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "David",
+      "lastName": "Steiner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000155",
+      "username": "s-2c-15",
+      "email": "s-2c-15@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Emma",
+      "lastName": "Strasser",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000156",
+      "username": "s-2c-16",
+      "email": "s-2c-16@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Felix",
+      "lastName": "Wagner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000157",
+      "username": "s-2c-17",
+      "email": "s-2c-17@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Greta",
+      "lastName": "Wallner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000158",
+      "username": "s-2c-18",
+      "email": "s-2c-18@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Hannes",
+      "lastName": "Weber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000159",
+      "username": "s-2c-19",
+      "email": "s-2c-19@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Iris",
+      "lastName": "Mayerhofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000160",
+      "username": "s-2c-20",
+      "email": "s-2c-20@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Jakob",
+      "lastName": "Berger",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000161",
+      "username": "s-2c-21",
+      "email": "s-2c-21@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Katharina",
+      "lastName": "Aigner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000162",
+      "username": "s-2c-22",
+      "email": "s-2c-22@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Lukas",
+      "lastName": "Bauer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000163",
+      "username": "s-2c-23",
+      "email": "s-2c-23@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Maria",
+      "lastName": "Brunner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000164",
+      "username": "s-2c-24",
+      "email": "s-2c-24@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Nico",
+      "lastName": "Eder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000165",
+      "username": "s-2c-25",
+      "email": "s-2c-25@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Olivia",
+      "lastName": "Fischer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000166",
+      "username": "s-2c-26",
+      "email": "s-2c-26@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Paul",
+      "lastName": "Gruber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000167",
+      "username": "s-2c-27",
+      "email": "s-2c-27@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Rebecca",
+      "lastName": "Hofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000168",
+      "username": "s-2c-28",
+      "email": "s-2c-28@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Richard",
+      "lastName": "Holzer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000169",
+      "username": "s-3a-01",
+      "email": "s-3a-01@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Theresa",
+      "lastName": "Strasser",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000170",
+      "username": "s-3a-02",
+      "email": "s-3a-02@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Tobias",
+      "lastName": "Wagner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000171",
+      "username": "s-3a-03",
+      "email": "s-3a-03@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Valentina",
+      "lastName": "Wallner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000172",
+      "username": "s-3a-04",
+      "email": "s-3a-04@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Valentin",
+      "lastName": "Weber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000173",
+      "username": "s-3a-05",
+      "email": "s-3a-05@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Yasmin",
+      "lastName": "Wolf",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000174",
+      "username": "s-3a-06",
+      "email": "s-3a-06@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Xaver",
+      "lastName": "Berger",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000175",
+      "username": "s-3a-07",
+      "email": "s-3a-07@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Amelie",
+      "lastName": "Aigner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000176",
+      "username": "s-3a-08",
+      "email": "s-3a-08@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Zacharias",
+      "lastName": "Linder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000177",
+      "username": "s-3a-09",
+      "email": "s-3a-09@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Charlotte",
+      "lastName": "Brunner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000178",
+      "username": "s-3a-10",
+      "email": "s-3a-10@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Bernhard",
+      "lastName": "Eder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000179",
+      "username": "s-3a-11",
+      "email": "s-3a-11@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Elena",
+      "lastName": "Fischer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000180",
+      "username": "s-3a-12",
+      "email": "s-3a-12@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Dominik",
+      "lastName": "Gruber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000181",
+      "username": "s-3a-13",
+      "email": "s-3a-13@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Anna",
+      "lastName": "Hofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000182",
+      "username": "s-3a-14",
+      "email": "s-3a-14@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Benjamin",
+      "lastName": "Holzer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000183",
+      "username": "s-3a-15",
+      "email": "s-3a-15@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Clara",
+      "lastName": "Huber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000184",
+      "username": "s-3a-16",
+      "email": "s-3a-16@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "David",
+      "lastName": "Köhler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000185",
+      "username": "s-3a-17",
+      "email": "s-3a-17@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Emma",
+      "lastName": "Köberl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000186",
+      "username": "s-3a-18",
+      "email": "s-3a-18@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Felix",
+      "lastName": "Kogler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000187",
+      "username": "s-3a-19",
+      "email": "s-3a-19@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Greta",
+      "lastName": "Weber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000188",
+      "username": "s-3a-20",
+      "email": "s-3a-20@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Hannes",
+      "lastName": "Lechner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000189",
+      "username": "s-3a-21",
+      "email": "s-3a-21@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Iris",
+      "lastName": "Linder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000190",
+      "username": "s-3a-22",
+      "email": "s-3a-22@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Jakob",
+      "lastName": "Maier",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000191",
+      "username": "s-3a-23",
+      "email": "s-3a-23@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Katharina",
+      "lastName": "Mayer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000192",
+      "username": "s-3a-24",
+      "email": "s-3a-24@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Lukas",
+      "lastName": "Mayerhofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000193",
+      "username": "s-3a-25",
+      "email": "s-3a-25@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Maria",
+      "lastName": "Pichler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000194",
+      "username": "s-3a-26",
+      "email": "s-3a-26@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Nico",
+      "lastName": "Reiter",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000195",
+      "username": "s-3a-27",
+      "email": "s-3a-27@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Olivia",
+      "lastName": "Riedl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000196",
+      "username": "s-3a-28",
+      "email": "s-3a-28@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Paul",
+      "lastName": "Schwarz",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000197",
+      "username": "s-3b-01",
+      "email": "s-3b-01@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Rebecca",
+      "lastName": "Huber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000198",
+      "username": "s-3b-02",
+      "email": "s-3b-02@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Richard",
+      "lastName": "Köhler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000199",
+      "username": "s-3b-03",
+      "email": "s-3b-03@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Theresa",
+      "lastName": "Köberl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000200",
+      "username": "s-3b-04",
+      "email": "s-3b-04@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Tobias",
+      "lastName": "Kogler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000201",
+      "username": "s-3b-05",
+      "email": "s-3b-05@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Valentina",
+      "lastName": "Lang",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000202",
+      "username": "s-3b-06",
+      "email": "s-3b-06@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Valentin",
+      "lastName": "Lechner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000203",
+      "username": "s-3b-07",
+      "email": "s-3b-07@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Yasmin",
+      "lastName": "Wagner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000204",
+      "username": "s-3b-08",
+      "email": "s-3b-08@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Xaver",
+      "lastName": "Maier",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000205",
+      "username": "s-3b-09",
+      "email": "s-3b-09@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Amelie",
+      "lastName": "Mayer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000206",
+      "username": "s-3b-10",
+      "email": "s-3b-10@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Zacharias",
+      "lastName": "Mayerhofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000207",
+      "username": "s-3b-11",
+      "email": "s-3b-11@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Charlotte",
+      "lastName": "Pichler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000208",
+      "username": "s-3b-12",
+      "email": "s-3b-12@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Bernhard",
+      "lastName": "Reiter",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000209",
+      "username": "s-3b-13",
+      "email": "s-3b-13@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Elena",
+      "lastName": "Riedl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000210",
+      "username": "s-3b-14",
+      "email": "s-3b-14@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Dominik",
+      "lastName": "Berger",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000211",
+      "username": "s-3b-15",
+      "email": "s-3b-15@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Anna",
+      "lastName": "Stadler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000212",
+      "username": "s-3b-16",
+      "email": "s-3b-16@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Benjamin",
+      "lastName": "Steiner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000213",
+      "username": "s-3b-17",
+      "email": "s-3b-17@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Clara",
+      "lastName": "Strasser",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000214",
+      "username": "s-3b-18",
+      "email": "s-3b-18@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "David",
+      "lastName": "Wagner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000215",
+      "username": "s-3b-19",
+      "email": "s-3b-19@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Emma",
+      "lastName": "Wallner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000216",
+      "username": "s-3b-20",
+      "email": "s-3b-20@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Felix",
+      "lastName": "Weber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000217",
+      "username": "s-3b-21",
+      "email": "s-3b-21@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Greta",
+      "lastName": "Wolf",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000218",
+      "username": "s-3b-22",
+      "email": "s-3b-22@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Hannes",
+      "lastName": "Berger",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000219",
+      "username": "s-3b-23",
+      "email": "s-3b-23@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Iris",
+      "lastName": "Aigner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000220",
+      "username": "s-3b-24",
+      "email": "s-3b-24@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Jakob",
+      "lastName": "Bauer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000221",
+      "username": "s-3b-25",
+      "email": "s-3b-25@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Katharina",
+      "lastName": "Brunner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000222",
+      "username": "s-3b-26",
+      "email": "s-3b-26@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Lukas",
+      "lastName": "Eder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000223",
+      "username": "s-3b-27",
+      "email": "s-3b-27@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Maria",
+      "lastName": "Fischer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000224",
+      "username": "s-3b-28",
+      "email": "s-3b-28@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Nico",
+      "lastName": "Gruber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000225",
+      "username": "s-3c-01",
+      "email": "s-3c-01@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Olivia",
+      "lastName": "Stadler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000226",
+      "username": "s-3c-02",
+      "email": "s-3c-02@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Paul",
+      "lastName": "Steiner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000227",
+      "username": "s-3c-03",
+      "email": "s-3c-03@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Rebecca",
+      "lastName": "Strasser",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000228",
+      "username": "s-3c-04",
+      "email": "s-3c-04@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Richard",
+      "lastName": "Wagner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000229",
+      "username": "s-3c-05",
+      "email": "s-3c-05@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Theresa",
+      "lastName": "Wallner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000230",
+      "username": "s-3c-06",
+      "email": "s-3c-06@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Tobias",
+      "lastName": "Weber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000231",
+      "username": "s-3c-07",
+      "email": "s-3c-07@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Valentina",
+      "lastName": "Wolf",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000232",
+      "username": "s-3c-08",
+      "email": "s-3c-08@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Valentin",
+      "lastName": "Berger",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000233",
+      "username": "s-3c-09",
+      "email": "s-3c-09@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Yasmin",
+      "lastName": "Aigner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000234",
+      "username": "s-3c-10",
+      "email": "s-3c-10@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Xaver",
+      "lastName": "Bauer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000235",
+      "username": "s-3c-11",
+      "email": "s-3c-11@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Amelie",
+      "lastName": "Brunner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000236",
+      "username": "s-3c-12",
+      "email": "s-3c-12@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Zacharias",
+      "lastName": "Reiter",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000237",
+      "username": "s-3c-13",
+      "email": "s-3c-13@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Charlotte",
+      "lastName": "Fischer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000238",
+      "username": "s-3c-14",
+      "email": "s-3c-14@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Bernhard",
+      "lastName": "Gruber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000239",
+      "username": "s-3c-15",
+      "email": "s-3c-15@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Elena",
+      "lastName": "Hofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000240",
+      "username": "s-3c-16",
+      "email": "s-3c-16@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Dominik",
+      "lastName": "Holzer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000241",
+      "username": "s-3c-17",
+      "email": "s-3c-17@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Anna",
+      "lastName": "Huber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000242",
+      "username": "s-3c-18",
+      "email": "s-3c-18@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Benjamin",
+      "lastName": "Köhler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000243",
+      "username": "s-3c-19",
+      "email": "s-3c-19@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Clara",
+      "lastName": "Köberl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000244",
+      "username": "s-3c-20",
+      "email": "s-3c-20@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "David",
+      "lastName": "Kogler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000245",
+      "username": "s-3c-21",
+      "email": "s-3c-21@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Emma",
+      "lastName": "Lang",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000246",
+      "username": "s-3c-22",
+      "email": "s-3c-22@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Felix",
+      "lastName": "Lechner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000247",
+      "username": "s-3c-23",
+      "email": "s-3c-23@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Greta",
+      "lastName": "Stadler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000248",
+      "username": "s-3c-24",
+      "email": "s-3c-24@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Hannes",
+      "lastName": "Maier",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000249",
+      "username": "s-3c-25",
+      "email": "s-3c-25@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Iris",
+      "lastName": "Mayer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000250",
+      "username": "s-3c-26",
+      "email": "s-3c-26@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Jakob",
+      "lastName": "Mayerhofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000251",
+      "username": "s-3c-27",
+      "email": "s-3c-27@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Katharina",
+      "lastName": "Pichler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000252",
+      "username": "s-3c-28",
+      "email": "s-3c-28@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Lukas",
+      "lastName": "Reiter",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000253",
+      "username": "s-4a-01",
+      "email": "s-4a-01@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Maria",
+      "lastName": "Hofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000254",
+      "username": "s-4a-02",
+      "email": "s-4a-02@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Nico",
+      "lastName": "Holzer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000255",
+      "username": "s-4a-03",
+      "email": "s-4a-03@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Olivia",
+      "lastName": "Köberl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000256",
+      "username": "s-4a-04",
+      "email": "s-4a-04@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Paul",
+      "lastName": "Köhler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000257",
+      "username": "s-4a-05",
+      "email": "s-4a-05@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Rebecca",
+      "lastName": "Köberl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000258",
+      "username": "s-4a-06",
+      "email": "s-4a-06@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Richard",
+      "lastName": "Kogler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000259",
+      "username": "s-4a-07",
+      "email": "s-4a-07@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Theresa",
+      "lastName": "Lang",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000260",
+      "username": "s-4a-08",
+      "email": "s-4a-08@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Tobias",
+      "lastName": "Lechner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000261",
+      "username": "s-4a-09",
+      "email": "s-4a-09@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Valentina",
+      "lastName": "Linder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000262",
+      "username": "s-4a-10",
+      "email": "s-4a-10@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Valentin",
+      "lastName": "Maier",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000263",
+      "username": "s-4a-11",
+      "email": "s-4a-11@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Yasmin",
+      "lastName": "Mayer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000264",
+      "username": "s-4a-12",
+      "email": "s-4a-12@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Xaver",
+      "lastName": "Mayerhofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000265",
+      "username": "s-4a-13",
+      "email": "s-4a-13@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Amelie",
+      "lastName": "Pichler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000266",
+      "username": "s-4a-14",
+      "email": "s-4a-14@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Zacharias",
+      "lastName": "Aigner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000267",
+      "username": "s-4a-15",
+      "email": "s-4a-15@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Charlotte",
+      "lastName": "Riedl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000268",
+      "username": "s-4a-16",
+      "email": "s-4a-16@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Bernhard",
+      "lastName": "Schwarz",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000269",
+      "username": "s-4a-17",
+      "email": "s-4a-17@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Elena",
+      "lastName": "Stadler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000270",
+      "username": "s-4a-18",
+      "email": "s-4a-18@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Dominik",
+      "lastName": "Berger",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000271",
+      "username": "s-4a-19",
+      "email": "s-4a-19@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Anna",
+      "lastName": "Strasser",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000272",
+      "username": "s-4a-20",
+      "email": "s-4a-20@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Benjamin",
+      "lastName": "Wagner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000273",
+      "username": "s-4a-21",
+      "email": "s-4a-21@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Clara",
+      "lastName": "Wallner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000274",
+      "username": "s-4a-22",
+      "email": "s-4a-22@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "David",
+      "lastName": "Weber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000275",
+      "username": "s-4a-23",
+      "email": "s-4a-23@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Emma",
+      "lastName": "Wolf",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000276",
+      "username": "s-4a-24",
+      "email": "s-4a-24@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Felix",
+      "lastName": "Berger",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000277",
+      "username": "s-4a-25",
+      "email": "s-4a-25@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Greta",
+      "lastName": "Aigner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000278",
+      "username": "s-4a-26",
+      "email": "s-4a-26@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Hannes",
+      "lastName": "Bauer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000279",
+      "username": "s-4a-27",
+      "email": "s-4a-27@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Iris",
+      "lastName": "Fischer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000280",
+      "username": "s-4a-28",
+      "email": "s-4a-28@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Jakob",
+      "lastName": "Eder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000281",
+      "username": "s-4b-01",
+      "email": "s-4b-01@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Katharina",
+      "lastName": "Riedl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000282",
+      "username": "s-4b-02",
+      "email": "s-4b-02@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Lukas",
+      "lastName": "Schwarz",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000283",
+      "username": "s-4b-03",
+      "email": "s-4b-03@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Maria",
+      "lastName": "Stadler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000284",
+      "username": "s-4b-04",
+      "email": "s-4b-04@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Nico",
+      "lastName": "Steiner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000285",
+      "username": "s-4b-05",
+      "email": "s-4b-05@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Olivia",
+      "lastName": "Weber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000286",
+      "username": "s-4b-06",
+      "email": "s-4b-06@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Paul",
+      "lastName": "Wagner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000287",
+      "username": "s-4b-07",
+      "email": "s-4b-07@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Rebecca",
+      "lastName": "Strasser",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000288",
+      "username": "s-4b-08",
+      "email": "s-4b-08@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Richard",
+      "lastName": "Weber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000289",
+      "username": "s-4b-09",
+      "email": "s-4b-09@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Theresa",
+      "lastName": "Wolf",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000290",
+      "username": "s-4b-10",
+      "email": "s-4b-10@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Tobias",
+      "lastName": "Berger",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000291",
+      "username": "s-4b-11",
+      "email": "s-4b-11@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Valentina",
+      "lastName": "Schwarz",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000292",
+      "username": "s-4b-12",
+      "email": "s-4b-12@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Valentin",
+      "lastName": "Bauer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000293",
+      "username": "s-4b-13",
+      "email": "s-4b-13@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Yasmin",
+      "lastName": "Brunner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000294",
+      "username": "s-4b-14",
+      "email": "s-4b-14@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Xaver",
+      "lastName": "Eder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000295",
+      "username": "s-4b-15",
+      "email": "s-4b-15@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Amelie",
+      "lastName": "Fischer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000296",
+      "username": "s-4b-16",
+      "email": "s-4b-16@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Zacharias",
+      "lastName": "Gruber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000297",
+      "username": "s-4b-17",
+      "email": "s-4b-17@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Charlotte",
+      "lastName": "Hofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000298",
+      "username": "s-4b-18",
+      "email": "s-4b-18@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Bernhard",
+      "lastName": "Holzer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000299",
+      "username": "s-4b-19",
+      "email": "s-4b-19@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Elena",
+      "lastName": "Huber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000300",
+      "username": "s-4b-20",
+      "email": "s-4b-20@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Dominik",
+      "lastName": "Köhler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000301",
+      "username": "s-4b-21",
+      "email": "s-4b-21@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Anna",
+      "lastName": "Huber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000302",
+      "username": "s-4b-22",
+      "email": "s-4b-22@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Benjamin",
+      "lastName": "Kogler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000303",
+      "username": "s-4b-23",
+      "email": "s-4b-23@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Clara",
+      "lastName": "Lang",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000304",
+      "username": "s-4b-24",
+      "email": "s-4b-24@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "David",
+      "lastName": "Lechner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000305",
+      "username": "s-4b-25",
+      "email": "s-4b-25@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Emma",
+      "lastName": "Linder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000306",
+      "username": "s-4b-26",
+      "email": "s-4b-26@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Felix",
+      "lastName": "Maier",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000307",
+      "username": "s-4b-27",
+      "email": "s-4b-27@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Greta",
+      "lastName": "Mayer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000308",
+      "username": "s-4b-28",
+      "email": "s-4b-28@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Hannes",
+      "lastName": "Pichler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000309",
+      "username": "s-4c-01",
+      "email": "s-4c-01@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Iris",
+      "lastName": "Fischer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000310",
+      "username": "s-4c-02",
+      "email": "s-4c-02@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Jakob",
+      "lastName": "Gruber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000311",
+      "username": "s-4c-03",
+      "email": "s-4c-03@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Katharina",
+      "lastName": "Hofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000312",
+      "username": "s-4c-04",
+      "email": "s-4c-04@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Lukas",
+      "lastName": "Weber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000313",
+      "username": "s-4c-05",
+      "email": "s-4c-05@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Maria",
+      "lastName": "Huber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000314",
+      "username": "s-4c-06",
+      "email": "s-4c-06@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Nico",
+      "lastName": "Köhler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000315",
+      "username": "s-4c-07",
+      "email": "s-4c-07@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Olivia",
+      "lastName": "Köberl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000316",
+      "username": "s-4c-08",
+      "email": "s-4c-08@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Paul",
+      "lastName": "Kogler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000317",
+      "username": "s-4c-09",
+      "email": "s-4c-09@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Rebecca",
+      "lastName": "Fischer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000318",
+      "username": "s-4c-10",
+      "email": "s-4c-10@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Richard",
+      "lastName": "Lechner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000319",
+      "username": "s-4c-11",
+      "email": "s-4c-11@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Theresa",
+      "lastName": "Linder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000320",
+      "username": "s-4c-12",
+      "email": "s-4c-12@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Tobias",
+      "lastName": "Maier",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000321",
+      "username": "s-4c-13",
+      "email": "s-4c-13@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Valentina",
+      "lastName": "Mayer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000322",
+      "username": "s-4c-14",
+      "email": "s-4c-14@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Valentin",
+      "lastName": "Mayerhofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000323",
+      "username": "s-4c-15",
+      "email": "s-4c-15@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Yasmin",
+      "lastName": "Pichler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000324",
+      "username": "s-4c-16",
+      "email": "s-4c-16@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Xaver",
+      "lastName": "Reiter",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000325",
+      "username": "s-4c-17",
+      "email": "s-4c-17@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Amelie",
+      "lastName": "Lang",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000326",
+      "username": "s-4c-18",
+      "email": "s-4c-18@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Zacharias",
+      "lastName": "Schwarz",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000327",
+      "username": "s-4c-19",
+      "email": "s-4c-19@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Charlotte",
+      "lastName": "Stadler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000328",
+      "username": "s-4c-20",
+      "email": "s-4c-20@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Bernhard",
+      "lastName": "Steiner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000329",
+      "username": "s-4c-21",
+      "email": "s-4c-21@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Elena",
+      "lastName": "Strasser",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000330",
+      "username": "s-4c-22",
+      "email": "s-4c-22@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Dominik",
+      "lastName": "Wagner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000331",
+      "username": "s-4c-23",
+      "email": "s-4c-23@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Anna",
+      "lastName": "Wallner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000332",
+      "username": "s-4c-24",
+      "email": "s-4c-24@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Benjamin",
+      "lastName": "Weber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000333",
+      "username": "s-4c-25",
+      "email": "s-4c-25@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Clara",
+      "lastName": "Stadler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000334",
+      "username": "s-4c-26",
+      "email": "s-4c-26@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "David",
+      "lastName": "Berger",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000335",
+      "username": "s-4c-27",
+      "email": "s-4c-27@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Emma",
+      "lastName": "Aigner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "cccc0000-0000-4000-8000-000000000336",
+      "username": "s-4c-28",
+      "email": "s-4c-28@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Felix",
+      "lastName": "Weber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "schueler"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000001",
+      "username": "e-fam-001-a",
+      "email": "e-fam-001-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Maria",
+      "lastName": "Aigner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000002",
+      "username": "e-fam-001-b",
+      "email": "e-fam-001-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Stefan",
+      "lastName": "Aigner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000003",
+      "username": "e-fam-002-a",
+      "email": "e-fam-002-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Andrea",
+      "lastName": "Bauer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000004",
+      "username": "e-fam-002-b",
+      "email": "e-fam-002-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Thomas",
+      "lastName": "Bauer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000005",
+      "username": "e-fam-003-a",
+      "email": "e-fam-003-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Sabine",
+      "lastName": "Brunner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000006",
+      "username": "e-fam-003-b",
+      "email": "e-fam-003-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Markus",
+      "lastName": "Brunner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000007",
+      "username": "e-fam-004-a",
+      "email": "e-fam-004-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Christina",
+      "lastName": "Eder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000008",
+      "username": "e-fam-004-b",
+      "email": "e-fam-004-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Peter",
+      "lastName": "Eder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000009",
+      "username": "e-fam-005-a",
+      "email": "e-fam-005-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Eva",
+      "lastName": "Gruber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000010",
+      "username": "e-fam-005-b",
+      "email": "e-fam-005-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Manuel",
+      "lastName": "Gruber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000011",
+      "username": "e-fam-006-a",
+      "email": "e-fam-006-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Sophia",
+      "lastName": "Holzer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000012",
+      "username": "e-fam-006-b",
+      "email": "e-fam-006-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "David",
+      "lastName": "Holzer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000013",
+      "username": "e-fam-007-a",
+      "email": "e-fam-007-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Lisa",
+      "lastName": "Huber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000014",
+      "username": "e-fam-007-b",
+      "email": "e-fam-007-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Andreas",
+      "lastName": "Huber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000015",
+      "username": "e-fam-008-a",
+      "email": "e-fam-008-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Katharina",
+      "lastName": "Köhler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000016",
+      "username": "e-fam-008-b",
+      "email": "e-fam-008-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Michael",
+      "lastName": "Köhler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000017",
+      "username": "e-fam-009-a",
+      "email": "e-fam-009-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Sandra",
+      "lastName": "Köberl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000018",
+      "username": "e-fam-009-b",
+      "email": "e-fam-009-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Daniel",
+      "lastName": "Köberl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000019",
+      "username": "e-fam-010-a",
+      "email": "e-fam-010-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Marlene",
+      "lastName": "Kogler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000020",
+      "username": "e-fam-010-b",
+      "email": "e-fam-010-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Tobias",
+      "lastName": "Kogler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000021",
+      "username": "e-fam-011-a",
+      "email": "e-fam-011-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Birgit",
+      "lastName": "Lang",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000022",
+      "username": "e-fam-011-b",
+      "email": "e-fam-011-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Christoph",
+      "lastName": "Lang",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000023",
+      "username": "e-fam-012-a",
+      "email": "e-fam-012-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Tanja",
+      "lastName": "Lechner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000024",
+      "username": "e-fam-012-b",
+      "email": "e-fam-012-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Felix",
+      "lastName": "Lechner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000025",
+      "username": "e-fam-013-a",
+      "email": "e-fam-013-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Hannah",
+      "lastName": "Maier",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000026",
+      "username": "e-fam-013-b",
+      "email": "e-fam-013-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Roland",
+      "lastName": "Maier",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000027",
+      "username": "e-fam-014-a",
+      "email": "e-fam-014-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Verena",
+      "lastName": "Mayer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000028",
+      "username": "e-fam-014-b",
+      "email": "e-fam-014-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Alexander",
+      "lastName": "Mayer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000029",
+      "username": "e-fam-015-a",
+      "email": "e-fam-015-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Beatrix",
+      "lastName": "Mayerhofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000030",
+      "username": "e-fam-015-b",
+      "email": "e-fam-015-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Karl-Heinz",
+      "lastName": "Mayerhofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000031",
+      "username": "e-fam-016-a",
+      "email": "e-fam-016-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Julia",
+      "lastName": "Pichler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000032",
+      "username": "e-fam-016-b",
+      "email": "e-fam-016-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Lukas",
+      "lastName": "Pichler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000033",
+      "username": "e-fam-017-a",
+      "email": "e-fam-017-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Elena",
+      "lastName": "Reiter",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000034",
+      "username": "e-fam-017-b",
+      "email": "e-fam-017-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Bernhard",
+      "lastName": "Reiter",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000035",
+      "username": "e-fam-018-a",
+      "email": "e-fam-018-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Greta",
+      "lastName": "Riedl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000036",
+      "username": "e-fam-018-b",
+      "email": "e-fam-018-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Wolfgang",
+      "lastName": "Riedl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000037",
+      "username": "e-fam-019-a",
+      "email": "e-fam-019-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Iris",
+      "lastName": "Stadler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000038",
+      "username": "e-fam-019-b",
+      "email": "e-fam-019-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Konstantin",
+      "lastName": "Stadler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000039",
+      "username": "e-fam-020-a",
+      "email": "e-fam-020-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Johanna",
+      "lastName": "Steiner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000040",
+      "username": "e-fam-020-b",
+      "email": "e-fam-020-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Jakob",
+      "lastName": "Steiner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000041",
+      "username": "e-fam-021-a",
+      "email": "e-fam-021-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Maria",
+      "lastName": "Strasser",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000042",
+      "username": "e-fam-021-b",
+      "email": "e-fam-021-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Stefan",
+      "lastName": "Strasser",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000043",
+      "username": "e-fam-022-a",
+      "email": "e-fam-022-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Andrea",
+      "lastName": "Wagner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000044",
+      "username": "e-fam-022-b",
+      "email": "e-fam-022-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Thomas",
+      "lastName": "Wagner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000045",
+      "username": "e-fam-023-a",
+      "email": "e-fam-023-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Sabine",
+      "lastName": "Wallner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000046",
+      "username": "e-fam-023-b",
+      "email": "e-fam-023-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Markus",
+      "lastName": "Wallner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000047",
+      "username": "e-fam-024-a",
+      "email": "e-fam-024-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Christina",
+      "lastName": "Linder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000048",
+      "username": "e-fam-024-b",
+      "email": "e-fam-024-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Peter",
+      "lastName": "Linder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000049",
+      "username": "e-fam-025-a",
+      "email": "e-fam-025-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Eva",
+      "lastName": "Maier",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000050",
+      "username": "e-fam-025-b",
+      "email": "e-fam-025-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Manuel",
+      "lastName": "Maier",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000051",
+      "username": "e-fam-026-a",
+      "email": "e-fam-026-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Sophia",
+      "lastName": "Mayer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000052",
+      "username": "e-fam-026-b",
+      "email": "e-fam-026-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "David",
+      "lastName": "Mayer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000053",
+      "username": "e-fam-027-a",
+      "email": "e-fam-027-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Lisa",
+      "lastName": "Pichler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000054",
+      "username": "e-fam-027-b",
+      "email": "e-fam-027-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Andreas",
+      "lastName": "Pichler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000055",
+      "username": "e-fam-028-a",
+      "email": "e-fam-028-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Katharina",
+      "lastName": "Reiter",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000056",
+      "username": "e-fam-028-b",
+      "email": "e-fam-028-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Michael",
+      "lastName": "Reiter",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000057",
+      "username": "e-fam-029-a",
+      "email": "e-fam-029-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Sandra",
+      "lastName": "Riedl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000058",
+      "username": "e-fam-029-b",
+      "email": "e-fam-029-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Daniel",
+      "lastName": "Riedl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000059",
+      "username": "e-fam-030-a",
+      "email": "e-fam-030-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Marlene",
+      "lastName": "Schwarz",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000060",
+      "username": "e-fam-030-b",
+      "email": "e-fam-030-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Tobias",
+      "lastName": "Schwarz",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000061",
+      "username": "e-fam-031-a",
+      "email": "e-fam-031-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Birgit",
+      "lastName": "Stadler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000062",
+      "username": "e-fam-031-b",
+      "email": "e-fam-031-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Christoph",
+      "lastName": "Stadler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000063",
+      "username": "e-fam-032-a",
+      "email": "e-fam-032-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Tanja",
+      "lastName": "Steiner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000064",
+      "username": "e-fam-032-b",
+      "email": "e-fam-032-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Felix",
+      "lastName": "Steiner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000065",
+      "username": "e-fam-033-a",
+      "email": "e-fam-033-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Hannah",
+      "lastName": "Strasser",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000066",
+      "username": "e-fam-033-b",
+      "email": "e-fam-033-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Roland",
+      "lastName": "Strasser",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000067",
+      "username": "e-fam-034-a",
+      "email": "e-fam-034-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Verena",
+      "lastName": "Wallner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000068",
+      "username": "e-fam-034-b",
+      "email": "e-fam-034-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Alexander",
+      "lastName": "Wallner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000069",
+      "username": "e-fam-035-a",
+      "email": "e-fam-035-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Beatrix",
+      "lastName": "Weber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000070",
+      "username": "e-fam-035-b",
+      "email": "e-fam-035-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Karl-Heinz",
+      "lastName": "Weber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000071",
+      "username": "e-fam-036-a",
+      "email": "e-fam-036-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Julia",
+      "lastName": "Wolf",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000072",
+      "username": "e-fam-036-b",
+      "email": "e-fam-036-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Lukas",
+      "lastName": "Wolf",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000073",
+      "username": "e-fam-037-a",
+      "email": "e-fam-037-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Elena",
+      "lastName": "Berger",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000074",
+      "username": "e-fam-037-b",
+      "email": "e-fam-037-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Bernhard",
+      "lastName": "Berger",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000075",
+      "username": "e-fam-038-a",
+      "email": "e-fam-038-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Greta",
+      "lastName": "Aigner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000076",
+      "username": "e-fam-038-b",
+      "email": "e-fam-038-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Wolfgang",
+      "lastName": "Aigner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000077",
+      "username": "e-fam-039-a",
+      "email": "e-fam-039-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Iris",
+      "lastName": "Bauer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000078",
+      "username": "e-fam-039-b",
+      "email": "e-fam-039-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Konstantin",
+      "lastName": "Bauer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000079",
+      "username": "e-fam-040-a",
+      "email": "e-fam-040-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Johanna",
+      "lastName": "Eder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000080",
+      "username": "e-fam-040-b",
+      "email": "e-fam-040-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Jakob",
+      "lastName": "Eder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000081",
+      "username": "e-fam-041-a",
+      "email": "e-fam-041-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Maria",
+      "lastName": "Fischer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000082",
+      "username": "e-fam-041-b",
+      "email": "e-fam-041-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Stefan",
+      "lastName": "Fischer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000083",
+      "username": "e-fam-042-a",
+      "email": "e-fam-042-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Andrea",
+      "lastName": "Gruber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000084",
+      "username": "e-fam-042-b",
+      "email": "e-fam-042-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Thomas",
+      "lastName": "Gruber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000085",
+      "username": "e-fam-043-a",
+      "email": "e-fam-043-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Sabine",
+      "lastName": "Hofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000086",
+      "username": "e-fam-043-b",
+      "email": "e-fam-043-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Markus",
+      "lastName": "Hofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000087",
+      "username": "e-fam-044-a",
+      "email": "e-fam-044-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Christina",
+      "lastName": "Holzer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000088",
+      "username": "e-fam-044-b",
+      "email": "e-fam-044-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Peter",
+      "lastName": "Holzer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000089",
+      "username": "e-fam-045-a",
+      "email": "e-fam-045-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Eva",
+      "lastName": "Huber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000090",
+      "username": "e-fam-045-b",
+      "email": "e-fam-045-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Manuel",
+      "lastName": "Huber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000091",
+      "username": "e-fam-046-a",
+      "email": "e-fam-046-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Sophia",
+      "lastName": "Köhler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000092",
+      "username": "e-fam-046-b",
+      "email": "e-fam-046-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "David",
+      "lastName": "Köhler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000093",
+      "username": "e-fam-047-a",
+      "email": "e-fam-047-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Lisa",
+      "lastName": "Kogler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000094",
+      "username": "e-fam-047-b",
+      "email": "e-fam-047-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Andreas",
+      "lastName": "Kogler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000095",
+      "username": "e-fam-048-a",
+      "email": "e-fam-048-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Katharina",
+      "lastName": "Wolf",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000096",
+      "username": "e-fam-048-b",
+      "email": "e-fam-048-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Michael",
+      "lastName": "Wolf",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000097",
+      "username": "e-fam-049-a",
+      "email": "e-fam-049-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Sandra",
+      "lastName": "Berger",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000098",
+      "username": "e-fam-049-b",
+      "email": "e-fam-049-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Daniel",
+      "lastName": "Berger",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000099",
+      "username": "e-fam-050-a",
+      "email": "e-fam-050-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Marlene",
+      "lastName": "Bauer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000100",
+      "username": "e-fam-050-b",
+      "email": "e-fam-050-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Tobias",
+      "lastName": "Bauer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000101",
+      "username": "e-fam-051-a",
+      "email": "e-fam-051-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Birgit",
+      "lastName": "Brunner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000102",
+      "username": "e-fam-051-b",
+      "email": "e-fam-051-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Christoph",
+      "lastName": "Brunner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000103",
+      "username": "e-fam-052-a",
+      "email": "e-fam-052-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Tanja",
+      "lastName": "Eder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000104",
+      "username": "e-fam-052-b",
+      "email": "e-fam-052-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Felix",
+      "lastName": "Eder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000105",
+      "username": "e-fam-053-a",
+      "email": "e-fam-053-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Hannah",
+      "lastName": "Fischer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000106",
+      "username": "e-fam-053-b",
+      "email": "e-fam-053-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Roland",
+      "lastName": "Fischer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000107",
+      "username": "e-fam-054-a",
+      "email": "e-fam-054-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Verena",
+      "lastName": "Gruber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000108",
+      "username": "e-fam-054-b",
+      "email": "e-fam-054-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Alexander",
+      "lastName": "Gruber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000109",
+      "username": "e-fam-055-a",
+      "email": "e-fam-055-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Beatrix",
+      "lastName": "Hofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000110",
+      "username": "e-fam-055-b",
+      "email": "e-fam-055-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Karl-Heinz",
+      "lastName": "Hofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000111",
+      "username": "e-fam-056-a",
+      "email": "e-fam-056-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Julia",
+      "lastName": "Holzer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000112",
+      "username": "e-fam-056-b",
+      "email": "e-fam-056-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Lukas",
+      "lastName": "Holzer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000113",
+      "username": "e-fam-057-a",
+      "email": "e-fam-057-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Elena",
+      "lastName": "Köhler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000114",
+      "username": "e-fam-057-b",
+      "email": "e-fam-057-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Bernhard",
+      "lastName": "Köhler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000115",
+      "username": "e-fam-058-a",
+      "email": "e-fam-058-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Greta",
+      "lastName": "Köberl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000116",
+      "username": "e-fam-058-b",
+      "email": "e-fam-058-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Wolfgang",
+      "lastName": "Köberl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000117",
+      "username": "e-fam-059-a",
+      "email": "e-fam-059-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Iris",
+      "lastName": "Kogler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000118",
+      "username": "e-fam-059-b",
+      "email": "e-fam-059-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Konstantin",
+      "lastName": "Kogler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000119",
+      "username": "e-fam-060-a",
+      "email": "e-fam-060-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Johanna",
+      "lastName": "Lang",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000120",
+      "username": "e-fam-060-b",
+      "email": "e-fam-060-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Jakob",
+      "lastName": "Lang",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000121",
+      "username": "e-fam-061-a",
+      "email": "e-fam-061-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Maria",
+      "lastName": "Lechner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000122",
+      "username": "e-fam-061-b",
+      "email": "e-fam-061-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Stefan",
+      "lastName": "Lechner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000123",
+      "username": "e-fam-062-a",
+      "email": "e-fam-062-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Andrea",
+      "lastName": "Linder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000124",
+      "username": "e-fam-062-b",
+      "email": "e-fam-062-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Thomas",
+      "lastName": "Linder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000125",
+      "username": "e-fam-063-a",
+      "email": "e-fam-063-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Sabine",
+      "lastName": "Mayer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000126",
+      "username": "e-fam-063-b",
+      "email": "e-fam-063-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Markus",
+      "lastName": "Mayer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000127",
+      "username": "e-fam-064-a",
+      "email": "e-fam-064-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Christina",
+      "lastName": "Mayerhofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000128",
+      "username": "e-fam-064-b",
+      "email": "e-fam-064-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Peter",
+      "lastName": "Mayerhofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000129",
+      "username": "e-fam-065-a",
+      "email": "e-fam-065-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Eva",
+      "lastName": "Pichler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000130",
+      "username": "e-fam-065-b",
+      "email": "e-fam-065-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Manuel",
+      "lastName": "Pichler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000131",
+      "username": "e-fam-066-a",
+      "email": "e-fam-066-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Sophia",
+      "lastName": "Reiter",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000132",
+      "username": "e-fam-066-b",
+      "email": "e-fam-066-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "David",
+      "lastName": "Reiter",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000133",
+      "username": "e-fam-067-a",
+      "email": "e-fam-067-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Lisa",
+      "lastName": "Riedl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000134",
+      "username": "e-fam-067-b",
+      "email": "e-fam-067-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Andreas",
+      "lastName": "Riedl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000135",
+      "username": "e-fam-068-a",
+      "email": "e-fam-068-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Katharina",
+      "lastName": "Schwarz",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000136",
+      "username": "e-fam-068-b",
+      "email": "e-fam-068-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Michael",
+      "lastName": "Schwarz",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000137",
+      "username": "e-fam-069-a",
+      "email": "e-fam-069-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Sandra",
+      "lastName": "Stadler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000138",
+      "username": "e-fam-069-b",
+      "email": "e-fam-069-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Daniel",
+      "lastName": "Stadler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000139",
+      "username": "e-fam-070-a",
+      "email": "e-fam-070-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Marlene",
+      "lastName": "Strasser",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000140",
+      "username": "e-fam-070-b",
+      "email": "e-fam-070-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Tobias",
+      "lastName": "Strasser",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000141",
+      "username": "e-fam-071-a",
+      "email": "e-fam-071-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Birgit",
+      "lastName": "Wagner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000142",
+      "username": "e-fam-071-b",
+      "email": "e-fam-071-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Christoph",
+      "lastName": "Wagner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000143",
+      "username": "e-fam-072-a",
+      "email": "e-fam-072-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Tanja",
+      "lastName": "Lechner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000144",
+      "username": "e-fam-072-b",
+      "email": "e-fam-072-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Felix",
+      "lastName": "Lechner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000145",
+      "username": "e-fam-073-a",
+      "email": "e-fam-073-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Hannah",
+      "lastName": "Linder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000146",
+      "username": "e-fam-073-b",
+      "email": "e-fam-073-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Roland",
+      "lastName": "Linder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000147",
+      "username": "e-fam-074-a",
+      "email": "e-fam-074-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Verena",
+      "lastName": "Maier",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000148",
+      "username": "e-fam-074-b",
+      "email": "e-fam-074-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Alexander",
+      "lastName": "Maier",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000149",
+      "username": "e-fam-075-a",
+      "email": "e-fam-075-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Beatrix",
+      "lastName": "Mayer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000150",
+      "username": "e-fam-075-b",
+      "email": "e-fam-075-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Karl-Heinz",
+      "lastName": "Mayer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000151",
+      "username": "e-fam-076-a",
+      "email": "e-fam-076-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Julia",
+      "lastName": "Mayerhofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000152",
+      "username": "e-fam-076-b",
+      "email": "e-fam-076-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Lukas",
+      "lastName": "Mayerhofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000153",
+      "username": "e-fam-077-a",
+      "email": "e-fam-077-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Elena",
+      "lastName": "Pichler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000154",
+      "username": "e-fam-077-b",
+      "email": "e-fam-077-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Bernhard",
+      "lastName": "Pichler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000155",
+      "username": "e-fam-078-a",
+      "email": "e-fam-078-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Greta",
+      "lastName": "Riedl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000156",
+      "username": "e-fam-078-b",
+      "email": "e-fam-078-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Wolfgang",
+      "lastName": "Riedl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000157",
+      "username": "e-fam-079-a",
+      "email": "e-fam-079-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Iris",
+      "lastName": "Schwarz",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000158",
+      "username": "e-fam-079-b",
+      "email": "e-fam-079-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Konstantin",
+      "lastName": "Schwarz",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000159",
+      "username": "e-fam-080-a",
+      "email": "e-fam-080-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Johanna",
+      "lastName": "Steiner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000160",
+      "username": "e-fam-080-b",
+      "email": "e-fam-080-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Jakob",
+      "lastName": "Steiner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000161",
+      "username": "e-fam-081-a",
+      "email": "e-fam-081-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Maria",
+      "lastName": "Strasser",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000162",
+      "username": "e-fam-081-b",
+      "email": "e-fam-081-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Stefan",
+      "lastName": "Strasser",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000163",
+      "username": "e-fam-082-a",
+      "email": "e-fam-082-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Andrea",
+      "lastName": "Wagner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000164",
+      "username": "e-fam-082-b",
+      "email": "e-fam-082-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Thomas",
+      "lastName": "Wagner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000165",
+      "username": "e-fam-083-a",
+      "email": "e-fam-083-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Sabine",
+      "lastName": "Wallner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000166",
+      "username": "e-fam-083-b",
+      "email": "e-fam-083-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Markus",
+      "lastName": "Wallner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000167",
+      "username": "e-fam-084-a",
+      "email": "e-fam-084-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Christina",
+      "lastName": "Wolf",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000168",
+      "username": "e-fam-084-b",
+      "email": "e-fam-084-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Peter",
+      "lastName": "Wolf",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000169",
+      "username": "e-fam-085-a",
+      "email": "e-fam-085-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Eva",
+      "lastName": "Berger",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000170",
+      "username": "e-fam-085-b",
+      "email": "e-fam-085-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Manuel",
+      "lastName": "Berger",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000171",
+      "username": "e-fam-086-a",
+      "email": "e-fam-086-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Sophia",
+      "lastName": "Aigner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000172",
+      "username": "e-fam-086-b",
+      "email": "e-fam-086-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "David",
+      "lastName": "Aigner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000173",
+      "username": "e-fam-087-a",
+      "email": "e-fam-087-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Lisa",
+      "lastName": "Bauer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000174",
+      "username": "e-fam-087-b",
+      "email": "e-fam-087-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Andreas",
+      "lastName": "Bauer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000175",
+      "username": "e-fam-088-a",
+      "email": "e-fam-088-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Katharina",
+      "lastName": "Brunner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000176",
+      "username": "e-fam-088-b",
+      "email": "e-fam-088-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Michael",
+      "lastName": "Brunner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000177",
+      "username": "e-fam-089-a",
+      "email": "e-fam-089-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Sandra",
+      "lastName": "Fischer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000178",
+      "username": "e-fam-089-b",
+      "email": "e-fam-089-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Daniel",
+      "lastName": "Fischer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000179",
+      "username": "e-fam-090-a",
+      "email": "e-fam-090-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Marlene",
+      "lastName": "Gruber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000180",
+      "username": "e-fam-090-b",
+      "email": "e-fam-090-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Tobias",
+      "lastName": "Gruber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000181",
+      "username": "e-fam-091-a",
+      "email": "e-fam-091-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Birgit",
+      "lastName": "Hofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000182",
+      "username": "e-fam-091-b",
+      "email": "e-fam-091-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Christoph",
+      "lastName": "Hofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000183",
+      "username": "e-fam-092-a",
+      "email": "e-fam-092-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Tanja",
+      "lastName": "Holzer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000184",
+      "username": "e-fam-092-b",
+      "email": "e-fam-092-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Felix",
+      "lastName": "Holzer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000185",
+      "username": "e-fam-093-a",
+      "email": "e-fam-093-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Hannah",
+      "lastName": "Huber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000186",
+      "username": "e-fam-093-b",
+      "email": "e-fam-093-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Roland",
+      "lastName": "Huber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000187",
+      "username": "e-fam-094-a",
+      "email": "e-fam-094-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Verena",
+      "lastName": "Köhler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000188",
+      "username": "e-fam-094-b",
+      "email": "e-fam-094-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Alexander",
+      "lastName": "Köhler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000189",
+      "username": "e-fam-095-a",
+      "email": "e-fam-095-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Beatrix",
+      "lastName": "Wallner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000190",
+      "username": "e-fam-095-b",
+      "email": "e-fam-095-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Karl-Heinz",
+      "lastName": "Wallner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000191",
+      "username": "e-fam-096-a",
+      "email": "e-fam-096-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Julia",
+      "lastName": "Wolf",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000192",
+      "username": "e-fam-096-b",
+      "email": "e-fam-096-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Lukas",
+      "lastName": "Wolf",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000193",
+      "username": "e-fam-097-a",
+      "email": "e-fam-097-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Elena",
+      "lastName": "Berger",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000194",
+      "username": "e-fam-097-b",
+      "email": "e-fam-097-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Bernhard",
+      "lastName": "Berger",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000195",
+      "username": "e-fam-098-a",
+      "email": "e-fam-098-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Greta",
+      "lastName": "Aigner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000196",
+      "username": "e-fam-098-b",
+      "email": "e-fam-098-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Wolfgang",
+      "lastName": "Aigner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000197",
+      "username": "e-fam-099-a",
+      "email": "e-fam-099-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Iris",
+      "lastName": "Bauer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000198",
+      "username": "e-fam-099-b",
+      "email": "e-fam-099-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Konstantin",
+      "lastName": "Bauer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000199",
+      "username": "e-fam-100-a",
+      "email": "e-fam-100-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Johanna",
+      "lastName": "Brunner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000200",
+      "username": "e-fam-100-b",
+      "email": "e-fam-100-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Jakob",
+      "lastName": "Brunner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000201",
+      "username": "e-fam-101-a",
+      "email": "e-fam-101-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Maria",
+      "lastName": "Eder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000202",
+      "username": "e-fam-101-b",
+      "email": "e-fam-101-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Stefan",
+      "lastName": "Eder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000203",
+      "username": "e-fam-102-a",
+      "email": "e-fam-102-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Andrea",
+      "lastName": "Gruber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000204",
+      "username": "e-fam-102-b",
+      "email": "e-fam-102-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Thomas",
+      "lastName": "Gruber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000205",
+      "username": "e-fam-103-a",
+      "email": "e-fam-103-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Sabine",
+      "lastName": "Hofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000206",
+      "username": "e-fam-103-b",
+      "email": "e-fam-103-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Markus",
+      "lastName": "Hofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000207",
+      "username": "e-fam-104-a",
+      "email": "e-fam-104-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Christina",
+      "lastName": "Holzer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000208",
+      "username": "e-fam-104-b",
+      "email": "e-fam-104-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Peter",
+      "lastName": "Holzer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000209",
+      "username": "e-fam-105-a",
+      "email": "e-fam-105-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Eva",
+      "lastName": "Köhler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000210",
+      "username": "e-fam-105-b",
+      "email": "e-fam-105-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Manuel",
+      "lastName": "Köhler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000211",
+      "username": "e-fam-106-a",
+      "email": "e-fam-106-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Sophia",
+      "lastName": "Köberl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000212",
+      "username": "e-fam-106-b",
+      "email": "e-fam-106-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "David",
+      "lastName": "Köberl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000213",
+      "username": "e-fam-107-a",
+      "email": "e-fam-107-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Lisa",
+      "lastName": "Kogler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000214",
+      "username": "e-fam-107-b",
+      "email": "e-fam-107-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Andreas",
+      "lastName": "Kogler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000215",
+      "username": "e-fam-108-a",
+      "email": "e-fam-108-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Katharina",
+      "lastName": "Lang",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000216",
+      "username": "e-fam-108-b",
+      "email": "e-fam-108-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Michael",
+      "lastName": "Lang",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000217",
+      "username": "e-fam-109-a",
+      "email": "e-fam-109-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Sandra",
+      "lastName": "Lechner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000218",
+      "username": "e-fam-109-b",
+      "email": "e-fam-109-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Daniel",
+      "lastName": "Lechner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000219",
+      "username": "e-fam-110-a",
+      "email": "e-fam-110-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Marlene",
+      "lastName": "Linder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000220",
+      "username": "e-fam-110-b",
+      "email": "e-fam-110-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Tobias",
+      "lastName": "Linder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000221",
+      "username": "e-fam-111-a",
+      "email": "e-fam-111-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Birgit",
+      "lastName": "Maier",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000222",
+      "username": "e-fam-111-b",
+      "email": "e-fam-111-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Christoph",
+      "lastName": "Maier",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000223",
+      "username": "e-fam-112-a",
+      "email": "e-fam-112-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Tanja",
+      "lastName": "Mayer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000224",
+      "username": "e-fam-112-b",
+      "email": "e-fam-112-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Felix",
+      "lastName": "Mayer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000225",
+      "username": "e-fam-113-a",
+      "email": "e-fam-113-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Hannah",
+      "lastName": "Mayerhofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000226",
+      "username": "e-fam-113-b",
+      "email": "e-fam-113-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Roland",
+      "lastName": "Mayerhofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000227",
+      "username": "e-fam-114-a",
+      "email": "e-fam-114-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Verena",
+      "lastName": "Pichler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000228",
+      "username": "e-fam-114-b",
+      "email": "e-fam-114-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Alexander",
+      "lastName": "Pichler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000229",
+      "username": "e-fam-115-a",
+      "email": "e-fam-115-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Beatrix",
+      "lastName": "Reiter",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000230",
+      "username": "e-fam-115-b",
+      "email": "e-fam-115-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Karl-Heinz",
+      "lastName": "Reiter",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000231",
+      "username": "e-fam-116-a",
+      "email": "e-fam-116-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Julia",
+      "lastName": "Schwarz",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000232",
+      "username": "e-fam-116-b",
+      "email": "e-fam-116-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Lukas",
+      "lastName": "Schwarz",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000233",
+      "username": "e-fam-117-a",
+      "email": "e-fam-117-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Elena",
+      "lastName": "Stadler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000234",
+      "username": "e-fam-117-b",
+      "email": "e-fam-117-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Bernhard",
+      "lastName": "Stadler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000235",
+      "username": "e-fam-118-a",
+      "email": "e-fam-118-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Greta",
+      "lastName": "Steiner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000236",
+      "username": "e-fam-118-b",
+      "email": "e-fam-118-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Wolfgang",
+      "lastName": "Steiner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000237",
+      "username": "e-fam-119-a",
+      "email": "e-fam-119-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Iris",
+      "lastName": "Köberl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000238",
+      "username": "e-fam-119-b",
+      "email": "e-fam-119-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Konstantin",
+      "lastName": "Köberl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000239",
+      "username": "e-fam-120-a",
+      "email": "e-fam-120-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Johanna",
+      "lastName": "Kogler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000240",
+      "username": "e-fam-120-b",
+      "email": "e-fam-120-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Jakob",
+      "lastName": "Kogler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000241",
+      "username": "e-fam-121-a",
+      "email": "e-fam-121-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Maria",
+      "lastName": "Lechner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000242",
+      "username": "e-fam-121-b",
+      "email": "e-fam-121-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Stefan",
+      "lastName": "Lechner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000243",
+      "username": "e-fam-122-a",
+      "email": "e-fam-122-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Andrea",
+      "lastName": "Linder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000244",
+      "username": "e-fam-122-b",
+      "email": "e-fam-122-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Thomas",
+      "lastName": "Linder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000245",
+      "username": "e-fam-123-a",
+      "email": "e-fam-123-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Sabine",
+      "lastName": "Maier",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000246",
+      "username": "e-fam-123-b",
+      "email": "e-fam-123-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Markus",
+      "lastName": "Maier",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000247",
+      "username": "e-fam-124-a",
+      "email": "e-fam-124-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Christina",
+      "lastName": "Mayer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000248",
+      "username": "e-fam-124-b",
+      "email": "e-fam-124-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Peter",
+      "lastName": "Mayer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000249",
+      "username": "e-fam-125-a",
+      "email": "e-fam-125-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Eva",
+      "lastName": "Mayerhofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000250",
+      "username": "e-fam-125-b",
+      "email": "e-fam-125-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Manuel",
+      "lastName": "Mayerhofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000251",
+      "username": "e-fam-126-a",
+      "email": "e-fam-126-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Sophia",
+      "lastName": "Pichler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000252",
+      "username": "e-fam-126-b",
+      "email": "e-fam-126-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "David",
+      "lastName": "Pichler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000253",
+      "username": "e-fam-127-a",
+      "email": "e-fam-127-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Lisa",
+      "lastName": "Reiter",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000254",
+      "username": "e-fam-127-b",
+      "email": "e-fam-127-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Andreas",
+      "lastName": "Reiter",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000255",
+      "username": "e-fam-128-a",
+      "email": "e-fam-128-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Katharina",
+      "lastName": "Riedl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000256",
+      "username": "e-fam-128-b",
+      "email": "e-fam-128-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Michael",
+      "lastName": "Riedl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000257",
+      "username": "e-fam-129-a",
+      "email": "e-fam-129-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Sandra",
+      "lastName": "Schwarz",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000258",
+      "username": "e-fam-129-b",
+      "email": "e-fam-129-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Daniel",
+      "lastName": "Schwarz",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000259",
+      "username": "e-fam-130-a",
+      "email": "e-fam-130-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Marlene",
+      "lastName": "Steiner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000260",
+      "username": "e-fam-130-b",
+      "email": "e-fam-130-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Tobias",
+      "lastName": "Steiner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000261",
+      "username": "e-fam-131-a",
+      "email": "e-fam-131-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Birgit",
+      "lastName": "Strasser",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000262",
+      "username": "e-fam-131-b",
+      "email": "e-fam-131-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Christoph",
+      "lastName": "Strasser",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000263",
+      "username": "e-fam-132-a",
+      "email": "e-fam-132-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Tanja",
+      "lastName": "Wagner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000264",
+      "username": "e-fam-132-b",
+      "email": "e-fam-132-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Felix",
+      "lastName": "Wagner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000265",
+      "username": "e-fam-133-a",
+      "email": "e-fam-133-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Hannah",
+      "lastName": "Wallner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000266",
+      "username": "e-fam-133-b",
+      "email": "e-fam-133-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Roland",
+      "lastName": "Wallner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000267",
+      "username": "e-fam-134-a",
+      "email": "e-fam-134-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Verena",
+      "lastName": "Weber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000268",
+      "username": "e-fam-134-b",
+      "email": "e-fam-134-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Alexander",
+      "lastName": "Weber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000269",
+      "username": "e-fam-135-a",
+      "email": "e-fam-135-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Beatrix",
+      "lastName": "Aigner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000270",
+      "username": "e-fam-135-b",
+      "email": "e-fam-135-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Karl-Heinz",
+      "lastName": "Aigner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000271",
+      "username": "e-fam-136-a",
+      "email": "e-fam-136-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Julia",
+      "lastName": "Bauer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000272",
+      "username": "e-fam-136-b",
+      "email": "e-fam-136-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Lukas",
+      "lastName": "Bauer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000273",
+      "username": "e-fam-137-a",
+      "email": "e-fam-137-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Elena",
+      "lastName": "Brunner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000274",
+      "username": "e-fam-137-b",
+      "email": "e-fam-137-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Bernhard",
+      "lastName": "Brunner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000275",
+      "username": "e-fam-138-a",
+      "email": "e-fam-138-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Greta",
+      "lastName": "Eder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000276",
+      "username": "e-fam-138-b",
+      "email": "e-fam-138-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Wolfgang",
+      "lastName": "Eder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000277",
+      "username": "e-fam-139-a",
+      "email": "e-fam-139-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Iris",
+      "lastName": "Fischer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000278",
+      "username": "e-fam-139-b",
+      "email": "e-fam-139-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Konstantin",
+      "lastName": "Fischer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000279",
+      "username": "e-fam-140-a",
+      "email": "e-fam-140-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Johanna",
+      "lastName": "Gruber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000280",
+      "username": "e-fam-140-b",
+      "email": "e-fam-140-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Jakob",
+      "lastName": "Gruber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000281",
+      "username": "e-fam-141-a",
+      "email": "e-fam-141-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Maria",
+      "lastName": "Hofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000282",
+      "username": "e-fam-141-b",
+      "email": "e-fam-141-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Stefan",
+      "lastName": "Hofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000283",
+      "username": "e-fam-142-a",
+      "email": "e-fam-142-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Andrea",
+      "lastName": "Holzer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000284",
+      "username": "e-fam-142-b",
+      "email": "e-fam-142-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Thomas",
+      "lastName": "Holzer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000285",
+      "username": "e-fam-143-a",
+      "email": "e-fam-143-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Sabine",
+      "lastName": "Wagner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000286",
+      "username": "e-fam-143-b",
+      "email": "e-fam-143-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Markus",
+      "lastName": "Wagner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000287",
+      "username": "e-fam-144-a",
+      "email": "e-fam-144-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Christina",
+      "lastName": "Wallner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000288",
+      "username": "e-fam-144-b",
+      "email": "e-fam-144-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Peter",
+      "lastName": "Wallner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000289",
+      "username": "e-fam-145-a",
+      "email": "e-fam-145-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Eva",
+      "lastName": "Weber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000290",
+      "username": "e-fam-145-b",
+      "email": "e-fam-145-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Manuel",
+      "lastName": "Weber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000291",
+      "username": "e-fam-146-a",
+      "email": "e-fam-146-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Sophia",
+      "lastName": "Wolf",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000292",
+      "username": "e-fam-146-b",
+      "email": "e-fam-146-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "David",
+      "lastName": "Wolf",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000293",
+      "username": "e-fam-147-a",
+      "email": "e-fam-147-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Lisa",
+      "lastName": "Berger",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000294",
+      "username": "e-fam-147-b",
+      "email": "e-fam-147-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Andreas",
+      "lastName": "Berger",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000295",
+      "username": "e-fam-148-a",
+      "email": "e-fam-148-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Katharina",
+      "lastName": "Aigner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000296",
+      "username": "e-fam-148-b",
+      "email": "e-fam-148-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Michael",
+      "lastName": "Aigner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000297",
+      "username": "e-fam-149-a",
+      "email": "e-fam-149-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Sandra",
+      "lastName": "Brunner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000298",
+      "username": "e-fam-149-b",
+      "email": "e-fam-149-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Daniel",
+      "lastName": "Brunner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000299",
+      "username": "e-fam-150-a",
+      "email": "e-fam-150-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Marlene",
+      "lastName": "Eder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000300",
+      "username": "e-fam-150-b",
+      "email": "e-fam-150-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Tobias",
+      "lastName": "Eder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000301",
+      "username": "e-fam-151-a",
+      "email": "e-fam-151-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Birgit",
+      "lastName": "Fischer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000302",
+      "username": "e-fam-151-b",
+      "email": "e-fam-151-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Christoph",
+      "lastName": "Fischer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000303",
+      "username": "e-fam-152-a",
+      "email": "e-fam-152-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Tanja",
+      "lastName": "Gruber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000304",
+      "username": "e-fam-152-b",
+      "email": "e-fam-152-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Felix",
+      "lastName": "Gruber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000305",
+      "username": "e-fam-153-a",
+      "email": "e-fam-153-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Hannah",
+      "lastName": "Hofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000306",
+      "username": "e-fam-153-b",
+      "email": "e-fam-153-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Roland",
+      "lastName": "Hofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000307",
+      "username": "e-fam-154-a",
+      "email": "e-fam-154-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Verena",
+      "lastName": "Holzer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000308",
+      "username": "e-fam-154-b",
+      "email": "e-fam-154-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Alexander",
+      "lastName": "Holzer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000309",
+      "username": "e-fam-155-a",
+      "email": "e-fam-155-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Beatrix",
+      "lastName": "Huber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000310",
+      "username": "e-fam-155-b",
+      "email": "e-fam-155-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Karl-Heinz",
+      "lastName": "Huber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000311",
+      "username": "e-fam-156-a",
+      "email": "e-fam-156-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Julia",
+      "lastName": "Köhler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000312",
+      "username": "e-fam-156-b",
+      "email": "e-fam-156-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Lukas",
+      "lastName": "Köhler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000313",
+      "username": "e-fam-157-a",
+      "email": "e-fam-157-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Elena",
+      "lastName": "Köberl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000314",
+      "username": "e-fam-157-b",
+      "email": "e-fam-157-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Bernhard",
+      "lastName": "Köberl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000315",
+      "username": "e-fam-158-a",
+      "email": "e-fam-158-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Greta",
+      "lastName": "Kogler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000316",
+      "username": "e-fam-158-b",
+      "email": "e-fam-158-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Wolfgang",
+      "lastName": "Kogler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000317",
+      "username": "e-fam-159-a",
+      "email": "e-fam-159-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Iris",
+      "lastName": "Lechner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000318",
+      "username": "e-fam-159-b",
+      "email": "e-fam-159-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Konstantin",
+      "lastName": "Lechner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000319",
+      "username": "e-fam-160-a",
+      "email": "e-fam-160-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Johanna",
+      "lastName": "Linder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000320",
+      "username": "e-fam-160-b",
+      "email": "e-fam-160-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Jakob",
+      "lastName": "Linder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000321",
+      "username": "e-fam-161-a",
+      "email": "e-fam-161-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Maria",
+      "lastName": "Maier",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000322",
+      "username": "e-fam-161-b",
+      "email": "e-fam-161-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Stefan",
+      "lastName": "Maier",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000323",
+      "username": "e-fam-162-a",
+      "email": "e-fam-162-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Andrea",
+      "lastName": "Mayer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000324",
+      "username": "e-fam-162-b",
+      "email": "e-fam-162-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Thomas",
+      "lastName": "Mayer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000325",
+      "username": "e-fam-163-a",
+      "email": "e-fam-163-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Sabine",
+      "lastName": "Mayerhofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000326",
+      "username": "e-fam-163-b",
+      "email": "e-fam-163-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Markus",
+      "lastName": "Mayerhofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000327",
+      "username": "e-fam-164-a",
+      "email": "e-fam-164-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Christina",
+      "lastName": "Reiter",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000328",
+      "username": "e-fam-164-b",
+      "email": "e-fam-164-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Peter",
+      "lastName": "Reiter",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000329",
+      "username": "e-fam-165-a",
+      "email": "e-fam-165-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Eva",
+      "lastName": "Riedl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000330",
+      "username": "e-fam-165-b",
+      "email": "e-fam-165-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Manuel",
+      "lastName": "Riedl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000331",
+      "username": "e-fam-166-a",
+      "email": "e-fam-166-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Sophia",
+      "lastName": "Schwarz",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000332",
+      "username": "e-fam-166-b",
+      "email": "e-fam-166-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "David",
+      "lastName": "Schwarz",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000333",
+      "username": "e-fam-167-a",
+      "email": "e-fam-167-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Lisa",
+      "lastName": "Huber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000334",
+      "username": "e-fam-167-b",
+      "email": "e-fam-167-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Andreas",
+      "lastName": "Huber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000335",
+      "username": "e-fam-168-a",
+      "email": "e-fam-168-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Katharina",
+      "lastName": "Köhler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000336",
+      "username": "e-fam-168-b",
+      "email": "e-fam-168-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Michael",
+      "lastName": "Köhler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000337",
+      "username": "e-fam-169-a",
+      "email": "e-fam-169-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Sandra",
+      "lastName": "Köberl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000338",
+      "username": "e-fam-169-b",
+      "email": "e-fam-169-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Daniel",
+      "lastName": "Köberl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000339",
+      "username": "e-fam-170-a",
+      "email": "e-fam-170-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Marlene",
+      "lastName": "Kogler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000340",
+      "username": "e-fam-170-b",
+      "email": "e-fam-170-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Tobias",
+      "lastName": "Kogler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000341",
+      "username": "e-fam-171-a",
+      "email": "e-fam-171-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Birgit",
+      "lastName": "Lang",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000342",
+      "username": "e-fam-171-b",
+      "email": "e-fam-171-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Christoph",
+      "lastName": "Lang",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000343",
+      "username": "e-fam-172-a",
+      "email": "e-fam-172-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Tanja",
+      "lastName": "Lechner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000344",
+      "username": "e-fam-172-b",
+      "email": "e-fam-172-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Felix",
+      "lastName": "Lechner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000345",
+      "username": "e-fam-173-a",
+      "email": "e-fam-173-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Hannah",
+      "lastName": "Maier",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000346",
+      "username": "e-fam-173-b",
+      "email": "e-fam-173-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Roland",
+      "lastName": "Maier",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000347",
+      "username": "e-fam-174-a",
+      "email": "e-fam-174-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Verena",
+      "lastName": "Mayer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000348",
+      "username": "e-fam-174-b",
+      "email": "e-fam-174-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Alexander",
+      "lastName": "Mayer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000349",
+      "username": "e-fam-175-a",
+      "email": "e-fam-175-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Beatrix",
+      "lastName": "Mayerhofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000350",
+      "username": "e-fam-175-b",
+      "email": "e-fam-175-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Karl-Heinz",
+      "lastName": "Mayerhofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000351",
+      "username": "e-fam-176-a",
+      "email": "e-fam-176-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Julia",
+      "lastName": "Pichler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000352",
+      "username": "e-fam-176-b",
+      "email": "e-fam-176-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Lukas",
+      "lastName": "Pichler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000353",
+      "username": "e-fam-177-a",
+      "email": "e-fam-177-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Elena",
+      "lastName": "Reiter",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000354",
+      "username": "e-fam-177-b",
+      "email": "e-fam-177-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Bernhard",
+      "lastName": "Reiter",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000355",
+      "username": "e-fam-178-a",
+      "email": "e-fam-178-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Greta",
+      "lastName": "Riedl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000356",
+      "username": "e-fam-178-b",
+      "email": "e-fam-178-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Wolfgang",
+      "lastName": "Riedl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000357",
+      "username": "e-fam-179-a",
+      "email": "e-fam-179-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Iris",
+      "lastName": "Stadler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000358",
+      "username": "e-fam-179-b",
+      "email": "e-fam-179-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Konstantin",
+      "lastName": "Stadler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000359",
+      "username": "e-fam-180-a",
+      "email": "e-fam-180-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Johanna",
+      "lastName": "Steiner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000360",
+      "username": "e-fam-180-b",
+      "email": "e-fam-180-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Jakob",
+      "lastName": "Steiner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000361",
+      "username": "e-fam-181-a",
+      "email": "e-fam-181-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Maria",
+      "lastName": "Strasser",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000362",
+      "username": "e-fam-181-b",
+      "email": "e-fam-181-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Stefan",
+      "lastName": "Strasser",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000363",
+      "username": "e-fam-182-a",
+      "email": "e-fam-182-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Andrea",
+      "lastName": "Wagner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000364",
+      "username": "e-fam-182-b",
+      "email": "e-fam-182-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Thomas",
+      "lastName": "Wagner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000365",
+      "username": "e-fam-183-a",
+      "email": "e-fam-183-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Sabine",
+      "lastName": "Wallner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000366",
+      "username": "e-fam-183-b",
+      "email": "e-fam-183-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Markus",
+      "lastName": "Wallner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000367",
+      "username": "e-fam-184-a",
+      "email": "e-fam-184-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Christina",
+      "lastName": "Weber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000368",
+      "username": "e-fam-184-b",
+      "email": "e-fam-184-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Peter",
+      "lastName": "Weber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000369",
+      "username": "e-fam-185-a",
+      "email": "e-fam-185-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Eva",
+      "lastName": "Wolf",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000370",
+      "username": "e-fam-185-b",
+      "email": "e-fam-185-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Manuel",
+      "lastName": "Wolf",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000371",
+      "username": "e-fam-186-a",
+      "email": "e-fam-186-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Sophia",
+      "lastName": "Aigner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000372",
+      "username": "e-fam-186-b",
+      "email": "e-fam-186-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "David",
+      "lastName": "Aigner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000373",
+      "username": "e-fam-187-a",
+      "email": "e-fam-187-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Lisa",
+      "lastName": "Bauer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000374",
+      "username": "e-fam-187-b",
+      "email": "e-fam-187-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Andreas",
+      "lastName": "Bauer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000375",
+      "username": "e-fam-188-a",
+      "email": "e-fam-188-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Katharina",
+      "lastName": "Brunner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000376",
+      "username": "e-fam-188-b",
+      "email": "e-fam-188-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Michael",
+      "lastName": "Brunner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000377",
+      "username": "e-fam-189-a",
+      "email": "e-fam-189-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Sandra",
+      "lastName": "Eder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000378",
+      "username": "e-fam-189-b",
+      "email": "e-fam-189-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Daniel",
+      "lastName": "Eder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000379",
+      "username": "e-fam-190-a",
+      "email": "e-fam-190-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Marlene",
+      "lastName": "Fischer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000380",
+      "username": "e-fam-190-b",
+      "email": "e-fam-190-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Tobias",
+      "lastName": "Fischer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000381",
+      "username": "e-fam-191-a",
+      "email": "e-fam-191-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Birgit",
+      "lastName": "Gruber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000382",
+      "username": "e-fam-191-b",
+      "email": "e-fam-191-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Christoph",
+      "lastName": "Gruber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000383",
+      "username": "e-fam-192-a",
+      "email": "e-fam-192-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Tanja",
+      "lastName": "Stadler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000384",
+      "username": "e-fam-192-b",
+      "email": "e-fam-192-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Felix",
+      "lastName": "Stadler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000385",
+      "username": "e-fam-193-a",
+      "email": "e-fam-193-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Hannah",
+      "lastName": "Steiner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000386",
+      "username": "e-fam-193-b",
+      "email": "e-fam-193-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Roland",
+      "lastName": "Steiner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000387",
+      "username": "e-fam-194-a",
+      "email": "e-fam-194-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Verena",
+      "lastName": "Strasser",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000388",
+      "username": "e-fam-194-b",
+      "email": "e-fam-194-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Alexander",
+      "lastName": "Strasser",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000389",
+      "username": "e-fam-195-a",
+      "email": "e-fam-195-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Beatrix",
+      "lastName": "Wagner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000390",
+      "username": "e-fam-195-b",
+      "email": "e-fam-195-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Karl-Heinz",
+      "lastName": "Wagner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000391",
+      "username": "e-fam-196-a",
+      "email": "e-fam-196-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Julia",
+      "lastName": "Wallner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000392",
+      "username": "e-fam-196-b",
+      "email": "e-fam-196-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Lukas",
+      "lastName": "Wallner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000393",
+      "username": "e-fam-197-a",
+      "email": "e-fam-197-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Elena",
+      "lastName": "Wolf",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000394",
+      "username": "e-fam-197-b",
+      "email": "e-fam-197-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Bernhard",
+      "lastName": "Wolf",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000395",
+      "username": "e-fam-198-a",
+      "email": "e-fam-198-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Greta",
+      "lastName": "Berger",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000396",
+      "username": "e-fam-198-b",
+      "email": "e-fam-198-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Wolfgang",
+      "lastName": "Berger",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000397",
+      "username": "e-fam-199-a",
+      "email": "e-fam-199-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Iris",
+      "lastName": "Aigner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000398",
+      "username": "e-fam-199-b",
+      "email": "e-fam-199-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Konstantin",
+      "lastName": "Aigner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000399",
+      "username": "e-fam-200-a",
+      "email": "e-fam-200-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Johanna",
+      "lastName": "Bauer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000400",
+      "username": "e-fam-200-b",
+      "email": "e-fam-200-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Jakob",
+      "lastName": "Bauer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000401",
+      "username": "e-fam-201-a",
+      "email": "e-fam-201-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Maria",
+      "lastName": "Brunner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000402",
+      "username": "e-fam-201-b",
+      "email": "e-fam-201-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Stefan",
+      "lastName": "Brunner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000403",
+      "username": "e-fam-202-a",
+      "email": "e-fam-202-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Andrea",
+      "lastName": "Fischer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000404",
+      "username": "e-fam-202-b",
+      "email": "e-fam-202-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Thomas",
+      "lastName": "Fischer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000405",
+      "username": "e-fam-203-a",
+      "email": "e-fam-203-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Sabine",
+      "lastName": "Gruber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000406",
+      "username": "e-fam-203-b",
+      "email": "e-fam-203-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Markus",
+      "lastName": "Gruber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000407",
+      "username": "e-fam-204-a",
+      "email": "e-fam-204-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Christina",
+      "lastName": "Hofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000408",
+      "username": "e-fam-204-b",
+      "email": "e-fam-204-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Peter",
+      "lastName": "Hofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000409",
+      "username": "e-fam-205-a",
+      "email": "e-fam-205-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Eva",
+      "lastName": "Holzer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000410",
+      "username": "e-fam-205-b",
+      "email": "e-fam-205-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Manuel",
+      "lastName": "Holzer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000411",
+      "username": "e-fam-206-a",
+      "email": "e-fam-206-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Sophia",
+      "lastName": "Huber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000412",
+      "username": "e-fam-206-b",
+      "email": "e-fam-206-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "David",
+      "lastName": "Huber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000413",
+      "username": "e-fam-207-a",
+      "email": "e-fam-207-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Lisa",
+      "lastName": "Köhler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000414",
+      "username": "e-fam-207-b",
+      "email": "e-fam-207-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Andreas",
+      "lastName": "Köhler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000415",
+      "username": "e-fam-208-a",
+      "email": "e-fam-208-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Katharina",
+      "lastName": "Köberl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000416",
+      "username": "e-fam-208-b",
+      "email": "e-fam-208-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Michael",
+      "lastName": "Köberl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000417",
+      "username": "e-fam-209-a",
+      "email": "e-fam-209-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Sandra",
+      "lastName": "Kogler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000418",
+      "username": "e-fam-209-b",
+      "email": "e-fam-209-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Daniel",
+      "lastName": "Kogler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000419",
+      "username": "e-fam-210-a",
+      "email": "e-fam-210-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Marlene",
+      "lastName": "Lang",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000420",
+      "username": "e-fam-210-b",
+      "email": "e-fam-210-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Tobias",
+      "lastName": "Lang",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000421",
+      "username": "e-fam-211-a",
+      "email": "e-fam-211-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Birgit",
+      "lastName": "Lechner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000422",
+      "username": "e-fam-211-b",
+      "email": "e-fam-211-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Christoph",
+      "lastName": "Lechner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000423",
+      "username": "e-fam-212-a",
+      "email": "e-fam-212-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Tanja",
+      "lastName": "Maier",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000424",
+      "username": "e-fam-212-b",
+      "email": "e-fam-212-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Felix",
+      "lastName": "Maier",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000425",
+      "username": "e-fam-213-a",
+      "email": "e-fam-213-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Hannah",
+      "lastName": "Mayer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000426",
+      "username": "e-fam-213-b",
+      "email": "e-fam-213-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Roland",
+      "lastName": "Mayer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000427",
+      "username": "e-fam-214-a",
+      "email": "e-fam-214-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Verena",
+      "lastName": "Mayerhofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000428",
+      "username": "e-fam-214-b",
+      "email": "e-fam-214-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Alexander",
+      "lastName": "Mayerhofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000429",
+      "username": "e-fam-215-a",
+      "email": "e-fam-215-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Beatrix",
+      "lastName": "Pichler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000430",
+      "username": "e-fam-215-b",
+      "email": "e-fam-215-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Karl-Heinz",
+      "lastName": "Pichler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000431",
+      "username": "e-fam-216-a",
+      "email": "e-fam-216-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Julia",
+      "lastName": "Reiter",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000432",
+      "username": "e-fam-216-b",
+      "email": "e-fam-216-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Lukas",
+      "lastName": "Reiter",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000433",
+      "username": "e-fam-217-a",
+      "email": "e-fam-217-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Elena",
+      "lastName": "Hofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000434",
+      "username": "e-fam-217-b",
+      "email": "e-fam-217-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Bernhard",
+      "lastName": "Hofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000435",
+      "username": "e-fam-218-a",
+      "email": "e-fam-218-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Greta",
+      "lastName": "Holzer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000436",
+      "username": "e-fam-218-b",
+      "email": "e-fam-218-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Wolfgang",
+      "lastName": "Holzer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000437",
+      "username": "e-fam-219-a",
+      "email": "e-fam-219-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Iris",
+      "lastName": "Köhler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000438",
+      "username": "e-fam-219-b",
+      "email": "e-fam-219-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Konstantin",
+      "lastName": "Köhler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000439",
+      "username": "e-fam-220-a",
+      "email": "e-fam-220-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Johanna",
+      "lastName": "Köberl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000440",
+      "username": "e-fam-220-b",
+      "email": "e-fam-220-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Jakob",
+      "lastName": "Köberl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000441",
+      "username": "e-fam-221-a",
+      "email": "e-fam-221-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Maria",
+      "lastName": "Kogler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000442",
+      "username": "e-fam-221-b",
+      "email": "e-fam-221-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Stefan",
+      "lastName": "Kogler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000443",
+      "username": "e-fam-222-a",
+      "email": "e-fam-222-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Andrea",
+      "lastName": "Lang",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000444",
+      "username": "e-fam-222-b",
+      "email": "e-fam-222-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Thomas",
+      "lastName": "Lang",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000445",
+      "username": "e-fam-223-a",
+      "email": "e-fam-223-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Sabine",
+      "lastName": "Lechner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000446",
+      "username": "e-fam-223-b",
+      "email": "e-fam-223-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Markus",
+      "lastName": "Lechner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000447",
+      "username": "e-fam-224-a",
+      "email": "e-fam-224-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Christina",
+      "lastName": "Linder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000448",
+      "username": "e-fam-224-b",
+      "email": "e-fam-224-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Peter",
+      "lastName": "Linder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000449",
+      "username": "e-fam-225-a",
+      "email": "e-fam-225-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Eva",
+      "lastName": "Maier",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000450",
+      "username": "e-fam-225-b",
+      "email": "e-fam-225-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Manuel",
+      "lastName": "Maier",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000451",
+      "username": "e-fam-226-a",
+      "email": "e-fam-226-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Sophia",
+      "lastName": "Mayer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000452",
+      "username": "e-fam-226-b",
+      "email": "e-fam-226-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "David",
+      "lastName": "Mayer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000453",
+      "username": "e-fam-227-a",
+      "email": "e-fam-227-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Lisa",
+      "lastName": "Mayerhofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000454",
+      "username": "e-fam-227-b",
+      "email": "e-fam-227-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Andreas",
+      "lastName": "Mayerhofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000455",
+      "username": "e-fam-228-a",
+      "email": "e-fam-228-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Katharina",
+      "lastName": "Pichler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000456",
+      "username": "e-fam-228-b",
+      "email": "e-fam-228-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Michael",
+      "lastName": "Pichler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000457",
+      "username": "e-fam-229-a",
+      "email": "e-fam-229-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Sandra",
+      "lastName": "Riedl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000458",
+      "username": "e-fam-229-b",
+      "email": "e-fam-229-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Daniel",
+      "lastName": "Riedl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000459",
+      "username": "e-fam-230-a",
+      "email": "e-fam-230-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Marlene",
+      "lastName": "Schwarz",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000460",
+      "username": "e-fam-230-b",
+      "email": "e-fam-230-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Tobias",
+      "lastName": "Schwarz",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000461",
+      "username": "e-fam-231-a",
+      "email": "e-fam-231-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Birgit",
+      "lastName": "Stadler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000462",
+      "username": "e-fam-231-b",
+      "email": "e-fam-231-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Christoph",
+      "lastName": "Stadler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000463",
+      "username": "e-fam-232-a",
+      "email": "e-fam-232-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Tanja",
+      "lastName": "Strasser",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000464",
+      "username": "e-fam-232-b",
+      "email": "e-fam-232-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Felix",
+      "lastName": "Strasser",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000465",
+      "username": "e-fam-233-a",
+      "email": "e-fam-233-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Hannah",
+      "lastName": "Wagner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000466",
+      "username": "e-fam-233-b",
+      "email": "e-fam-233-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Roland",
+      "lastName": "Wagner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000467",
+      "username": "e-fam-234-a",
+      "email": "e-fam-234-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Verena",
+      "lastName": "Wallner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000468",
+      "username": "e-fam-234-b",
+      "email": "e-fam-234-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Alexander",
+      "lastName": "Wallner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000469",
+      "username": "e-fam-235-a",
+      "email": "e-fam-235-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Beatrix",
+      "lastName": "Weber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000470",
+      "username": "e-fam-235-b",
+      "email": "e-fam-235-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Karl-Heinz",
+      "lastName": "Weber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000471",
+      "username": "e-fam-236-a",
+      "email": "e-fam-236-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Julia",
+      "lastName": "Wolf",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000472",
+      "username": "e-fam-236-b",
+      "email": "e-fam-236-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Lukas",
+      "lastName": "Wolf",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000473",
+      "username": "e-fam-237-a",
+      "email": "e-fam-237-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Elena",
+      "lastName": "Berger",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000474",
+      "username": "e-fam-237-b",
+      "email": "e-fam-237-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Bernhard",
+      "lastName": "Berger",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000475",
+      "username": "e-fam-238-a",
+      "email": "e-fam-238-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Greta",
+      "lastName": "Aigner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000476",
+      "username": "e-fam-238-b",
+      "email": "e-fam-238-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Wolfgang",
+      "lastName": "Aigner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000477",
+      "username": "e-fam-239-a",
+      "email": "e-fam-239-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Iris",
+      "lastName": "Bauer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000478",
+      "username": "e-fam-239-b",
+      "email": "e-fam-239-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Konstantin",
+      "lastName": "Bauer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000479",
+      "username": "e-fam-240-a",
+      "email": "e-fam-240-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Johanna",
+      "lastName": "Eder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000480",
+      "username": "e-fam-240-b",
+      "email": "e-fam-240-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Jakob",
+      "lastName": "Eder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000481",
+      "username": "e-fam-241-a",
+      "email": "e-fam-241-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Maria",
+      "lastName": "Riedl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000482",
+      "username": "e-fam-241-b",
+      "email": "e-fam-241-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Stefan",
+      "lastName": "Riedl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000483",
+      "username": "e-fam-242-a",
+      "email": "e-fam-242-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Andrea",
+      "lastName": "Schwarz",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000484",
+      "username": "e-fam-242-b",
+      "email": "e-fam-242-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Thomas",
+      "lastName": "Schwarz",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000485",
+      "username": "e-fam-243-a",
+      "email": "e-fam-243-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Sabine",
+      "lastName": "Stadler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000486",
+      "username": "e-fam-243-b",
+      "email": "e-fam-243-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Markus",
+      "lastName": "Stadler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000487",
+      "username": "e-fam-244-a",
+      "email": "e-fam-244-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Christina",
+      "lastName": "Steiner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000488",
+      "username": "e-fam-244-b",
+      "email": "e-fam-244-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Peter",
+      "lastName": "Steiner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000489",
+      "username": "e-fam-245-a",
+      "email": "e-fam-245-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Eva",
+      "lastName": "Wagner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000490",
+      "username": "e-fam-245-b",
+      "email": "e-fam-245-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Manuel",
+      "lastName": "Wagner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000491",
+      "username": "e-fam-246-a",
+      "email": "e-fam-246-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Sophia",
+      "lastName": "Weber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000492",
+      "username": "e-fam-246-b",
+      "email": "e-fam-246-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "David",
+      "lastName": "Weber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000493",
+      "username": "e-fam-247-a",
+      "email": "e-fam-247-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Lisa",
+      "lastName": "Wolf",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000494",
+      "username": "e-fam-247-b",
+      "email": "e-fam-247-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Andreas",
+      "lastName": "Wolf",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000495",
+      "username": "e-fam-248-a",
+      "email": "e-fam-248-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Katharina",
+      "lastName": "Berger",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000496",
+      "username": "e-fam-248-b",
+      "email": "e-fam-248-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Michael",
+      "lastName": "Berger",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000497",
+      "username": "e-fam-249-a",
+      "email": "e-fam-249-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Sandra",
+      "lastName": "Bauer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000498",
+      "username": "e-fam-249-b",
+      "email": "e-fam-249-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Daniel",
+      "lastName": "Bauer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000499",
+      "username": "e-fam-250-a",
+      "email": "e-fam-250-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Marlene",
+      "lastName": "Brunner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000500",
+      "username": "e-fam-250-b",
+      "email": "e-fam-250-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Tobias",
+      "lastName": "Brunner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000501",
+      "username": "e-fam-251-a",
+      "email": "e-fam-251-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Birgit",
+      "lastName": "Eder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000502",
+      "username": "e-fam-251-b",
+      "email": "e-fam-251-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Christoph",
+      "lastName": "Eder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000503",
+      "username": "e-fam-252-a",
+      "email": "e-fam-252-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Tanja",
+      "lastName": "Fischer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000504",
+      "username": "e-fam-252-b",
+      "email": "e-fam-252-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Felix",
+      "lastName": "Fischer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000505",
+      "username": "e-fam-253-a",
+      "email": "e-fam-253-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Hannah",
+      "lastName": "Gruber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000506",
+      "username": "e-fam-253-b",
+      "email": "e-fam-253-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Roland",
+      "lastName": "Gruber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000507",
+      "username": "e-fam-254-a",
+      "email": "e-fam-254-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Verena",
+      "lastName": "Hofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000508",
+      "username": "e-fam-254-b",
+      "email": "e-fam-254-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Alexander",
+      "lastName": "Hofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000509",
+      "username": "e-fam-255-a",
+      "email": "e-fam-255-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Beatrix",
+      "lastName": "Holzer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000510",
+      "username": "e-fam-255-b",
+      "email": "e-fam-255-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Karl-Heinz",
+      "lastName": "Holzer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000511",
+      "username": "e-fam-256-a",
+      "email": "e-fam-256-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Julia",
+      "lastName": "Huber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000512",
+      "username": "e-fam-256-b",
+      "email": "e-fam-256-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Lukas",
+      "lastName": "Huber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000513",
+      "username": "e-fam-257-a",
+      "email": "e-fam-257-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Elena",
+      "lastName": "Köhler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000514",
+      "username": "e-fam-257-b",
+      "email": "e-fam-257-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Bernhard",
+      "lastName": "Köhler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000515",
+      "username": "e-fam-258-a",
+      "email": "e-fam-258-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Greta",
+      "lastName": "Kogler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000516",
+      "username": "e-fam-258-b",
+      "email": "e-fam-258-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Wolfgang",
+      "lastName": "Kogler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000517",
+      "username": "e-fam-259-a",
+      "email": "e-fam-259-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Iris",
+      "lastName": "Lang",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000518",
+      "username": "e-fam-259-b",
+      "email": "e-fam-259-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Konstantin",
+      "lastName": "Lang",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000519",
+      "username": "e-fam-260-a",
+      "email": "e-fam-260-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Johanna",
+      "lastName": "Lechner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000520",
+      "username": "e-fam-260-b",
+      "email": "e-fam-260-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Jakob",
+      "lastName": "Lechner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000521",
+      "username": "e-fam-261-a",
+      "email": "e-fam-261-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Maria",
+      "lastName": "Linder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000522",
+      "username": "e-fam-261-b",
+      "email": "e-fam-261-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Stefan",
+      "lastName": "Linder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000523",
+      "username": "e-fam-262-a",
+      "email": "e-fam-262-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Andrea",
+      "lastName": "Maier",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000524",
+      "username": "e-fam-262-b",
+      "email": "e-fam-262-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Thomas",
+      "lastName": "Maier",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000525",
+      "username": "e-fam-263-a",
+      "email": "e-fam-263-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Sabine",
+      "lastName": "Mayer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000526",
+      "username": "e-fam-263-b",
+      "email": "e-fam-263-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Markus",
+      "lastName": "Mayer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000527",
+      "username": "e-fam-264-a",
+      "email": "e-fam-264-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Christina",
+      "lastName": "Fischer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000528",
+      "username": "e-fam-264-b",
+      "email": "e-fam-264-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Peter",
+      "lastName": "Fischer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000529",
+      "username": "e-fam-265-a",
+      "email": "e-fam-265-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Eva",
+      "lastName": "Gruber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000530",
+      "username": "e-fam-265-b",
+      "email": "e-fam-265-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Manuel",
+      "lastName": "Gruber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000531",
+      "username": "e-fam-266-a",
+      "email": "e-fam-266-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Sophia",
+      "lastName": "Hofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000532",
+      "username": "e-fam-266-b",
+      "email": "e-fam-266-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "David",
+      "lastName": "Hofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000533",
+      "username": "e-fam-267-a",
+      "email": "e-fam-267-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Lisa",
+      "lastName": "Huber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000534",
+      "username": "e-fam-267-b",
+      "email": "e-fam-267-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Andreas",
+      "lastName": "Huber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000535",
+      "username": "e-fam-268-a",
+      "email": "e-fam-268-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Katharina",
+      "lastName": "Köhler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000536",
+      "username": "e-fam-268-b",
+      "email": "e-fam-268-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Michael",
+      "lastName": "Köhler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000537",
+      "username": "e-fam-269-a",
+      "email": "e-fam-269-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Sandra",
+      "lastName": "Köberl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000538",
+      "username": "e-fam-269-b",
+      "email": "e-fam-269-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Daniel",
+      "lastName": "Köberl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000539",
+      "username": "e-fam-270-a",
+      "email": "e-fam-270-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Marlene",
+      "lastName": "Kogler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000540",
+      "username": "e-fam-270-b",
+      "email": "e-fam-270-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Tobias",
+      "lastName": "Kogler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000541",
+      "username": "e-fam-271-a",
+      "email": "e-fam-271-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Birgit",
+      "lastName": "Lechner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000542",
+      "username": "e-fam-271-b",
+      "email": "e-fam-271-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Christoph",
+      "lastName": "Lechner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000543",
+      "username": "e-fam-272-a",
+      "email": "e-fam-272-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Tanja",
+      "lastName": "Linder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000544",
+      "username": "e-fam-272-b",
+      "email": "e-fam-272-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Felix",
+      "lastName": "Linder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000545",
+      "username": "e-fam-273-a",
+      "email": "e-fam-273-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Hannah",
+      "lastName": "Maier",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000546",
+      "username": "e-fam-273-b",
+      "email": "e-fam-273-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Roland",
+      "lastName": "Maier",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000547",
+      "username": "e-fam-274-a",
+      "email": "e-fam-274-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Verena",
+      "lastName": "Mayer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000548",
+      "username": "e-fam-274-b",
+      "email": "e-fam-274-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Alexander",
+      "lastName": "Mayer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000549",
+      "username": "e-fam-275-a",
+      "email": "e-fam-275-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Beatrix",
+      "lastName": "Mayerhofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000550",
+      "username": "e-fam-275-b",
+      "email": "e-fam-275-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Karl-Heinz",
+      "lastName": "Mayerhofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000551",
+      "username": "e-fam-276-a",
+      "email": "e-fam-276-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Julia",
+      "lastName": "Pichler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000552",
+      "username": "e-fam-276-b",
+      "email": "e-fam-276-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Lukas",
+      "lastName": "Pichler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000553",
+      "username": "e-fam-277-a",
+      "email": "e-fam-277-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Elena",
+      "lastName": "Reiter",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000554",
+      "username": "e-fam-277-b",
+      "email": "e-fam-277-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Bernhard",
+      "lastName": "Reiter",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000555",
+      "username": "e-fam-278-a",
+      "email": "e-fam-278-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Greta",
+      "lastName": "Schwarz",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000556",
+      "username": "e-fam-278-b",
+      "email": "e-fam-278-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Wolfgang",
+      "lastName": "Schwarz",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000557",
+      "username": "e-fam-279-a",
+      "email": "e-fam-279-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Iris",
+      "lastName": "Stadler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000558",
+      "username": "e-fam-279-b",
+      "email": "e-fam-279-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Konstantin",
+      "lastName": "Stadler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000559",
+      "username": "e-fam-280-a",
+      "email": "e-fam-280-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Johanna",
+      "lastName": "Steiner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000560",
+      "username": "e-fam-280-b",
+      "email": "e-fam-280-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Jakob",
+      "lastName": "Steiner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000561",
+      "username": "e-fam-281-a",
+      "email": "e-fam-281-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Maria",
+      "lastName": "Strasser",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000562",
+      "username": "e-fam-281-b",
+      "email": "e-fam-281-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Stefan",
+      "lastName": "Strasser",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000563",
+      "username": "e-fam-282-a",
+      "email": "e-fam-282-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Andrea",
+      "lastName": "Wagner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000564",
+      "username": "e-fam-282-b",
+      "email": "e-fam-282-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Thomas",
+      "lastName": "Wagner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000565",
+      "username": "e-fam-283-a",
+      "email": "e-fam-283-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Sabine",
+      "lastName": "Wallner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000566",
+      "username": "e-fam-283-b",
+      "email": "e-fam-283-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Markus",
+      "lastName": "Wallner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000567",
+      "username": "e-fam-284-a",
+      "email": "e-fam-284-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Christina",
+      "lastName": "Weber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000568",
+      "username": "e-fam-284-b",
+      "email": "e-fam-284-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Peter",
+      "lastName": "Weber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000569",
+      "username": "e-fam-285-a",
+      "email": "e-fam-285-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Eva",
+      "lastName": "Berger",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000570",
+      "username": "e-fam-285-b",
+      "email": "e-fam-285-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Manuel",
+      "lastName": "Berger",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000571",
+      "username": "e-fam-286-a",
+      "email": "e-fam-286-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Sophia",
+      "lastName": "Aigner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000572",
+      "username": "e-fam-286-b",
+      "email": "e-fam-286-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "David",
+      "lastName": "Aigner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000573",
+      "username": "e-fam-287-a",
+      "email": "e-fam-287-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Lisa",
+      "lastName": "Linder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000574",
+      "username": "e-fam-287-b",
+      "email": "e-fam-287-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Andreas",
+      "lastName": "Linder",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000575",
+      "username": "e-fam-288-a",
+      "email": "e-fam-288-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Katharina",
+      "lastName": "Schwarz",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000576",
+      "username": "e-fam-288-b",
+      "email": "e-fam-288-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Michael",
+      "lastName": "Schwarz",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000577",
+      "username": "e-fam-289-a",
+      "email": "e-fam-289-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Sandra",
+      "lastName": "Mayerhofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000578",
+      "username": "e-fam-289-b",
+      "email": "e-fam-289-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Daniel",
+      "lastName": "Mayerhofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000579",
+      "username": "e-fam-290-a",
+      "email": "e-fam-290-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Marlene",
+      "lastName": "Wagner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000580",
+      "username": "e-fam-290-b",
+      "email": "e-fam-290-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Tobias",
+      "lastName": "Wagner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000581",
+      "username": "e-fam-291-a",
+      "email": "e-fam-291-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Birgit",
+      "lastName": "Aigner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000582",
+      "username": "e-fam-291-b",
+      "email": "e-fam-291-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Christoph",
+      "lastName": "Aigner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000583",
+      "username": "e-fam-292-a",
+      "email": "e-fam-292-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Tanja",
+      "lastName": "Maier",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000584",
+      "username": "e-fam-292-b",
+      "email": "e-fam-292-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Felix",
+      "lastName": "Maier",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000585",
+      "username": "e-fam-293-a",
+      "email": "e-fam-293-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Hannah",
+      "lastName": "Fischer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000586",
+      "username": "e-fam-293-b",
+      "email": "e-fam-293-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Roland",
+      "lastName": "Fischer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000587",
+      "username": "e-fam-294-a",
+      "email": "e-fam-294-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Verena",
+      "lastName": "Köberl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000588",
+      "username": "e-fam-294-b",
+      "email": "e-fam-294-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Alexander",
+      "lastName": "Köberl",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000589",
+      "username": "e-fam-295-a",
+      "email": "e-fam-295-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Beatrix",
+      "lastName": "Huber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000590",
+      "username": "e-fam-295-b",
+      "email": "e-fam-295-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Karl-Heinz",
+      "lastName": "Huber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000591",
+      "username": "e-fam-296-a",
+      "email": "e-fam-296-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Julia",
+      "lastName": "Lang",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000592",
+      "username": "e-fam-296-b",
+      "email": "e-fam-296-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Lukas",
+      "lastName": "Lang",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000593",
+      "username": "e-fam-297-a",
+      "email": "e-fam-297-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Elena",
+      "lastName": "Weber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000594",
+      "username": "e-fam-297-b",
+      "email": "e-fam-297-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Bernhard",
+      "lastName": "Weber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000595",
+      "username": "e-fam-298-a",
+      "email": "e-fam-298-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Greta",
+      "lastName": "Fischer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000596",
+      "username": "e-fam-298-b",
+      "email": "e-fam-298-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Wolfgang",
+      "lastName": "Fischer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000597",
+      "username": "e-fam-299-a",
+      "email": "e-fam-299-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Iris",
+      "lastName": "Stadler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000598",
+      "username": "e-fam-299-b",
+      "email": "e-fam-299-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Konstantin",
+      "lastName": "Stadler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000599",
+      "username": "e-fam-300-a",
+      "email": "e-fam-300-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Johanna",
+      "lastName": "Reiter",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000600",
+      "username": "e-fam-300-b",
+      "email": "e-fam-300-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Jakob",
+      "lastName": "Reiter",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000601",
+      "username": "e-fam-301-a",
+      "email": "e-fam-301-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Maria",
+      "lastName": "Weber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000602",
+      "username": "e-fam-301-b",
+      "email": "e-fam-301-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Stefan",
+      "lastName": "Weber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000603",
+      "username": "e-fam-302-a",
+      "email": "e-fam-302-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Andrea",
+      "lastName": "Berger",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000604",
+      "username": "e-fam-302-b",
+      "email": "e-fam-302-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Thomas",
+      "lastName": "Berger",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000605",
+      "username": "e-fam-303-a",
+      "email": "e-fam-303-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Sabine",
+      "lastName": "Pichler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000606",
+      "username": "e-fam-303-b",
+      "email": "e-fam-303-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Markus",
+      "lastName": "Pichler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000607",
+      "username": "e-fam-304-a",
+      "email": "e-fam-304-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Christina",
+      "lastName": "Berger",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000608",
+      "username": "e-fam-304-b",
+      "email": "e-fam-304-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Peter",
+      "lastName": "Berger",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000609",
+      "username": "e-fam-305-a",
+      "email": "e-fam-305-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Eva",
+      "lastName": "Weber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000610",
+      "username": "e-fam-305-b",
+      "email": "e-fam-305-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Manuel",
+      "lastName": "Weber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000611",
+      "username": "e-fam-306-a",
+      "email": "e-fam-306-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Sophia",
+      "lastName": "Hofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000612",
+      "username": "e-fam-306-b",
+      "email": "e-fam-306-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "David",
+      "lastName": "Hofer",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000613",
+      "username": "e-fam-307-a",
+      "email": "e-fam-307-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Lisa",
+      "lastName": "Brunner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000614",
+      "username": "e-fam-307-b",
+      "email": "e-fam-307-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Andreas",
+      "lastName": "Brunner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000615",
+      "username": "e-fam-308-a",
+      "email": "e-fam-308-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Katharina",
+      "lastName": "Steiner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000616",
+      "username": "e-fam-308-b",
+      "email": "e-fam-308-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Michael",
+      "lastName": "Steiner",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000617",
+      "username": "e-fam-309-a",
+      "email": "e-fam-309-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Sandra",
+      "lastName": "Stadler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000618",
+      "username": "e-fam-309-b",
+      "email": "e-fam-309-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Daniel",
+      "lastName": "Stadler",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000619",
+      "username": "e-fam-310-a",
+      "email": "e-fam-310-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Marlene",
+      "lastName": "Strasser",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000620",
+      "username": "e-fam-310-b",
+      "email": "e-fam-310-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Tobias",
+      "lastName": "Strasser",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000621",
+      "username": "e-fam-311-a",
+      "email": "e-fam-311-a@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Birgit",
+      "lastName": "Weber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
+    },
+    {
+      "id": "dddd0000-0000-4000-8000-000000000622",
+      "username": "e-fam-311-b",
+      "email": "e-fam-311-b@demo.schoolflow.dev",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Christoph",
+      "lastName": "Weber",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Demo1234!",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "eltern"
+      ],
+      "attributes": {
+        "managed_by_seed": [
+          "175"
+        ]
+      }
     }
   ]
 }

--- a/scripts/generate-realm-users.ts
+++ b/scripts/generate-realm-users.ts
@@ -1,0 +1,188 @@
+#!/usr/bin/env tsx
+/**
+ * #175 — Regenerate the bulk-user block in docker/keycloak/realm-export.json
+ * from `apps/api/prisma/seed-data.ts`.
+ *
+ * Idempotent: Bulk + parallel-legacy users carry
+ *   `attributes.managed_by_seed = ["175"]`
+ * so the script removes any prior managed entries before writing fresh
+ * ones. The 5 real legacy users (admin-user/lehrer-user/eltern-user/
+ * schueler-user/schulleitung-user) and the `service-account-schoolflow-
+ * admin-api` entry have no such marker and are preserved untouched.
+ *
+ * Usage:
+ *   pnpm tsx scripts/generate-realm-users.ts          # write
+ *   pnpm tsx scripts/generate-realm-users.ts --dry    # print summary only
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import {
+  buildBulkSchoolData,
+  DEMO_PASSWORD,
+  getBulkSchulleitung,
+  getBulkTeachers,
+  getParallelLegacyUsers,
+} from '../apps/api/prisma/seed-data';
+
+const REPO_ROOT = resolve(__dirname, '..');
+const REALM_PATH = resolve(REPO_ROOT, 'docker/keycloak/realm-export.json');
+
+const MANAGED_MARKER_KEY = 'managed_by_seed';
+const MANAGED_MARKER_VAL = '175';
+
+interface KcUser {
+  id?: string;
+  username?: string;
+  email?: string;
+  enabled?: boolean;
+  emailVerified?: boolean;
+  firstName?: string;
+  lastName?: string;
+  credentials?: Array<{ type: string; value: string; temporary?: boolean }>;
+  realmRoles?: string[];
+  attributes?: Record<string, string[]>;
+  serviceAccountClientId?: string;
+  clientRoles?: Record<string, string[]>;
+}
+
+function isManaged(u: KcUser): boolean {
+  return Array.isArray(u.attributes?.[MANAGED_MARKER_KEY])
+    && u.attributes![MANAGED_MARKER_KEY].includes(MANAGED_MARKER_VAL);
+}
+
+function emailFor(username: string): string {
+  return `${username}@demo.schoolflow.dev`;
+}
+
+function buildKcUser(args: {
+  id: string;
+  username: string;
+  firstName: string;
+  lastName: string;
+  email?: string;
+  realmRole: 'admin' | 'schulleitung' | 'lehrer' | 'eltern' | 'schueler';
+}): KcUser {
+  return {
+    id: args.id,
+    username: args.username,
+    email: args.email ?? emailFor(args.username),
+    enabled: true,
+    emailVerified: true,
+    firstName: args.firstName,
+    lastName: args.lastName,
+    credentials: [{ type: 'password', value: DEMO_PASSWORD, temporary: false }],
+    realmRoles: [args.realmRole],
+    attributes: { [MANAGED_MARKER_KEY]: [MANAGED_MARKER_VAL] },
+  };
+}
+
+function main(): void {
+  const dryRun = process.argv.includes('--dry');
+
+  // 1. Read existing realm-export.json
+  const raw = readFileSync(REALM_PATH, 'utf-8');
+  const realm = JSON.parse(raw) as { users?: KcUser[] };
+  if (!Array.isArray(realm.users)) {
+    throw new Error('realm-export.json has no users[] array');
+  }
+
+  // 2. Filter out managed users (will be regenerated)
+  const preserved = realm.users.filter((u) => !isManaged(u));
+  const removed = realm.users.length - preserved.length;
+
+  // 3. Build fresh bulk + parallel-legacy users from seed-data
+  const fresh: KcUser[] = [];
+
+  // 3a. 5 parallel kc-* legacy mirrors
+  for (const u of getParallelLegacyUsers()) {
+    fresh.push(buildKcUser({
+      id: u.kcUuid,
+      username: u.kcUsername,
+      firstName: u.firstName,
+      lastName: u.lastName,
+      email: u.email,
+      realmRole: u.role,
+    }));
+  }
+
+  // 3b. 1 schulleitung-01
+  const sl = getBulkSchulleitung();
+  fresh.push(buildKcUser({
+    id: sl.kcUuid,
+    username: sl.kcUsername,
+    firstName: sl.firstName,
+    lastName: sl.lastName,
+    realmRole: 'schulleitung',
+  }));
+
+  // 3c. 32 bulk teachers
+  for (const t of getBulkTeachers()) {
+    fresh.push(buildKcUser({
+      id: t.kcUuid,
+      username: t.kcUsername,
+      firstName: t.firstName,
+      lastName: t.lastName,
+      realmRole: 'lehrer',
+    }));
+  }
+
+  // 3d. 336 students + 622 parents
+  const { students, families } = buildBulkSchoolData();
+  for (const s of students) {
+    fresh.push(buildKcUser({
+      id: s.kcUuid,
+      username: s.kcUsername,
+      firstName: s.firstName,
+      lastName: s.lastName,
+      realmRole: 'schueler',
+    }));
+  }
+  for (const f of families) {
+    fresh.push(buildKcUser({
+      id: f.mother.kcUuid,
+      username: f.mother.kcUsername,
+      firstName: f.mother.firstName,
+      lastName: f.mother.lastName,
+      realmRole: 'eltern',
+    }));
+    fresh.push(buildKcUser({
+      id: f.father.kcUuid,
+      username: f.father.kcUsername,
+      firstName: f.father.firstName,
+      lastName: f.father.lastName,
+      realmRole: 'eltern',
+    }));
+  }
+
+  // 4. Compose final user list: preserved + fresh
+  realm.users = [...preserved, ...fresh];
+
+  // 5. Summary
+  const summary = {
+    realmPath: REALM_PATH,
+    preserved: preserved.length,
+    removed,
+    fresh: fresh.length,
+    total: realm.users.length,
+    breakdown: {
+      parallelLegacy: getParallelLegacyUsers().length,
+      schulleitung: 1,
+      teachers: getBulkTeachers().length,
+      students: students.length,
+      parents: families.length * 2,
+    },
+  };
+  console.log('Realm-export users:');
+  console.log(JSON.stringify(summary, null, 2));
+
+  if (dryRun) {
+    console.log('\n--dry: not writing file.');
+    return;
+  }
+
+  // 6. Write back with stable formatting (2-space indent matches existing file)
+  writeFileSync(REALM_PATH, JSON.stringify(realm, null, 2) + '\n', 'utf-8');
+  console.log(`\nWrote ${REALM_PATH}`);
+}
+
+main();

--- a/testdaten.md
+++ b/testdaten.md
@@ -1,0 +1,345 @@
+# Testdaten — Demo-Seed Spezifikation
+
+> Spezifikation für Issue [#175](https://github.com/martinvidec/openaustria-school-flow/issues/175). Diese Datei ist der **Kontrakt**, den `apps/api/prisma/seed.ts` + `docker/keycloak/realm-export.json` implementieren.
+
+## Übersicht
+
+| Entität | Anzahl |
+|---|---|
+| School | 1 (`SchoolFlow Demo-Gymnasium`) |
+| SchoolType | `AHS` (entspricht Stundentafel AHS-Unterstufe) |
+| SchoolYear | 1 aktives Jahr (`2026/2027`) |
+| Schulstufen | 4 (1.–4. Klasse, Schulstufe 5–8) |
+| Klassen | 12 (3 Parallelklassen pro Stufe: A/B/C) |
+| Schüler | 336 (28 pro Klasse) |
+| Familien | ~311 (286 Einzelkind + 25 Geschwisterpaare) |
+| Eltern-KC-Accounts | ~622 (2 pro Familie) |
+| Lehrer | 32 |
+| Schulleitung | 1 |
+| Admin | 1 |
+| Räume | 19 |
+| Fächer | 14 |
+| ClassSubject-Zuweisungen | ~140 (12 Klassen × Stundentafel-Einträge) |
+| **KC-Accounts gesamt** | **~991** (336 Schüler + 622 Eltern + 32 Lehrer + 1 Schulleitung + 1 Admin — die 5 Legacy-Seed-User bleiben zusätzlich erhalten) |
+
+## Demo-Passwort
+
+**Alle Bulk-User erhalten das Passwort `Demo1234!`.** Single source of truth für Demo-Logins. Die 5 bestehenden Legacy-Seed-User (`kc-admin`, `kc-schulleitung`, `kc-lehrer`, `kc-eltern`, `kc-schueler`) behalten ihr bestehendes Passwort aus `docker/keycloak/realm-export.json` (Backward-Compat für E2E-Specs).
+
+## Naming-Konventionen
+
+| Rolle | KC-Username-Muster | Display (Vorname + Nachname) |
+|---|---|---|
+| Schüler | `s-{stufe}{klasse}-{nr}` z.B. `s-1a-01` … `s-4c-28` | aus Pool deutsch-österreichischer Vornamen + Nachnamen, deterministisch zugewiesen |
+| Lehrer | `l-{fach}-{nr}` z.B. `l-d-01`, `l-m-02` | analog |
+| Eltern | `e-fam-{nnn}-a` und `e-fam-{nnn}-b` z.B. `e-fam-001-a` | analog |
+| Schulleitung | `schulleitung-01` | wie bisher |
+| Admin | `admin` | wie bisher |
+
+**Family-ID-Mapping**: Familien 001–286 = Einzelkind-Familien, 287–311 = Geschwisterpaar-Familien. Siehe Abschnitt _Geschwister-Mapping_ unten.
+
+## Räume
+
+| # | Name | RoomType | Capacity | Equipment |
+|---|---|---|---|---|
+| 1 | Klassenzimmer 1A | KLASSENZIMMER | 30 | Overheadprojektor |
+| 2 | Klassenzimmer 1B | KLASSENZIMMER | 30 | Overheadprojektor |
+| 3 | Klassenzimmer 1C | KLASSENZIMMER | 30 | Overheadprojektor |
+| 4 | Klassenzimmer 2A | KLASSENZIMMER | 30 | Overheadprojektor |
+| 5 | Klassenzimmer 2B | KLASSENZIMMER | 30 | Overheadprojektor |
+| 6 | Klassenzimmer 2C | KLASSENZIMMER | 30 | Overheadprojektor |
+| 7 | Klassenzimmer 3A | KLASSENZIMMER | 30 | Overheadprojektor |
+| 8 | Klassenzimmer 3B | KLASSENZIMMER | 30 | Overheadprojektor |
+| 9 | Klassenzimmer 3C | KLASSENZIMMER | 30 | Overheadprojektor |
+| 10 | Klassenzimmer 4A | KLASSENZIMMER | 30 | Overheadprojektor |
+| 11 | Klassenzimmer 4B | KLASSENZIMMER | 30 | Overheadprojektor |
+| 12 | Klassenzimmer 4C | KLASSENZIMMER | 30 | Overheadprojektor |
+| 13 | Turnsaal 1 | TURNSAAL | 60 | Sportgeräte |
+| 14 | Turnsaal 2 | TURNSAAL | 60 | Sportgeräte |
+| 15 | Biologiesaal | LABOR | 30 | Overheadprojektor, Mikroskope, Modelle |
+| 16 | Chemiesaal | LABOR | 30 | Overheadprojektor, Abzug, Bunsenbrenner |
+| 17 | Physiksaal | LABOR | 30 | Overheadprojektor, Experimentier-Set, Stromversorgung |
+| 18 | Computersaal 1 | EDV_RAUM | 28 | 28 PCs, Beamer, Whiteboard |
+| 19 | Computersaal 2 | EDV_RAUM | 28 | 28 PCs, Beamer, Whiteboard |
+
+**Heimraum-Zuweisung (`SchoolClass.homeRoomId`)**: 1A→Klassenzimmer 1A, 1B→Klassenzimmer 1B, …, 4C→Klassenzimmer 4C. Klassen verwenden ihren Heimraum für alle Stunden, die nicht explizit einen Fachraum brauchen (BSP→Turnsaal, BU→Biologiesaal, CH→Chemiesaal, PH→Physiksaal, INF→Computersaal).
+
+## Klassen
+
+| # | Name | Stufe (yearLevel) | Heimraum | Klassenvorstand |
+|---|---|---|---|---|
+| 1 | 1A | 5 | Klassenzimmer 1A | `l-d-01` (Maria Huber) |
+| 2 | 1B | 5 | Klassenzimmer 1B | `l-m-01` (Stefan Bauer) |
+| 3 | 1C | 5 | Klassenzimmer 1C | `l-e-01` (Sabine Wagner) |
+| 4 | 2A | 6 | Klassenzimmer 2A | `l-d-02` (Thomas Gruber) |
+| 5 | 2B | 6 | Klassenzimmer 2B | `l-m-02` (Julia Berger) |
+| 6 | 2C | 6 | Klassenzimmer 2C | `l-e-02` (Markus Pichler) |
+| 7 | 3A | 7 | Klassenzimmer 3A | `l-d-03` (Anna Maier) |
+| 8 | 3B | 7 | Klassenzimmer 3B | `l-m-03` (Lukas Hofer) |
+| 9 | 3C | 7 | Klassenzimmer 3C | `l-e-03` (Christina Schwarz) |
+| 10 | 4A | 8 | Klassenzimmer 4A | `l-gw-01` (Peter Lechner) |
+| 11 | 4B | 8 | Klassenzimmer 4B | `l-gs-01` (Eva Reiter) |
+| 12 | 4C | 8 | Klassenzimmer 4C | `l-bu-01` (Manuel Steiner) |
+
+## Fächer + Stundentafel (AHS-Unterstufe)
+
+| Kürzel | Name | SubjectType | Std/Woche pro Klasse | Stufen | Fachraum-Pflicht | Splits |
+|---|---|---|---|---|---|---|
+| D | Deutsch | PFLICHT | 4 | 5–8 | — | — |
+| M | Mathematik | PFLICHT | 4 | 5–8 | — | — |
+| **E** | Englisch | PFLICHT | 4 | 5–8 | — | **2 Sprach-Gruppen (LANGUAGE)** |
+| GW | Geographie und Wirtschaftskunde | PFLICHT | 2 | 5–8 | — | — |
+| GS | Geschichte und Sozialkunde | PFLICHT | 2 | **6–8 only** | — | — |
+| BE | Bildnerische Erziehung | PFLICHT | 2 | 5–8 | — | — |
+| ME | Musikerziehung | PFLICHT | 2 | 5–8 | — | — |
+| BU | Biologie und Umweltkunde | PFLICHT | 2 | 5–8 | Biologiesaal | — |
+| PH | Physik | PFLICHT | 2 | 7–8 | Physiksaal | — |
+| CH | Chemie | PFLICHT | 2 | 8 | Chemiesaal | — |
+| INF | Informatik | PFLICHT | 1 | 5–8 | Computersaal 1/2 | **kein Split** (28 Schüler, 28 PCs) |
+| BSP | Bewegung und Sport | PFLICHT | 4 | 5–8 | Turnsaal 1/2 | — |
+| **RE** | Religion | PFLICHT | 2 | 5–8 | — | **2 Konfessions-Gruppen (RELIGION)** |
+| WE | Werken | PFLICHT | 2 | 5–8 | — | — |
+
+**Stundentafel-Reichweite**:
+- GS erst ab Stufe 6 (1A/B/C bekommen kein GS — entspricht realem AHS-Lehrplan)
+- PH erst ab Stufe 7 (1./2. Klasse kein PH)
+- CH nur Stufe 8 (nur 4A/B/C)
+
+## Unterrichtsgruppen (Group-Splits)
+
+Das Schema modelliert das via `Group` + `GroupMembership` + `ClassSubject.groupId`. Pro (Klasse × Splitter-Fach) gibt es mehrere ClassSubject-Rows, jede mit eigener `groupId`, sodass die Stundenplanung 2 parallele Slots erzeugen kann.
+
+### Englisch-Gruppen (GroupType=LANGUAGE)
+
+Pro Klasse 2 Gruppen, ~50/50-Split:
+
+| Gruppe-Name | Schüler-Anzahl | Schüler-Indexes (in der Klasse) |
+|---|---|---|
+| `E-Gruppe-1` | 14 | Schüler 01–14 |
+| `E-Gruppe-2` | 14 | Schüler 15–28 |
+
+→ 12 Klassen × 2 E-Gruppen = **24 ClassSubject-Rows für E** (statt 12 ohne Split).
+
+Lehrer-Verteilung: Die 3 E-Lehrer (`l-e-01`/`-02`/`-03`) bekommen je 8 Slots = ~24 Wochenstunden (passt zur Standardlehrverpflichtung).
+
+### Religion-Gruppen (GroupType=RELIGION)
+
+Pro Klasse 2 Gruppen, realistisch österreichisch-katholisch dominiert:
+
+| Gruppe-Name | Schüler-Anzahl | Schüler-Indexes (in der Klasse) | Lehrer |
+|---|---|---|---|
+| `RE-katholisch` | 22 | Schüler 01–22 | `l-re-01` (Pater Albrecht) |
+| `RE-evangelisch` | 6 | Schüler 23–28 | `l-re-02` (Hannah Mayrhofer) |
+
+→ 12 Klassen × 2 RE-Gruppen = **24 ClassSubject-Rows für RE**.
+
+Lehrer-Last: `l-re-01` → 12 Klassen × 2 Std = 24 Std (voll). `l-re-02` → 12 Klassen × 2 Std = 24 Std (voll). Beide Lehrer haben kein Zweitfach.
+
+## Lehrer
+
+32 Lehrer + 1 Schulleitung. Jeder Lehrer hat 1–2 Unterrichtsfächer (realistisch für AHS-Unterstufe: Klassenlehrer mit Fachkombi).
+
+| # | KC-Username | Vorname | Nachname | Fächer | Anmerkung |
+|---|---|---|---|---|---|
+| 1 | `l-d-01` | Maria | Huber | D, GS | KV 1A |
+| 2 | `l-d-02` | Thomas | Gruber | D, RE | KV 2A |
+| 3 | `l-d-03` | Anna | Maier | D, E | KV 3A |
+| 4 | `l-m-01` | Stefan | Bauer | M, PH | KV 1B |
+| 5 | `l-m-02` | Julia | Berger | M, INF | KV 2B |
+| 6 | `l-m-03` | Lukas | Hofer | M, CH | KV 3B |
+| 7 | `l-e-01` | Sabine | Wagner | E, BE | KV 1C |
+| 8 | `l-e-02` | Markus | Pichler | E, GW | KV 2C |
+| 9 | `l-e-03` | Christina | Schwarz | E, ME | KV 3C |
+| 10 | `l-gw-01` | Peter | Lechner | GW, GS | KV 4A |
+| 11 | `l-gs-01` | Eva | Reiter | GS, D | KV 4B |
+| 12 | `l-bu-01` | Manuel | Steiner | BU, CH | KV 4C |
+| 13 | `l-be-01` | Sophie | Mayer | BE, WE | — |
+| 14 | `l-be-02` | David | Aigner | BE, ME | — |
+| 15 | `l-me-01` | Lisa | Wolf | ME, RE | — |
+| 16 | `l-me-02` | Andreas | Köhler | ME, D | — |
+| 17 | `l-bu-02` | Katharina | Brunner | BU, PH | — |
+| 18 | `l-ph-01` | Michael | Fischer | PH, M | — |
+| 19 | `l-ph-02` | Sandra | Holzer | PH, INF | — |
+| 20 | `l-ch-01` | Daniel | Weber | CH, BU | — |
+| 21 | `l-inf-01` | Tobias | Hartl | INF, M | — |
+| 22 | `l-inf-02` | Marlene | Eder | INF, PH | — |
+| 23 | `l-bsp-01` | Felix | Riedl | BSP | männlich |
+| 24 | `l-bsp-02` | Christoph | Stadler | BSP | männlich |
+| 25 | `l-bsp-03` | Tanja | Lang | BSP | weiblich |
+| 26 | `l-bsp-04` | Birgit | Köberl | BSP | weiblich |
+| 27 | `l-re-01` | Pater | Albrecht | RE | katholisch |
+| 28 | `l-re-02` | Hannah | Mayrhofer | RE | evangelisch |
+| 29 | `l-we-01` | Roland | Köhler | WE, BE | — |
+| 30 | `l-we-02` | Verena | Wallner | WE, INF | — |
+| 31 | `l-d-04` | Beatrix | Strasser | D, BE | Reserve |
+| 32 | `l-m-04` | Alexander | Linder | M, PH | Reserve |
+| 33 | `schulleitung-01` | Karl-Heinz | Direktor | — | Schulleitung |
+
+## ClassSubject-Zuweisungen
+
+Pro Klasse wird die Stundentafel (siehe oben) angewandt. ClassSubject-Anzahl pro Klasse hängt von Stufe + Splits ab:
+
+| Stufe | Klassen | Fächer | Davon Splits (×2) | ClassSubject-Anzahl pro Klasse |
+|---|---|---|---|---|
+| 5 | 1A/B/C | D, M, E, GW, BE, ME, BU, INF, BSP, RE, WE (kein GS, PH, CH) | E + RE | 11 + 2 = **13** |
+| 6 | 2A/B/C | + GS | E + RE | 12 + 2 = **14** |
+| 7 | 3A/B/C | + GS, PH | E + RE | 13 + 2 = **15** |
+| 8 | 4A/B/C | + GS, PH, CH | E + RE | 14 + 2 = **16** |
+
+**Total ClassSubject-Rows**: 3 × 13 + 3 × 14 + 3 × 15 + 3 × 16 = **174**.
+
+### Lehrer-Zuweisungs-Regeln
+
+1. **Hauptfächer (D, M)**: 3 Lehrer pro Fach, Last 4 Klassen × 4 Std = 16 Std pro Lehrer. Reserve-Lehrer (`l-d-04`, `l-m-04`) für Fülllast und Vertretungen.
+2. **Englisch (E, mit 2 Gruppen pro Klasse)**: 3 Lehrer, 24 Gruppen-Slots → je 8 Slots × 3 Std = 24 Std pro Lehrer (voll).
+3. **Nebenfächer (GW, BE, ME, BU, WE)**: 2 Lehrer pro Fach (`-01`/`-02`), je 6 Klassen × 2 Std = 12 Std (+ Zweitfach).
+4. **GS** (nur ab Stufe 6, 9 Klassen): 2 Lehrer (`l-d-01` als KV-1A mit Zweitfach GS + `l-gs-01`), je 4–5 Klassen × 2 Std.
+5. **PH** (nur ab Stufe 7, 6 Klassen): 2 Lehrer (`l-ph-01`/`l-ph-02`), je 3 Klassen × 2 Std.
+6. **CH** (nur Stufe 8, 3 Klassen): 1 Lehrer (`l-ch-01`), 3 Klassen × 2 Std = 6 Std (+ Zweitfach BU).
+7. **INF**: 2 Lehrer (`l-inf-01`/`l-inf-02`), 12 Klassen × 1 Std = 12 Std verteilt.
+8. **BSP**: 4 Lehrer rotieren über 12 Klassen-Slots × 4 Std = 48 Std → je 12 Std pro Lehrer. KEIN Geschlechter-Split im Demo-Seed (vereinfacht — Koedukation entspricht aktuellem AHS-Standard seit 2007).
+9. **RE** (2 Gruppen pro Klasse): `l-re-01` kath. → alle 12 `RE-katholisch`-ClassSubjects; `l-re-02` evang. → alle 12 `RE-evangelisch`-ClassSubjects.
+10. **Klassenvorstand**: siehe Klassen-Tabelle oben — der KV ist immer einer der Hauptfach-Lehrer dieser Klasse.
+
+Detailliertes Mapping pro (Klasse × Fach × Lehrer × Group) wird beim Seed-Implement deterministisch generiert (Modulo-Index). Final-Zuordnung folgt als Anhang nach Seed-Implementation.
+
+## Schüler
+
+336 Schüler, 28 pro Klasse. Vornamen + Nachnamen aus deterministischen Pools, indiziert via `(klasse, nr)`. Geburtstag-Verteilung: Schulstufe 5 = 2016-Geboren, Stufe 6 = 2015-Geboren, Stufe 7 = 2014-Geboren, Stufe 8 = 2013-Geboren.
+
+### Group-Memberships pro Schüler
+
+Jeder Schüler ist Mitglied in 2 Group-Rows seiner Klasse:
+
+| Splitter-Fach | Schüler-Index 01–14 | Schüler-Index 15–22 | Schüler-Index 23–28 |
+|---|---|---|---|
+| E (LANGUAGE) | `E-Gruppe-1` | `E-Gruppe-2` | `E-Gruppe-2` |
+| RE (RELIGION) | `RE-katholisch` | `RE-katholisch` | `RE-evangelisch` |
+
+→ Schüler 15–22 sind in `E-Gruppe-2` + `RE-katholisch`. Schüler 23–28 sind in `E-Gruppe-2` + `RE-evangelisch`. Vollständig deterministisch.
+
+### Schüler-Vornamen-Pool (deterministisch zyklisch)
+
+Männlich: Anton, Benjamin, Christian, David, Elias, Felix, Georg, Hannes, Ivan, Jakob, Konstantin, Lukas, Maximilian, Nico, Oliver, Paul, Quirin, Richard, Stefan, Tobias, Ulrich, Valentin, Wolfgang, Xaver, Yannick, Zacharias, Andreas, Bernhard, Clemens, Dominik.
+
+Weiblich: Anna, Bianca, Clara, Daniela, Emma, Franziska, Greta, Hanna, Iris, Johanna, Katharina, Lena, Maria, Nina, Olivia, Paula, Rebecca, Sophie, Theresa, Ursula, Valentina, Wilma, Yasmin, Zoe, Amelie, Bernadette, Charlotte, Diana, Elena, Fiona.
+
+### Schüler-Nachnamen-Pool
+
+Aigner, Bauer, Brunner, Eder, Fischer, Gruber, Hofer, Holzer, Huber, Köhler, Köberl, Kogler, Lang, Lechner, Linder, Maier, Mayer, Mayerhofer, Pichler, Reiter, Riedl, Schwarz, Stadler, Steiner, Strasser, Wagner, Wallner, Weber, Wolf, Berger.
+
+### Zuordnung
+
+- Schüler `s-1a-01` bis `s-1a-28`: Vornamen-Pool zyklisch ab Index 0, Nachnamen-Pool zyklisch ab Index 0, Geschlecht alternierend (gerade Nr = m, ungerade = w)
+- Schüler `s-1b-XX` setzt Vornamen-Pool ab Index 28 fort, Nachnamen ab Index 14, etc.
+- StudentNumber: identisch mit KC-Username (`s-1a-01`)
+
+Komplette Schülerliste mit Vorname/Nachname/Geburtsdatum/KC-Username wird beim Seed-Implementation generiert und in einem Anhang dieser Datei dokumentiert.
+
+## Eltern + Geschwister-Mapping
+
+### Familien-Struktur
+
+| Bereich | Familien-IDs | Schüler | Anzahl Familien |
+|---|---|---|---|
+| Einzelkind-Familien | 001–286 | je 1 Schüler | 286 |
+| Geschwisterpaar-Familien | 287–311 | je 2 Schüler | 25 |
+
+**Geschwister-Verteilung** (25 Paare, ~15% von 336): Geschwisterpaare werden zufällig über die 12 Klassen verteilt, immer in unterschiedlichen Klassenstufen (realistisch).
+
+Beispiel-Mapping (deterministisch):
+- Familie 287: `s-1a-15` + `s-3a-08`
+- Familie 288: `s-1a-22` + `s-4b-11`
+- Familie 289: `s-1b-04` + `s-2c-19`
+- … (volles Mapping wird beim Seed-Implement generiert + hier dokumentiert)
+
+### Eltern-Accounts
+
+Pro Familie 2 Eltern: `e-fam-{nnn}-a` (Mutter) + `e-fam-{nnn}-b` (Vater). Beide haben:
+- KC-Account mit Passwort `Demo1234!`
+- Person.personType = `PARENT`
+- Parent-Row mit `children` = alle Student-Rows der Familie (1 oder 2 Kinder)
+
+Eltern-Vornamen aus dedupliziertem Pool: Maria/Stefan, Andrea/Thomas, Sabine/Markus, Christina/Peter, Eva/Manuel, Sophia/David, Lisa/Andreas, Katharina/Michael, Sandra/Daniel, Marlene/Tobias, Birgit/Christoph, Tanja/Felix, Hannah/Roland, Verena/Alexander, Beatrix/Karl-Heinz, … (Pool zyklisch verlängert).
+
+Eltern-Nachname = Nachname des/der Kinder.
+
+### Geschwister-Detection (Tests / UI)
+
+E2E-Specs können sich darauf verlassen, dass:
+- `e-fam-287-a` und `e-fam-287-b` jeweils 2 `parentStudent`-Beziehungen haben
+- `s-1a-15` und `s-3a-08` denselben `parentId`-Set haben → Multi-Child-Filter im Eltern-Stundenplan ist abdeckbar
+- Family-IDs 287–311 sind die kanonische Geschwister-Whitelist
+
+## Login-Credentials (Zusammenfassung)
+
+| Rolle | KC-Username-Pattern | Passwort | Anzahl |
+|---|---|---|---|
+| Admin | `admin` | (Legacy aus `realm-export.json`) | 1 |
+| Schulleitung | `schulleitung-01` | `Demo1234!` | 1 |
+| Lehrer | `l-{fach}-{nr}` | `Demo1234!` | 32 |
+| Schüler | `s-{stufe}{klasse}-{nr}` | `Demo1234!` | 336 |
+| Eltern | `e-fam-{nnn}-{a,b}` | `Demo1234!` | 622 |
+| Legacy-Test-User | `kc-admin/lehrer/schulleitung/eltern/schueler` | (unverändert) | 5 |
+| **Gesamt** | — | — | **~997** |
+
+## Backward-Compatibility (Hard Rule)
+
+**Die 5 Legacy-Seed-User bleiben unverändert:**
+- `kc-admin` (UUID `e0000000-0000-4000-8000-000000000001`)
+- `kc-schulleitung` (UUID `e0000000-0000-4000-8000-000000000002`)
+- `kc-lehrer` (UUID `10000000-0000-4000-8000-000000000001`)
+- `kc-eltern` (UUID `d0000000-0000-4000-8000-000000000005`)
+- `kc-schueler` (UUID `d0000000-0000-4000-8000-000000000004`)
+
+Diese sind hardcoded in `apps/web/e2e/fixtures/seed-uuids.ts` und in zig E2E-Spec-Helpers. Sie MÜSSEN als zusätzliche User UNVERÄNDERT im Realm-Export bleiben. Die Bulk-Demo-User leben PARALLEL daneben in derselben Demo-School.
+
+## Schul-Setup
+
+- **School.name**: `SchoolFlow Demo-Gymnasium`
+- **School.schoolType**: `AHS`
+- **School.abWeekEnabled**: `false`
+- **SchoolYear**: 1 aktives Jahr `2026/2027`, isActive=true, startDate 2026-09-01, semesterBreak 2027-02-01, endDate 2027-06-30
+- **SchoolDay**: Montag–Freitag isActive=true (Samstag/Sonntag inaktiv)
+- **TimeGrid**: 8 Stunden á 50 Min, beginnend 07:50 Uhr, Pausen nach 2./4./6. Stunde (5 Min, 10 Min, 15 Min)
+
+## TeacherAbsence (Demo-Krank-Meldungen)
+
+3 zukünftige TeacherAbsence-Rows damit die Vertretungs-UI auf `/admin/substitutions` echte Daten zum Anzeigen hat:
+
+| # | Lehrer | Zeitraum | Reason | Affected (nach Solver-Run) |
+|---|---|---|---|---|
+| 1 | `l-d-02` (Thomas Gruber, KV 2A) | nächster Montag–Mittwoch (3 Tage) | KRANK | D + RE-Lessons dieser Tage |
+| 2 | `l-m-03` (Lukas Hofer, KV 3B) | übermorgen (1 Tag) | KRANK | M + CH-Lessons dieses Tages |
+| 3 | `l-bsp-01` (Felix Riedl) | in 14 Tagen Montag–Freitag (5 Tage) | KRANK | BSP-Lessons aller dieser Tage |
+
+**Datums-Logik**: Die Daten werden zum Seed-Zeitpunkt relativ zu `new Date()` berechnet — z.B. `nextMondayISODate()` (analog dem E2E-Helper). Das hält die Daten "immer in der Zukunft" über mehrere Re-Seeds hinweg.
+
+**Wichtige Einschränkung**: TeacherAbsence ohne `TimetableLesson` erzeugt keine sichtbaren `Substitution`-Rows — die Substitution-Expansion in `teacher-absence.service.ts:138` matched gegen `TimetableLesson` über `(runId, teacherId, dayOfWeek)`. Da der Seed keinen vorgenerierten Stundenplan anlegt (siehe nächster Abschnitt), wird die Vertretungs-UI die Absences erst zeigen, nachdem ein Admin lokal den Solver getriggert hat.
+
+→ Für Demos die direkt mit Vertretungen experimentieren wollen: Solver-Run via `POST /timetable/solve` als ersten Schritt, dann sind die Substitutions sichtbar.
+
+## Was NICHT Teil des Seeds ist
+
+- **TimetableRun + TimetableLesson**: Stundenplan wird NICHT vorgenerier­t. Der Solver kann lokal getriggert werden (`POST /timetable/solve`) und produziert auf Basis der Stundentafel + Räume + Lehrer einen Run. Pre-generierter Stundenplan wäre Fragile-by-Design (Solver-Output ist nicht deterministisch über Versionen).
+- **ConstraintWeightOverrides**: Defaults aus den ConstraintTemplates bleiben aktiv.
+- **AuditEntries**: leer, werden zur Runtime erzeugt.
+- **DSGVO-Entries**: keine.
+
+## Implementation-Hints für den Seed
+
+- **Idempotenz**: Seed muss `upsert`-basiert sein. Erneutes `prisma:seed` darf nicht duplizieren.
+- **Reihenfolge**: School → SchoolYear → Rooms → SchoolDays → TimeGrid → Roles+Permissions → KC-User-Resolution → Persons (alle Rollen) → Teachers → Students+Parents+ParentStudent → SchoolClasses (mit Klassenvorstand + Heimraum) → Subjects → ClassSubjects (mit Lehrer-Zuweisung).
+- **KC-UUID-Generierung**: Bulk-User bekommen deterministische UUIDs aus einem Hash der Username (z.B. `uuidv5('schoolflow.demo', username)`), damit Re-Seed identische IDs erzeugt.
+- **Realm-Export**: `docker/keycloak/realm-export.json` wird programmatisch erweitert. Eine `scripts/generate-bulk-users.ts` (oder ähnlich) erzeugt die KC-User-Block-JSON aus dieser Spec — der Seed-Code in `seed.ts` referenziert dieselbe Generator-Logik für Person-Anlage.
+- **Performance**: ~1000 User × KC-Import kann 30–60s dauern. Acceptable; Demo-Seed läuft nicht in jedem CI-Lauf (CI verwendet `db:e2e:reset` → seed → throwaway-Schulen für eigene Tests).
+
+## Entscheidungen aus dem Review
+
+| # | Frage | Entscheidung |
+|---|---|---|
+| 1 | GS-Stundentafel-Reichweite? | **GS nur ab Stufe 6** (realistisch) — 1A/B/C haben kein GS |
+| 2 | Religion-Splits? | **Ja** — `RE-katholisch` + `RE-evangelisch` pro Klasse als 2 Group-Rows (GroupType=RELIGION) |
+| 3 | Sprachen-Splits? | **Ja** — `E-Gruppe-1` + `E-Gruppe-2` pro Klasse als 2 Group-Rows (GroupType=LANGUAGE) |
+| 4 | INF-Splits? | **Nein** — alle 28 Schüler in einem Computersaal-Slot, kein Split |
+| 5 | TeacherAbsence-Beispiele? | **Ja** — 3 zukünftige Krank-Meldungen (siehe Sektion oben) |


### PR DESCRIPTION
Closes #175

## Summary

- testdaten.md (Spec) — Single source of truth für die Demo-Datenmenge (bereits in vorigem Commit von #175 gemerged)
- `apps/api/prisma/seed-data.ts` — deterministisches Daten-Modul (UUID-Schema, Name-Pools, Family-Mapping mit 25 Geschwisterpaaren, Group-Memberships, ClassSubject-Generator)
- `scripts/generate-realm-users.ts` — idempotenter Regenerator für den `users[]`-Block in `docker/keycloak/realm-export.json` (Marker `attributes.managed_by_seed=["175"]`)
- `docker/keycloak/realm-export.json` — 996 neue Bulk-User (5 parallel-kc-* Mirror + 1 schulleitung-01 + 32 lehrer + 336 schüler + 622 eltern), Demo-Passwort `Demo1234!`
- `apps/api/prisma/seed.ts` — neue Section 175 hängt das demo-spezifische Setup ans Ende von `main()`. Schule heißt jetzt `SchoolFlow Demo-Gymnasium`

## Lokale Verifikation (gegen frischen Stack)

```
scripts/dev-down.sh --infra && docker volume rm docker_keycloak_db_data docker_postgres_data && scripts/dev-up.sh
```

DB-Counts nach Seed (1. + 2. Run identisch — Idempotenz bestätigt):

| Table | Count | Aufteilung |
|---|---|---|
| persons | 1011 | 5 legacy KC + 5 parallel kc-* + 3 legacy lehrer + 7 legacy schüler + 1 schulleitung-01 + 32 bulk lehrer + 336 schüler + 622 eltern |
| students | 345 | 6 legacy + 1 KC-schueler + 1 kc-schueler-parallel + 1 archived + 336 bulk |
| teachers | 41 | 3 legacy + 3 KC-linked + 3 parallel-kc-* (admin/lehrer/schulleitung) + 1 schulleitung-01 + 32 bulk |
| parents | 624 | 1 KC-eltern + 1 kc-eltern-parallel + 622 bulk |
| rooms | 25 | 6 legacy + 19 neu |
| subjects | 14 | 4 legacy (D/M/E/BSP slug-ids) + 10 neu |
| school_classes | 12 | 1A/1B (slug-ids, updated) + 2A-4C (neu) |
| class_subjects | 174 | Stundentafel exakt nach Spec (24 E mit LANGUAGE-Splits, 24 RE mit RELIGION-Splits) |
| groups | 48 | 12 Klassen × 4 Gruppen (E-1, E-2, RE-katholisch, RE-evangelisch) |
| group_memberships | 672 | 12 × 28 × 2 |
| teacher_absences | 3 | nächster Montag (3d), übermorgen (1d), in 14d Mo-Fr (5d) |
| parent_students | 673 | 1 legacy + 672 bulk (286 Single-Familien × 2 Eltern + 25 Geschwisterpaare × 2 Kinder × 2 Eltern) |

Login-Test (alle 5 mit `Demo1234!` erfolgreich):
- `s-1a-01` / Demo1234! → /users/me liefert Anna Aigner (STUDENT, classId=seed-class-1a)
- `l-d-01` / Demo1234! → /users/me liefert Maria Huber (TEACHER)
- `e-fam-001-a` / Demo1234!
- `schulleitung-01` / Demo1234!
- `kc-admin` (Parallel-Mirror) / Demo1234!

## Sanity-Tests

19 vitest checks in `apps/api/prisma/__tests__/seed-data.spec.ts`:
- Counts (336/311/32/19/14/12)
- UUID-Eindeutigkeit über KC-, Person- und Room-Domain
- Family-Integrität (jeder Schüler in genau einer Familie, Geschwister teilen Nachname + sind in unterschiedlichen Stufen)
- ClassSubject-Math (174 total, 24 E mit LANGUAGE, 24 RE mit RELIGION-Splits + korrekte kath/evang. Lehrer, GS erst ab Stufe 6, CH nur in Stufe 8)

Volle API-Suite weiter grün: 795 passed / 65 todo / 7 skipped.

## Backward-Compat

- 5 echte Legacy-KC-User (`admin-user`/`lehrer-user`/`eltern-user`/`schueler-user`/`schulleitung-user` mit UUIDs `00000000-0000-0000-0000-00000000000{1..5}`) bleiben in `realm-export.json` UNVERÄNDERT — alle E2E-Specs in `apps/web/e2e/helpers/login.ts` funktionieren weiter.
- `service-account-schoolflow-admin-api` ebenfalls unverändert.
- 7 SEED_*_UUID Konstanten in `apps/web/e2e/fixtures/seed-uuids.ts` bleiben gültig (alle DB-Records existieren weiter).
- Klassen 1A/1B behalten Slug-IDs (`seed-class-1a`/`seed-class-1b`); Subjects D/M/E/BSP behalten Slug-IDs (`seed-subject-{d,m,e,bsp}`); Räume 1-6 behalten ihre `30000000-*` UUIDs.

## Test plan

- [ ] CI grün durch (KC-Container muss 996 neue User beim Realm-Import schlucken — Realm-File 538 KB statt 50 KB)
- [ ] `apps/web` E2E-Suite läuft durch (alle Specs nutzen throwaway-school, sollten nicht betroffen sein)

## Bekannte Follow-ups (nicht in dieser PR)

- `apps/api/prisma/seed.ts` `resolveKeycloakUserIds()` lädt KC-User mit `?max=100`. Mit 1000+ Usern im Realm fallen die 5 Legacy-Usernames aus dem Fenster und werden auf den hardcodierten Fallback gemapped — funktional fine (UUIDs matchen realm-export.json exakt), aber das Self-Heal-Verhalten ist effektiv deaktiviert. Issue zum Refactor auf per-username `?username=admin-user` Search-Query folgt separat.
- KC-Healthcheck in CI: mit 538 KB Realm dauert der Import ~5-15s länger als zuvor. Falls CI-Timeout bricht → Healthcheck-Timeout in docker-compose hochziehen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)