### PR TITLE
feat(timetable): #179 — soft-persist solver results with COMPLETED_WITH_CONFLICTS (Pattern B of #177)

### DIFF
--- a/apps/api/prisma/migrations/20260604073426_add_timetable_conflict_and_status/migration.sql
+++ b/apps/api/prisma/migrations/20260604073426_add_timetable_conflict_and_status/migration.sql
@@ -1,0 +1,34 @@
+-- AlterEnum
+ALTER TYPE "SolveStatus" ADD VALUE 'COMPLETED_WITH_CONFLICTS';
+
+-- CreateTable
+CREATE TABLE "timetable_conflicts" (
+    "id" TEXT NOT NULL,
+    "run_id" TEXT NOT NULL,
+    "conflict_type" TEXT NOT NULL,
+    "class_subject_id" TEXT NOT NULL,
+    "teacher_id" TEXT NOT NULL,
+    "room_id" TEXT NOT NULL,
+    "day_of_week" "DayOfWeek" NOT NULL,
+    "period_number" INTEGER NOT NULL,
+    "week_type" TEXT NOT NULL DEFAULT 'BOTH',
+    "conflicts_with_class_subject_id" TEXT,
+    "teacher_label" TEXT,
+    "subject_label" TEXT,
+    "class_label" TEXT,
+    "room_label" TEXT,
+    "conflicts_with_label" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'OPEN',
+    "resolution_action" TEXT,
+    "resolved_by" TEXT,
+    "resolved_at" TIMESTAMP(3),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "timetable_conflicts_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "timetable_conflicts_run_id_idx" ON "timetable_conflicts"("run_id");
+
+-- AddForeignKey
+ALTER TABLE "timetable_conflicts" ADD CONSTRAINT "timetable_conflicts_run_id_fkey" FOREIGN KEY ("run_id") REFERENCES "timetable_runs"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -721,6 +721,12 @@ enum SolveStatus {
   QUEUED
   SOLVING
   COMPLETED
+  // Issue #177-B: the solver returned a usable plan, but one or more lessons
+  // could not be persisted without violating the teacher/room slot-uniqueness
+  // (residual hardScore<0). The non-conflicting lessons ARE persisted and the
+  // run is activatable as a partial plan; the dropped lessons are recorded as
+  // TimetableConflict rows for manual resolution (#177-C).
+  COMPLETED_WITH_CONFLICTS
   FAILED
   STOPPED
 }
@@ -767,10 +773,62 @@ model TimetableRun {
   createdAt        DateTime    @default(now()) @map("created_at")
   updatedAt        DateTime    @updatedAt @map("updated_at")
 
-  lessons TimetableLesson[]
+  lessons   TimetableLesson[]
+  conflicts TimetableConflict[]
 
   @@index([schoolId, createdAt])
   @@map("timetable_runs")
+}
+
+// --- TimetableConflict (Issue #177-B) ---
+//
+// A lesson the solver placed but that could NOT be persisted into
+// TimetableLesson without violating one of its slot-uniqueness constraints
+// (teacher or room double-booked in the same day/period/weekType). The
+// solver tolerates a residual hardScore<0 internally; the DB does not. Rather
+// than failing the whole run, handleCompletion persists every non-conflicting
+// lesson and records the dropped ones here so the admin sees exactly WHICH
+// teacher/room is double-booked and can resolve it manually (#177-C).
+//
+// Display labels are denormalized at persist time so the conflict UI renders
+// without re-joining ClassSubject/Teacher/Subject/Room. status/resolved* track
+// the manual-resolution lifecycle consumed by #177-C.
+model TimetableConflict {
+  id           String       @id @default(uuid())
+  runId        String       @map("run_id")
+  run          TimetableRun @relation(fields: [runId], references: [id], onDelete: Cascade)
+
+  // 'TEACHER' | 'ROOM' — which slot-uniqueness the dropped lesson would break.
+  conflictType String @map("conflict_type")
+
+  // The dropped lesson's intended placement (same shape as TimetableLesson).
+  classSubjectId String    @map("class_subject_id")
+  teacherId      String    @map("teacher_id")
+  roomId         String    @map("room_id")
+  dayOfWeek      DayOfWeek  @map("day_of_week")
+  periodNumber   Int        @map("period_number")
+  weekType       String     @default("BOTH") @map("week_type")
+
+  // The classSubject of the ACCEPTED lesson it collides with (context for #177-C).
+  conflictsWithClassSubjectId String? @map("conflicts_with_class_subject_id")
+
+  // Denormalized, human-readable labels resolved at persist time.
+  teacherLabel      String? @map("teacher_label")
+  subjectLabel      String? @map("subject_label")
+  classLabel        String? @map("class_label")
+  roomLabel         String? @map("room_label")
+  conflictsWithLabel String? @map("conflicts_with_label")
+
+  // Resolution lifecycle (#177-C). status: 'OPEN' | 'RESOLVED'.
+  status           String    @default("OPEN")
+  resolutionAction String?   @map("resolution_action")
+  resolvedBy       String?   @map("resolved_by")
+  resolvedAt       DateTime? @map("resolved_at")
+
+  createdAt DateTime @default(now()) @map("created_at")
+
+  @@index([runId])
+  @@map("timetable_conflicts")
 }
 
 // --- TimetableLesson (solved lesson assignment) ---

--- a/apps/api/src/modules/timetable/timetable.controller.ts
+++ b/apps/api/src/modules/timetable/timetable.controller.ts
@@ -116,6 +116,24 @@ export class TimetableController {
     return this.timetableService.getViolations(runId);
   }
 
+  /**
+   * GET /api/v1/schools/:schoolId/timetable/runs/:runId/conflicts
+   * Issue #177-B: lists the lessons dropped during persistence because they
+   * would break the teacher/room slot-uniqueness (the actionable conflicts
+   * behind a COMPLETED_WITH_CONFLICTS run). Foundation for the manual
+   * resolution UX (#177-C).
+   *
+   * Response: TimetableConflict[] (denormalized labels included).
+   */
+  @Get('runs/:runId/conflicts')
+  @CheckPermissions({ action: 'read', subject: 'timetable' })
+  @ApiOperation({ summary: 'Get unpersistable slot conflicts for a solve run' })
+  @ApiResponse({ status: 200, description: 'Timetable conflicts' })
+  @ApiResponse({ status: 404, description: 'Run not found' })
+  async getConflicts(@Param('runId') runId: string) {
+    return this.timetableService.getConflicts(runId);
+  }
+
   @Delete('runs/:runId/stop')
   @HttpCode(HttpStatus.OK)
   @CheckPermissions({ action: 'update', subject: 'timetable' })

--- a/apps/api/src/modules/timetable/timetable.service.spec.ts
+++ b/apps/api/src/modules/timetable/timetable.service.spec.ts
@@ -60,17 +60,26 @@ describe('TimetableService', () => {
       // returns 6 (matches the seed-school count); the no-rooms spec
       // overrides to 0.
       count: vi.fn().mockResolvedValue(6),
+      // #177-B: handleCompletion resolves room names for conflict labels.
+      findMany: vi.fn().mockResolvedValue([]),
     },
     timetableRun: {
       create: vi.fn().mockResolvedValue(mockRun),
       findMany: vi.fn().mockResolvedValue(mockRuns),
       findUnique: vi.fn().mockResolvedValue({ ...mockRun, lessons: [] }),
+      findUniqueOrThrow: vi.fn().mockResolvedValue(mockRun),
       update: vi.fn().mockResolvedValue(mockRun),
       updateMany: vi.fn().mockResolvedValue({ count: 3 }),
       deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
     },
     timetableLesson: {
       createMany: vi.fn().mockResolvedValue({ count: 5 }),
+    },
+    // #177-B: handleCompletion records dropped lessons here when the solver
+    // returns a residual slot-conflict. Default mock no-ops.
+    timetableConflict: {
+      createMany: vi.fn().mockResolvedValue({ count: 0 }),
+      findMany: vi.fn().mockResolvedValue([]),
     },
     // Issue #72: handleCompletion now resolves classSubject.teacherId
     // through a single batch query before INSERT. Default mock returns
@@ -299,7 +308,14 @@ describe('TimetableService', () => {
             weekType: 'BOTH',
           }),
         ]),
+        // #177-B: idempotent insert (partition guarantees uniqueness, but a
+        // duplicate sidecar callback must not throw).
+        skipDuplicates: true,
       });
+      // No conflicts on a clean (hardScore=0) result.
+      expect(
+        prismaService.timetableConflict.createMany,
+      ).not.toHaveBeenCalled();
     });
 
     it('should not create lessons when none returned', async () => {
@@ -318,13 +334,15 @@ describe('TimetableService', () => {
       expect(prismaService.timetableLesson.createMany).not.toHaveBeenCalled();
     });
 
-    // Regression for issue #175 demo-seed bug: solver returns near-optimal
-    // result (hardScore=-1) that satisfies its internal teacherConflict model
-    // but trips the strict DB @@unique([runId, teacherId, dayOfWeek,
-    // periodNumber, weekType]). Pre-fix: createMany threw → run record was
-    // already updated to COMPLETED → admin activated an empty timetable.
-    // Post-fix: catch + flip run to FAILED + record errorReason.
-    it('should mark run FAILED + record errorReason when createMany trips a DB unique-constraint', async () => {
+    // Regression for issue #177-B (supersedes the #175 "→ FAILED" behaviour):
+    // the solver returns a near-optimal result (hardScore=-1) where two lessons
+    // share the same (teacher, day, period, weekType) — fine in its internal
+    // model, but the DB @@unique([runId, teacherId, dayOfWeek, periodNumber,
+    // weekType]) rejects the second. Pre-#177 the whole createMany was flipped
+    // to FAILED, blocking the admin. Post-#177: the non-conflicting lesson IS
+    // persisted, the dropped one is recorded as a TimetableConflict, and the
+    // run becomes COMPLETED_WITH_CONFLICTS (activatable as a partial plan).
+    it('should soft-persist + record a TEACHER conflict on a residual slot clash', async () => {
       const result: SolveResultDto = {
         runId: 'run-1',
         status: 'COMPLETED',
@@ -341,8 +359,9 @@ describe('TimetableService', () => {
             weekType: 'BOTH',
           },
           {
-            // same teacher (cs-1 → teacher-1), same slot → DB rejects
-            lessonId: 'cs-1-1-BOTH',
+            // cs-2 is taught by the SAME teacher in the SAME slot → the second
+            // lesson cannot be persisted without a teacher double-booking.
+            lessonId: 'cs-2-0-BOTH',
             timeslotId: 'ts-1',
             roomId: 'room-2',
             dayOfWeek: 'MONDAY',
@@ -353,29 +372,126 @@ describe('TimetableService', () => {
         violations: [],
       };
 
-      // Reset the createMany mock from beforeEach (defaults to resolved) and
-      // make it throw the Prisma unique-constraint error verbatim.
-      prismaService.timetableLesson.createMany.mockRejectedValueOnce(
-        new Error(
-          'Unique constraint failed on the fields: (`run_id`, `teacher_id`, `day_of_week`, `period_number`, `week_type`)',
-        ),
+      // Both ClassSubjects resolve to teacher-1 → real teacher double-book.
+      prismaService.classSubject.findMany.mockResolvedValueOnce([
+        {
+          id: 'cs-1',
+          teacherId: 'teacher-1',
+          subject: { name: 'Mathematik', shortName: 'M' },
+          schoolClass: { name: '3a' },
+          teacher: { person: { lastName: 'Müller', firstName: 'Anna' } },
+        },
+        {
+          id: 'cs-2',
+          teacherId: 'teacher-1',
+          subject: { name: 'Physik', shortName: 'PH' },
+          schoolClass: { name: '3b' },
+          teacher: { person: { lastName: 'Müller', firstName: 'Anna' } },
+        },
+      ]);
+      prismaService.room.findMany.mockResolvedValueOnce([
+        { id: 'room-1', name: 'R1' },
+        { id: 'room-2', name: 'R2' },
+      ]);
+
+      await expect(
+        service.handleCompletion('run-1', result),
+      ).resolves.toBeUndefined();
+
+      // Only the conflict-free lesson (cs-1) is persisted.
+      expect(prismaService.timetableLesson.createMany).toHaveBeenCalledTimes(1);
+      const lessonArg = (prismaService.timetableLesson.createMany as any).mock
+        .calls[0][0];
+      expect(lessonArg.data).toHaveLength(1);
+      expect(lessonArg.data[0]).toMatchObject({
+        classSubjectId: 'cs-1',
+        teacherId: 'teacher-1',
+        periodNumber: 1,
+      });
+
+      // The dropped lesson is recorded as a TEACHER conflict with labels.
+      expect(prismaService.timetableConflict.createMany).toHaveBeenCalledTimes(
+        1,
       );
-      // Suppress the expected error log so vitest output stays clean.
+      const conflictArg = (prismaService.timetableConflict.createMany as any)
+        .mock.calls[0][0];
+      expect(conflictArg.data).toHaveLength(1);
+      expect(conflictArg.data[0]).toMatchObject({
+        runId: 'run-1',
+        conflictType: 'TEACHER',
+        classSubjectId: 'cs-2',
+        teacherId: 'teacher-1',
+        roomId: 'room-2',
+        dayOfWeek: 'MONDAY',
+        periodNumber: 1,
+        weekType: 'BOTH',
+        conflictsWithClassSubjectId: 'cs-1',
+        teacherLabel: 'Müller',
+        subjectLabel: 'Physik 3b',
+        classLabel: '3b',
+        roomLabel: 'R2',
+        conflictsWithLabel: 'Mathematik 3a',
+      });
+
+      // Run downgraded to COMPLETED_WITH_CONFLICTS + kept inactive.
+      const updateCalls = (prismaService.timetableRun.update as any).mock.calls;
+      const conflictUpdate = updateCalls.find(
+        ([arg]: [{ data: { status?: string } }]) =>
+          arg.data.status === 'COMPLETED_WITH_CONFLICTS',
+      );
+      expect(
+        conflictUpdate,
+        'expected an update to COMPLETED_WITH_CONFLICTS',
+      ).toBeDefined();
+      expect(conflictUpdate[0]).toMatchObject({
+        where: { id: 'run-1' },
+        data: { status: 'COMPLETED_WITH_CONFLICTS', isActive: false },
+      });
+    });
+
+    // The try/catch → FAILED fallback still guards UNEXPECTED DB errors (not a
+    // slot clash — those are partitioned out before the insert). A clean result
+    // whose createMany throws an unrelated error must flip the run to FAILED.
+    it('should flip run to FAILED when createMany throws an unexpected DB error', async () => {
+      const result: SolveResultDto = {
+        runId: 'run-1',
+        status: 'COMPLETED',
+        hardScore: 0,
+        softScore: -8,
+        elapsedSeconds: 120,
+        lessons: [
+          {
+            lessonId: 'cs-1-0-BOTH',
+            timeslotId: 'ts-1',
+            roomId: 'room-1',
+            dayOfWeek: 'MONDAY',
+            periodNumber: 1,
+            weekType: 'BOTH',
+          },
+        ],
+        violations: [],
+      };
+
+      prismaService.timetableLesson.createMany.mockRejectedValueOnce(
+        new Error('connection terminated unexpectedly'),
+      );
       const errSpy = vi
         .spyOn(service['logger'], 'error')
         .mockImplementation(() => undefined);
 
-      // Must NOT throw — the controller would otherwise return 500 to the
-      // solver-sidecar which retries the same failing payload.
-      await expect(service.handleCompletion('run-1', result)).resolves.toBeUndefined();
+      await expect(
+        service.handleCompletion('run-1', result),
+      ).resolves.toBeUndefined();
 
-      // First update: solver result with status=COMPLETED.
-      // Second update: failure remediation with FAILED + isActive=false + errorReason.
       const updateCalls = (prismaService.timetableRun.update as any).mock.calls;
       const failedUpdate = updateCalls.find(
-        ([arg]: [{ data: { status?: string } }]) => arg.data.status === 'FAILED',
+        ([arg]: [{ data: { status?: string } }]) =>
+          arg.data.status === 'FAILED',
       );
-      expect(failedUpdate, 'expected a second timetableRun.update with status=FAILED').toBeDefined();
+      expect(
+        failedUpdate,
+        'expected an update with status=FAILED',
+      ).toBeDefined();
       expect(failedUpdate[0]).toMatchObject({
         where: { id: 'run-1' },
         data: {
@@ -384,8 +500,40 @@ describe('TimetableService', () => {
           errorReason: expect.stringContaining('Lesson persistence failed'),
         },
       });
+      // No conflict rows recorded on an unexpected failure.
+      expect(
+        prismaService.timetableConflict.createMany,
+      ).not.toHaveBeenCalled();
 
       errSpy.mockRestore();
+    });
+  });
+
+  describe('getConflicts', () => {
+    it('should return the run conflicts ordered oldest-first', async () => {
+      const rows = [
+        { id: 'conf-1', runId: 'run-1', conflictType: 'TEACHER' },
+        { id: 'conf-2', runId: 'run-1', conflictType: 'ROOM' },
+      ];
+      prismaService.timetableConflict.findMany.mockResolvedValueOnce(rows);
+
+      const result = await service.getConflicts('run-1');
+
+      expect(result).toEqual(rows);
+      expect(
+        prismaService.timetableRun.findUniqueOrThrow,
+      ).toHaveBeenCalledWith({ where: { id: 'run-1' }, select: { id: true } });
+      expect(prismaService.timetableConflict.findMany).toHaveBeenCalledWith({
+        where: { runId: 'run-1' },
+        orderBy: { createdAt: 'asc' },
+      });
+    });
+
+    it('should propagate NotFound when the run does not exist', async () => {
+      prismaService.timetableRun.findUniqueOrThrow.mockRejectedValueOnce(
+        new Error('No TimetableRun found'),
+      );
+      await expect(service.getConflicts('missing')).rejects.toThrow();
     });
   });
 
@@ -424,6 +572,7 @@ describe('TimetableService', () => {
         where: { schoolId: 'school-1' },
         orderBy: { createdAt: 'desc' },
         take: 3,
+        include: { _count: { select: { conflicts: true } } },
       });
     });
   });

--- a/apps/api/src/modules/timetable/timetable.service.ts
+++ b/apps/api/src/modules/timetable/timetable.service.ts
@@ -154,124 +154,234 @@ export class TimetableService {
       },
     });
 
-    // Persist lesson assignments.
-    //
-    // The lessonId carries the source ClassSubject id plus an index and the
-    // weekType variant:
-    //
-    //   `${classSubjectId}-${i}-${weekType}`
-    //
-    // where weekType ∈ {BOTH, A, B}. The legacy parser (Phase 14) called
-    // `lastIndexOf('-')` and dropped only the index suffix, which broke when
-    // Issue #72 introduced the trailing `-${weekType}` segment — the prefix
-    // produced was `${classSubjectId}-${i}` and the FK-less classSubjectId
-    // column got polluted with non-existent ids. The regex below pins the
-    // expected suffix shape explicitly.
-    //
-    // Issue #71 follow-up: also fetch the assigned teacherId from the
-    // ClassSubject record so persisted TimetableLessons carry a real
-    // teacher reference instead of the legacy hardcoded ''. The solver
-    // already respects the assignment for conflict + availability; this
-    // line is what surfaces it in the /timetable UI.
-    if (result.lessons && result.lessons.length > 0) {
-      const lessonIdRegex = /^(.+)-(\d+)-(BOTH|A|B)$/;
-      const parsed = result.lessons
-        .map((lesson: SolvedLessonDto) => {
-          const match = lesson.lessonId.match(lessonIdRegex);
-          if (!match) {
-            this.logger.error(
-              `Unparseable lessonId from solver, skipping: ${lesson.lessonId}`,
-            );
-            return null;
-          }
-          return {
-            lesson,
-            classSubjectId: match[1],
-          };
-        })
-        .filter(
-          (
-            entry,
-          ): entry is { lesson: SolvedLessonDto; classSubjectId: string } =>
-            entry !== null,
-        );
+    // No lessons to persist (solver FAILED / empty result) — nothing else to do.
+    if (!result.lessons || result.lessons.length === 0) {
+      return;
+    }
 
-      if (parsed.length < result.lessons.length) {
-        this.logger.warn(
-          `Skipped ${
-            result.lessons.length - parsed.length
-          } lessons with unparseable ids (run ${runId})`,
-        );
-      }
-
-      // Resolve teacherIds in a single query keyed by the parsed
-      // classSubjectIds. Subjects without an assigned teacher fall back to
-      // '' so the NOT-NULL teacher_id column stays satisfied (legacy
-      // behaviour pre-#71/#72).
-      const csIds = Array.from(new Set(parsed.map((p) => p.classSubjectId)));
-      const csRows = await this.prisma.classSubject.findMany({
-        where: { id: { in: csIds } },
-        select: { id: true, teacherId: true },
-      });
-      const teacherByCs = new Map(
-        csRows.map((cs) => [cs.id, cs.teacherId ?? '']),
+    // Parse lessonIds. Each carries the source ClassSubject id plus an index
+    // and the weekType variant:
+    //
+    //   `${classSubjectId}-${i}-${weekType}`   weekType ∈ {BOTH, A, B}
+    //
+    // The legacy parser (Phase 14) called `lastIndexOf('-')` and dropped only
+    // the index suffix, which broke when Issue #72 introduced the trailing
+    // `-${weekType}` segment. The regex below pins the expected suffix shape.
+    const lessonIdRegex = /^(.+)-(\d+)-(BOTH|A|B)$/;
+    const parsed = result.lessons
+      .map((lesson: SolvedLessonDto) => {
+        const match = lesson.lessonId.match(lessonIdRegex);
+        if (!match) {
+          this.logger.error(
+            `Unparseable lessonId from solver, skipping: ${lesson.lessonId}`,
+          );
+          return null;
+        }
+        return { lesson, classSubjectId: match[1] };
+      })
+      .filter(
+        (
+          entry,
+        ): entry is { lesson: SolvedLessonDto; classSubjectId: string } =>
+          entry !== null,
       );
 
-      const lessonRecords = parsed.map(({ lesson, classSubjectId }) => ({
+    if (parsed.length < result.lessons.length) {
+      this.logger.warn(
+        `Skipped ${
+          result.lessons.length - parsed.length
+        } lessons with unparseable ids (run ${runId})`,
+      );
+    }
+
+    // Resolve the assigned teacher + display labels for every ClassSubject in
+    // one query. Issue #71: TimetableLesson.teacherId must carry the real
+    // assignment (not the legacy ''); Issue #177-B: the subject/class/teacher
+    // labels are denormalized into any TimetableConflict rows so the conflict
+    // UI renders without re-joining.
+    const csIds = Array.from(new Set(parsed.map((p) => p.classSubjectId)));
+    const csRows = await this.prisma.classSubject.findMany({
+      where: { id: { in: csIds } },
+      select: {
+        id: true,
+        teacherId: true,
+        subject: { select: { name: true, shortName: true } },
+        schoolClass: { select: { name: true } },
+        teacher: {
+          select: { person: { select: { lastName: true, firstName: true } } },
+        },
+      },
+    });
+    const csById = new Map(csRows.map((cs) => [cs.id, cs]));
+
+    // Room names for conflict labels.
+    const roomIds = Array.from(new Set(parsed.map((p) => p.lesson.roomId)));
+    const roomRows = await this.prisma.room.findMany({
+      where: { id: { in: roomIds } },
+      select: { id: true, name: true },
+    });
+    const roomNameById = new Map(roomRows.map((r) => [r.id, r.name]));
+
+    // Build candidate lesson records (same shape as TimetableLesson).
+    type Candidate = {
+      classSubjectId: string;
+      record: {
+        runId: string;
+        classSubjectId: string;
+        teacherId: string;
+        roomId: string;
+        dayOfWeek: any;
+        periodNumber: number;
+        weekType: string;
+      };
+    };
+    const candidates: Candidate[] = parsed.map(({ lesson, classSubjectId }) => ({
+      classSubjectId,
+      record: {
         runId,
         classSubjectId,
-        teacherId: teacherByCs.get(classSubjectId) ?? '',
+        teacherId: csById.get(classSubjectId)?.teacherId ?? '',
         roomId: lesson.roomId,
         dayOfWeek: lesson.dayOfWeek as any,
         periodNumber: lesson.periodNumber,
         weekType: lesson.weekType,
-      }));
+      },
+    }));
 
-      if (lessonRecords.length > 0) {
-        try {
-          await this.prisma.timetableLesson.createMany({
-            data: lessonRecords,
-          });
-        } catch (err) {
-          // Issue #175: Solver may return a near-optimal solution with a
-          // residual hard violation (hardScore = -1) that satisfies its
-          // internal model but trips the strict DB unique-constraint on
-          // (run_id, teacher_id, day, period, week_type) or the analogous
-          // room constraint. The original code threw — but the run record
-          // was already updated to COMPLETED above, leaving the user with
-          // a "successful" run that has 0 lessons and silently activates
-          // to an empty timetable.
-          //
-          // Now: flip the run to FAILED + record errorReason so the UI can
-          // surface the failure card (TimetableService.startSolve already
-          // primes the same code path for sidecar 5xx / watchdog timeouts).
-          // Also defensively flip isActive=false so the admin can't activate
-          // an empty run via stale UI state.
-          const message = (err as Error).message;
-          this.logger.error(
-            `createMany failed for run ${runId} (${lessonRecords.length} records): ${message}`,
-            (err as Error).stack,
-          );
-          await this.prisma.timetableRun.update({
-            where: { id: runId },
-            data: {
-              status: 'FAILED',
-              isActive: false,
-              errorReason: `Lesson persistence failed: ${message.split('\n')[0]}`,
-            },
-          });
-          // Do not rethrow: the solver-sidecar callback has done its job
-          // (delivered the result), and a 500 response would only trigger a
-          // retry that fails the same way. The run is now FAILED in the DB,
-          // which is the observable outcome the UI needs.
-          return;
-        }
+    // ---- Issue #177-B: deterministic conflict partition ----
+    //
+    // TimetableLesson carries TWO slot-uniqueness constraints that must hold
+    // over the persisted set:
+    //   @@unique([runId, teacherId, dayOfWeek, periodNumber, weekType])
+    //   @@unique([runId, roomId,    dayOfWeek, periodNumber, weekType])
+    //
+    // Timefold may return a near-optimal solution with a residual hardScore<0
+    // (e.g. one teacher double-booked) that satisfies its internal model but
+    // violates these DB constraints. Pre-#177 the whole `createMany` threw and
+    // the run was flipped to FAILED — leaving the admin with no usable plan.
+    //
+    // Now: greedily accept candidates in solver order, reserving each one's
+    // teacher-key and room-key. A candidate that would re-use an already
+    // reserved key is dropped into `conflicts` (recording which accepted
+    // lesson it collides with). This guarantees the accepted set trips
+    // neither unique constraint, so a usable PARTIAL plan always persists and
+    // the offending slots become actionable TimetableConflict rows (#177-C).
+    const slotKey = (r: Candidate['record']) =>
+      `${r.dayOfWeek}|${r.periodNumber}|${r.weekType}`;
+    const acceptedByTeacherKey = new Map<string, Candidate>();
+    const acceptedByRoomKey = new Map<string, Candidate>();
+    const accepted: Candidate['record'][] = [];
+    const conflicts: {
+      cand: Candidate;
+      conflictType: 'TEACHER' | 'ROOM';
+      other: Candidate;
+    }[] = [];
+
+    for (const cand of candidates) {
+      const r = cand.record;
+      const teacherKey = `${r.teacherId}|${slotKey(r)}`;
+      const roomKey = `${r.roomId}|${slotKey(r)}`;
+      const teacherClash = acceptedByTeacherKey.get(teacherKey);
+      const roomClash = acceptedByRoomKey.get(roomKey);
+      if (teacherClash || roomClash) {
+        conflicts.push({
+          cand,
+          conflictType: teacherClash ? 'TEACHER' : 'ROOM',
+          other: (teacherClash ?? roomClash) as Candidate,
+        });
+      } else {
+        accepted.push(r);
+        acceptedByTeacherKey.set(teacherKey, cand);
+        acceptedByRoomKey.set(roomKey, cand);
       }
-
-      this.logger.log(
-        `Stored ${lessonRecords.length} lesson assignments for run ${runId}`,
-      );
     }
+
+    // Persist the accepted (conflict-free) lessons. skipDuplicates is
+    // belt-and-suspenders: the partition already guarantees uniqueness, but a
+    // duplicate sidecar callback (retry) racing this insert would otherwise
+    // throw — ON CONFLICT DO NOTHING keeps that idempotent.
+    try {
+      if (accepted.length > 0) {
+        await this.prisma.timetableLesson.createMany({
+          data: accepted,
+          skipDuplicates: true,
+        });
+      }
+    } catch (err) {
+      // An UNEXPECTED DB failure (not a slot clash — those are partitioned out
+      // above). Flip to FAILED so the run can't masquerade as activatable with
+      // a half-written plan. Do not rethrow: a 500 to the sidecar would only
+      // trigger a retry that fails the same way.
+      const message = (err as Error).message;
+      this.logger.error(
+        `createMany failed for run ${runId} (${accepted.length} records): ${message}`,
+        (err as Error).stack,
+      );
+      await this.prisma.timetableRun.update({
+        where: { id: runId },
+        data: {
+          status: 'FAILED',
+          isActive: false,
+          errorReason: `Lesson persistence failed: ${message.split('\n')[0]}`,
+        },
+      });
+      return;
+    }
+
+    // Record any dropped lessons as actionable conflicts and downgrade the run
+    // to COMPLETED_WITH_CONFLICTS (stays inactive until the admin activates the
+    // partial plan or resolves the conflicts in #177-C).
+    if (conflicts.length > 0) {
+      const subjClassLabel = (
+        cs: (typeof csRows)[number] | undefined,
+      ): string | null => {
+        if (!cs) return null;
+        const subj = cs.subject?.name ?? cs.subject?.shortName ?? 'Fach';
+        const klass = cs.schoolClass?.name;
+        return klass ? `${subj} ${klass}` : subj;
+      };
+      const teacherLabel = (
+        cs: (typeof csRows)[number] | undefined,
+      ): string | null => (cs?.teacher?.person?.lastName ?? null);
+
+      await this.prisma.timetableConflict.createMany({
+        data: conflicts.map(({ cand, conflictType, other }) => {
+          const cs = csById.get(cand.classSubjectId);
+          const otherCs = csById.get(other.classSubjectId);
+          return {
+            runId,
+            conflictType,
+            classSubjectId: cand.record.classSubjectId,
+            teacherId: cand.record.teacherId,
+            roomId: cand.record.roomId,
+            dayOfWeek: cand.record.dayOfWeek,
+            periodNumber: cand.record.periodNumber,
+            weekType: cand.record.weekType,
+            conflictsWithClassSubjectId: other.classSubjectId,
+            teacherLabel: teacherLabel(cs),
+            subjectLabel: subjClassLabel(cs),
+            classLabel: cs?.schoolClass?.name ?? null,
+            roomLabel: roomNameById.get(cand.record.roomId) ?? null,
+            conflictsWithLabel: subjClassLabel(otherCs),
+          };
+        }),
+      });
+
+      await this.prisma.timetableRun.update({
+        where: { id: runId },
+        data: { status: 'COMPLETED_WITH_CONFLICTS' as any, isActive: false },
+      });
+
+      this.logger.warn(
+        `Run ${runId}: persisted ${accepted.length} lesson(s), ` +
+          `recorded ${conflicts.length} conflict(s) (COMPLETED_WITH_CONFLICTS)`,
+      );
+      return;
+    }
+
+    this.logger.log(
+      `Stored ${accepted.length} lesson assignments for run ${runId}`,
+    );
   }
 
   /**
@@ -299,6 +409,9 @@ export class TimetableService {
       where: { schoolId },
       orderBy: { createdAt: 'desc' },
       take: MAX_RUNS_PER_SCHOOL,
+      // Issue #177-B: surface the conflict count so /admin/solver can render
+      // the "N Konflikte zu lösen" badge without a per-row follow-up fetch.
+      include: { _count: { select: { conflicts: true } } },
     });
   }
 
@@ -357,6 +470,26 @@ export class TimetableService {
     // violations is stored as JSON array of ViolationGroupDto objects
     const violations = run.violations as unknown as ViolationGroupDto[];
     return Array.isArray(violations) ? violations : [];
+  }
+
+  /**
+   * Issue #177-B: list the lessons that could not be persisted without
+   * breaking the teacher/room slot-uniqueness (the dropped lessons behind a
+   * COMPLETED_WITH_CONFLICTS run). Each row carries denormalized labels so the
+   * conflict UI renders without re-joining; ordered oldest-first for stable
+   * rendering. Foundation for the manual-resolution UX (#177-C).
+   */
+  async getConflicts(runId: string) {
+    // Validate the run exists (404 instead of an empty list for a bad id).
+    await this.prisma.timetableRun.findUniqueOrThrow({
+      where: { id: runId },
+      select: { id: true },
+    });
+
+    return this.prisma.timetableConflict.findMany({
+      where: { runId },
+      orderBy: { createdAt: 'asc' },
+    });
   }
 
   /**

--- a/apps/web/e2e/admin-solver-conflicts.spec.ts
+++ b/apps/web/e2e/admin-solver-conflicts.spec.ts
@@ -1,0 +1,131 @@
+/**
+ * Issue #177-B — regression lock for the COMPLETED_WITH_CONFLICTS workflow.
+ *
+ * Background: the solver routinely returns a near-optimal plan with a residual
+ * hardScore<0 (e.g. one teacher double-booked). Pre-#177 the whole run was
+ * flipped to FAILED and the admin was permanently blocked — no plan ever
+ * shipped. Post-#177 the non-conflicting lessons ARE persisted, the dropped
+ * ones become TimetableConflict rows, and the run is COMPLETED_WITH_CONFLICTS
+ * (activatable as a partial plan + a visible conflict surface).
+ *
+ * This spec would have FAILED without the fix: pre-#177 there was no
+ * COMPLETED_WITH_CONFLICTS status, no conflicts endpoint, and no conflict card.
+ *
+ * Throwaway-school architecture (D4): each spec provisions its own school +
+ * timetable stack + one recorded conflict via `withConflict: true`, so there
+ * is no shared-resource race and no real ~5-minute solver run needed. The
+ * fixture writes exactly the shape `handleCompletion` would persist.
+ *
+ *   CONFLICT-01 — /admin/solver renders the "N Konflikte zu lösen" card +
+ *                 the conflict row + an enabled Aktivieren button.
+ *   CONFLICT-02 — activating the COMPLETED_WITH_CONFLICTS run navigates to
+ *                 /timetable and renders the persisted partial plan.
+ */
+import { expect, test } from '@playwright/test';
+import { loginAsAdmin } from './helpers/login';
+import {
+  createThrowawaySchool,
+  type ThrowawaySchoolFixture,
+} from './fixtures/throwaway-school';
+import { useThrowawaySchoolHeader } from './helpers/school-context';
+
+test.describe('Issue #177-B — COMPLETED_WITH_CONFLICTS workflow (throwaway-school)', () => {
+  // UI rendering is identical across viewports; desktop-only avoids
+  // mobile-selector divergence (mirrors timetable-generation-flow.spec.ts).
+  test.skip(
+    ({ isMobile }) => isMobile,
+    'Conflict surface rendering is identical across viewports — desktop only.',
+  );
+
+  let fixture: ThrowawaySchoolFixture | undefined;
+
+  test.afterEach(async () => {
+    if (fixture) {
+      await fixture.cleanup();
+      fixture = undefined;
+    }
+  });
+
+  test('CONFLICT-01: /admin/solver surfaces the conflict card + enabled Aktivieren', async ({
+    page,
+    context,
+  }) => {
+    fixture = await createThrowawaySchool({
+      roles: { admin: true },
+      withTimetableStack: { active: false },
+      withConflict: true,
+      namePrefix: 'E2E-CONFLICT01',
+    });
+    const stack = fixture.timetable!;
+    expect(stack.conflictId, 'fixture must record a conflict id').toBeTruthy();
+
+    await useThrowawaySchoolHeader(context, fixture.schoolId);
+    await loginAsAdmin(page);
+    await page.goto('/admin/solver');
+
+    // The recent-runs row shows the conflict count badge instead of a raw
+    // COMPLETED status.
+    const runRow = page.getByTestId(`recent-run-row-${stack.timetableRunId}`);
+    await expect(runRow).toBeVisible();
+    await expect(runRow).toContainText('Konflikte');
+
+    // The dedicated "N Konflikte zu lösen" card renders the dropped lesson.
+    const conflictsCard = page.getByTestId('solver-conflicts-card');
+    await expect(
+      conflictsCard,
+      'conflict card must render for a COMPLETED_WITH_CONFLICTS run',
+    ).toBeVisible();
+    await expect(conflictsCard).toContainText('Lehrer-Doppelbelegung');
+    await expect(
+      page.getByTestId(`conflict-row-${stack.conflictId}`),
+    ).toBeVisible();
+
+    // A COMPLETED_WITH_CONFLICTS run is still activatable (partial plan).
+    await expect(
+      page.getByTestId(`activate-run-${stack.timetableRunId}`),
+      'Aktivieren must be enabled for COMPLETED_WITH_CONFLICTS + !isActive',
+    ).toBeVisible();
+  });
+
+  test('CONFLICT-02: activating the partial plan navigates to /timetable and renders the persisted lesson', async ({
+    page,
+    context,
+  }) => {
+    fixture = await createThrowawaySchool({
+      roles: { admin: true },
+      withTimetableStack: { active: false },
+      withConflict: true,
+      namePrefix: 'E2E-CONFLICT02',
+    });
+    const stack = fixture.timetable!;
+
+    await useThrowawaySchoolHeader(context, fixture.schoolId);
+    await loginAsAdmin(page);
+    await page.goto('/admin/solver');
+
+    const activateBtn = page.getByTestId(
+      `activate-run-${stack.timetableRunId}`,
+    );
+    await expect(activateBtn).toBeVisible();
+    await activateBtn.click();
+
+    // Activation publishes the partial plan and navigates to /timetable.
+    await page.waitForURL('**/timetable', { timeout: 10_000 });
+
+    // The single conflict-free lesson must render — proves the partial plan is
+    // a usable timetable, not an empty one.
+    const trigger = page.getByRole('combobox').first();
+    await expect(trigger).toBeVisible();
+    await trigger.click();
+    const dropdown = page.getByRole('listbox');
+    await expect(dropdown).toBeVisible();
+    await dropdown
+      .getByRole('option', { name: stack.teacherDisplayName, exact: true })
+      .click();
+
+    await expect(
+      page.getByText(stack.subjectShortName, { exact: true }).first(),
+      'persisted partial-plan lesson must render after activation',
+    ).toBeVisible();
+  });
+});

--- a/apps/web/e2e/fixtures/throwaway-school.ts
+++ b/apps/web/e2e/fixtures/throwaway-school.ts
@@ -97,10 +97,16 @@ const { PrismaClient } = require('../../../api/dist/config/database/generated/cl
     };
     timetableRun: {
       create: (args: any) => Promise<{ id: string }>;
+      update: (args: any) => Promise<{ id: string }>;
       deleteMany: (args: any) => Promise<unknown>;
     };
     timetableLesson: {
       create: (args: any) => Promise<{ id: string; dayOfWeek: string; periodNumber: number }>;
+    };
+    // Issue #177-B — record the residual conflict behind a
+    // COMPLETED_WITH_CONFLICTS run. Cascade-deletes with the run.
+    timetableConflict: {
+      create: (args: any) => Promise<{ id: string }>;
     };
     timetableLessonEdit: {
       create: (args: any) => Promise<{ id: string }>;
@@ -164,6 +170,17 @@ export interface ThrowawaySchoolOptions {
    * so existing callers keep working unchanged.
    */
   withTimetableStack?: boolean | { active?: boolean };
+  /**
+   * Issue #177-B — turn the timetable run into a COMPLETED_WITH_CONFLICTS run
+   * by recording one TimetableConflict (a TEACHER double-book the solver would
+   * have dropped) and flipping the run status. Requires `withTimetableStack`.
+   * The conflict references the stack's own ClassSubject/Teacher/Room at
+   * MONDAY/period-1 (i.e. it would have collided with the persisted lesson).
+   * Cleanup piggy-backs on the run cascade (TimetableConflict.onDelete:
+   * Cascade). The new conflict id is exposed via
+   * `ThrowawayTimetableStack.conflictId`.
+   */
+  withConflict?: boolean;
   /**
    * Issue #138 — list of students to provision in the throwaway. Each entry
    * creates a Person + Student row enrolled in `classIds[0]`. Names show up
@@ -298,6 +315,8 @@ export interface ThrowawayTimetableStack {
   lessonDayOfWeek: 'MONDAY';
   /** 1 — the seeded lesson's period. */
   lessonPeriodNumber: 1;
+  /** Issue #177-B — the TimetableConflict id when `withConflict: true`. */
+  conflictId?: string;
 }
 
 /**
@@ -448,6 +467,11 @@ export async function createThrowawaySchool(
   if (options.withSecondTeacherLesson && !withTimetableStack) {
     throw new Error(
       'createThrowawaySchool: withSecondTeacherLesson requires withTimetableStack (no run + classSubject + room to attach the second lesson to)',
+    );
+  }
+  if (options.withConflict && !withTimetableStack) {
+    throw new Error(
+      'createThrowawaySchool: withConflict requires withTimetableStack (no run/classSubject/teacher/room to attach the conflict to)',
     );
   }
   if (options.withParentLinks?.eltern && !roles.eltern) {
@@ -694,6 +718,37 @@ export async function createThrowawaySchool(
         },
       });
 
+      // Issue #177-B — record a residual conflict + flip the run to
+      // COMPLETED_WITH_CONFLICTS. The conflict mirrors what
+      // TimetableService.handleCompletion writes for a dropped TEACHER
+      // double-book at the same slot as the persisted lesson.
+      let conflictId: string | undefined;
+      if (options.withConflict) {
+        const conflict = await prisma.timetableConflict.create({
+          data: {
+            runId: run.id,
+            conflictType: 'TEACHER',
+            classSubjectId: classSubject.id,
+            teacherId: teacher.id,
+            roomId: room.id,
+            dayOfWeek: 'MONDAY',
+            periodNumber: 1,
+            weekType: 'BOTH',
+            conflictsWithClassSubjectId: classSubject.id,
+            teacherLabel: teacherLastName,
+            subjectLabel: subject.name,
+            classLabel: null,
+            roomLabel: room.name,
+            conflictsWithLabel: subject.name,
+          },
+        });
+        conflictId = conflict.id;
+        await prisma.timetableRun.update({
+          where: { id: run.id },
+          data: { status: 'COMPLETED_WITH_CONFLICTS' },
+        });
+      }
+
       timetable = {
         teacherId: teacher.id,
         teacherDisplayName,
@@ -710,6 +765,7 @@ export async function createThrowawaySchool(
         classId: classIdForStack,
         lessonDayOfWeek: 'MONDAY',
         lessonPeriodNumber: 1,
+        conflictId,
       };
     }
 

--- a/apps/web/src/components/admin/solver/ConflictsCard.tsx
+++ b/apps/web/src/components/admin/solver/ConflictsCard.tsx
@@ -1,0 +1,119 @@
+import { Link } from '@tanstack/react-router';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  useTimetableConflicts,
+  type TimetableConflictDto,
+} from '@/hooks/useTimetableConflicts';
+
+/**
+ * Issue #177-B — read-only surface for the dropped-lesson conflicts behind a
+ * COMPLETED_WITH_CONFLICTS run. Renders "N Konflikte zu lösen" with a
+ * human-readable list (which teacher/room is double-booked in which slot) and
+ * a deep-link to the manual editor. Returns null when the run has no conflicts
+ * so the page stays clean for healthy runs.
+ *
+ * The full per-conflict resolution UX (reassign teacher / move slot / cancel)
+ * lands in #177-C; this card is the visibility floor that unblocks the admin.
+ */
+
+const DAY_LABELS: Record<string, string> = {
+  MONDAY: 'Mo',
+  TUESDAY: 'Di',
+  WEDNESDAY: 'Mi',
+  THURSDAY: 'Do',
+  FRIDAY: 'Fr',
+  SATURDAY: 'Sa',
+  SUNDAY: 'So',
+};
+
+function slotLabel(c: TimetableConflictDto): string {
+  const day = DAY_LABELS[c.dayOfWeek] ?? c.dayOfWeek;
+  const week = c.weekType && c.weekType !== 'BOTH' ? ` · Woche ${c.weekType}` : '';
+  return `${day} ${c.periodNumber}. Stunde${week}`;
+}
+
+export function ConflictsCard({
+  schoolId,
+  runId,
+}: {
+  schoolId: string;
+  runId: string;
+}) {
+  const { data: conflicts = [] } = useTimetableConflicts(schoolId, runId);
+
+  if (conflicts.length === 0) return null;
+
+  const n = conflicts.length;
+
+  return (
+    <Card
+      className="border-amber-400/60 bg-amber-50/40"
+      data-testid="solver-conflicts-card"
+    >
+      <CardHeader>
+        <CardTitle className="text-[20px] text-amber-700">
+          {n} {n === 1 ? 'Konflikt' : 'Konflikte'} zu lösen
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3 text-sm">
+        <p className="text-muted-foreground">
+          Der Stundenplan wurde erstellt, aber {n}{' '}
+          {n === 1 ? 'Lektion konnte' : 'Lektionen konnten'} nicht eingeplant
+          werden, ohne eine Doppelbelegung zu erzeugen. Der Plan ist als
+          Teilplan aktivierbar — lösen Sie die Konflikte anschließend unter
+          „Stundenplan bearbeiten“.
+        </p>
+        <ul className="space-y-2">
+          {conflicts.map((c) => (
+            <li
+              key={c.id}
+              className="rounded-md border border-amber-200 bg-background/60 p-3"
+              data-testid={`conflict-row-${c.id}`}
+            >
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="rounded bg-amber-100 px-2 py-0.5 text-xs font-semibold text-amber-800">
+                  {c.conflictType === 'TEACHER'
+                    ? 'Lehrer-Doppelbelegung'
+                    : 'Raum-Doppelbelegung'}
+                </span>
+                <span className="font-mono text-xs text-muted-foreground">
+                  {slotLabel(c)}
+                </span>
+              </div>
+              <div className="mt-1.5">
+                <span className="font-semibold">
+                  {c.subjectLabel ?? 'Lektion'}
+                </span>
+                {c.conflictsWithLabel && (
+                  <>
+                    {' '}
+                    kollidiert mit{' '}
+                    <span className="font-semibold">{c.conflictsWithLabel}</span>
+                  </>
+                )}
+                {c.conflictType === 'TEACHER' && c.teacherLabel && (
+                  <span className="text-muted-foreground">
+                    {' '}
+                    · Lehrer: {c.teacherLabel}
+                  </span>
+                )}
+                {c.conflictType === 'ROOM' && c.roomLabel && (
+                  <span className="text-muted-foreground">
+                    {' '}
+                    · Raum: {c.roomLabel}
+                  </span>
+                )}
+              </div>
+            </li>
+          ))}
+        </ul>
+        <Link
+          to="/admin/timetable-edit"
+          className="inline-block text-sm font-medium text-primary underline-offset-4 hover:underline"
+        >
+          Stundenplan bearbeiten →
+        </Link>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/hooks/useRecentTimetableRuns.ts
+++ b/apps/web/src/hooks/useRecentTimetableRuns.ts
@@ -8,12 +8,22 @@ import { apiFetch } from '@/lib/api';
  */
 export interface RecentRunDto {
   id: string;
-  status: 'QUEUED' | 'SOLVING' | 'COMPLETED' | 'FAILED' | 'STOPPED';
+  status:
+    | 'QUEUED'
+    | 'SOLVING'
+    | 'COMPLETED'
+    // Issue #177-B: solver produced a usable plan but some lessons were
+    // dropped to satisfy slot-uniqueness. Activatable as a partial plan.
+    | 'COMPLETED_WITH_CONFLICTS'
+    | 'FAILED'
+    | 'STOPPED';
   hardScore: number | null;
   softScore: number | null;
   elapsedSeconds: number | null;
   isActive: boolean;
   errorReason: string | null;
+  /** Issue #177-B: number of dropped-lesson conflicts recorded for this run. */
+  conflictCount: number;
   createdAt: string;
 }
 
@@ -51,6 +61,10 @@ export function useRecentTimetableRuns(schoolId: string | null | undefined) {
         elapsedSeconds: r.elapsedSeconds ?? null,
         isActive: !!r.isActive,
         errorReason: r.errorReason ?? null,
+        // Prisma `include: { _count: { select: { conflicts } } }` rides along
+        // on each run row (#177-B). Fall back to 0 for older/partial payloads.
+        conflictCount:
+          (r as { _count?: { conflicts?: number } })._count?.conflicts ?? 0,
         createdAt: String(r.createdAt ?? ''),
       }));
     },

--- a/apps/web/src/hooks/useTimetableConflicts.ts
+++ b/apps/web/src/hooks/useTimetableConflicts.ts
@@ -1,0 +1,56 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiFetch } from '@/lib/api';
+
+/**
+ * One conflict row from
+ * `GET /api/v1/schools/:schoolId/timetable/runs/:runId/conflicts`.
+ *
+ * Mirrors the `TimetableConflict` Prisma model (#177-B): a lesson the solver
+ * placed but that could not be persisted without double-booking a teacher or
+ * room in the same slot. Denormalized labels are resolved at persist time so
+ * this renders without re-joining.
+ */
+export interface TimetableConflictDto {
+  id: string;
+  runId: string;
+  conflictType: 'TEACHER' | 'ROOM';
+  classSubjectId: string;
+  teacherId: string;
+  roomId: string;
+  dayOfWeek: string;
+  periodNumber: number;
+  weekType: string;
+  conflictsWithClassSubjectId: string | null;
+  teacherLabel: string | null;
+  subjectLabel: string | null;
+  classLabel: string | null;
+  roomLabel: string | null;
+  conflictsWithLabel: string | null;
+  status: 'OPEN' | 'RESOLVED';
+  createdAt: string;
+}
+
+/**
+ * Issue #177-B — load the dropped-lesson conflicts for a single run so
+ * /admin/solver can render the "N Konflikte zu lösen" card. Only enabled when
+ * a runId is supplied (the page passes the most recent
+ * COMPLETED_WITH_CONFLICTS run).
+ */
+export function useTimetableConflicts(
+  schoolId: string | null | undefined,
+  runId: string | null | undefined,
+) {
+  return useQuery({
+    queryKey: ['timetable-conflicts', schoolId ?? '', runId ?? ''],
+    queryFn: async (): Promise<TimetableConflictDto[]> => {
+      if (!schoolId || !runId) return [];
+      const res = await apiFetch(
+        `/api/v1/schools/${schoolId}/timetable/runs/${runId}/conflicts`,
+      );
+      if (!res.ok) return [];
+      const body: unknown = await res.json();
+      return Array.isArray(body) ? (body as TimetableConflictDto[]) : [];
+    },
+    enabled: !!schoolId && !!runId,
+  });
+}

--- a/apps/web/src/routes/_authenticated/admin/solver.tsx
+++ b/apps/web/src/routes/_authenticated/admin/solver.tsx
@@ -9,6 +9,7 @@ import { useSolverSocket } from '@/hooks/useSolverSocket';
 import { useRecentTimetableRuns } from '@/hooks/useRecentTimetableRuns';
 import { apiFetch } from '@/lib/api';
 import { GeneratorPageWeightsCard } from '@/components/admin/solver/GeneratorPageWeightsCard';
+import { ConflictsCard } from '@/components/admin/solver/ConflictsCard';
 
 export const Route = createFileRoute('/_authenticated/admin/solver')({
   component: AdminSolverPage,
@@ -142,6 +143,14 @@ function AdminSolverPage() {
     activeRun?.status === 'QUEUED';
   const failedRun =
     activeRun?.status === 'FAILED' ? activeRun : null;
+
+  // #177-B: the most recent run that produced unpersistable conflicts (dropped
+  // lessons) drives the "N Konflikte zu lösen" card. COMPLETED_WITH_CONFLICTS
+  // is the canonical signal; conflictCount>0 is a defensive fallback for older
+  // payloads. Independent of WS state — sourced from the resilient REST list.
+  const conflictRun = recentRuns.find(
+    (r) => r.status === 'COMPLETED_WITH_CONFLICTS' || r.conflictCount > 0,
+  );
 
   return (
     <div className="max-w-[800px] mx-auto space-y-6">
@@ -292,8 +301,12 @@ function AdminSolverPage() {
                       dateStyle: 'short',
                       timeStyle: 'short',
                     });
+                // #177-B: a COMPLETED_WITH_CONFLICTS run is activatable too —
+                // its persisted lessons form a valid partial plan.
                 const canActivate =
-                  run.status === 'COMPLETED' && !run.isActive;
+                  (run.status === 'COMPLETED' ||
+                    run.status === 'COMPLETED_WITH_CONFLICTS') &&
+                  !run.isActive;
                 return (
                   <li
                     key={run.id}
@@ -309,12 +322,18 @@ function AdminSolverPage() {
                               ? 'rounded bg-emerald-100 px-2 py-0.5 text-xs font-semibold text-emerald-800'
                               : run.status === 'COMPLETED'
                                 ? 'rounded bg-blue-100 px-2 py-0.5 text-xs font-semibold text-blue-800'
-                                : run.status === 'FAILED'
-                                  ? 'rounded bg-red-100 px-2 py-0.5 text-xs font-semibold text-red-800'
-                                  : 'rounded bg-muted px-2 py-0.5 text-xs font-semibold text-muted-foreground'
+                                : run.status === 'COMPLETED_WITH_CONFLICTS'
+                                  ? 'rounded bg-amber-100 px-2 py-0.5 text-xs font-semibold text-amber-800'
+                                  : run.status === 'FAILED'
+                                    ? 'rounded bg-red-100 px-2 py-0.5 text-xs font-semibold text-red-800'
+                                    : 'rounded bg-muted px-2 py-0.5 text-xs font-semibold text-muted-foreground'
                           }
                         >
-                          {run.isActive ? 'Aktiv' : run.status}
+                          {run.isActive
+                            ? 'Aktiv'
+                            : run.status === 'COMPLETED_WITH_CONFLICTS'
+                              ? `${run.conflictCount} Konflikte`
+                              : run.status}
                         </span>
                       </div>
                       <div className="text-xs text-muted-foreground">
@@ -344,6 +363,13 @@ function AdminSolverPage() {
             </ul>
           </CardContent>
         </Card>
+      )}
+
+      {/* #177-B: conflict surface — when the most recent run is
+          COMPLETED_WITH_CONFLICTS, list the dropped lessons (which teacher/room
+          is double-booked in which slot) so the admin can resolve them. */}
+      {schoolId && conflictRun && (
+        <ConflictsCard schoolId={schoolId} runId={conflictRun.id} />
       )}
 
       {/* #53 Schicht 1: failure card — surfaces the watchdog-detected


### PR DESCRIPTION
## Was & Warum

Sub-Issue **B** von #177. Der Timefold-Solver liefert bei realistischer Schulgröße regelmäßig `hardScore=-1` (eine residuale Lehrer-/Raum-Doppelbelegung). Bisher hat `handleCompletion` per all-or-nothing `createMany` die DB-Unique-Constraint getrippt → Run `FAILED` → **Admin permanent blockiert**, kein Stundenplan kam je durch.

Diese PR macht die Persistierung **soft**: die nicht-konfligierenden Lessons werden gespeichert, die verbleibenden als `TimetableConflict` erfasst, und der Run wird `COMPLETED_WITH_CONFLICTS` — aktivierbar als **Teilplan**, mit sichtbarem Konflikt-Surface.

## Änderungen

**Backend**
- `schema.prisma`: neuer `SolveStatus`-Wert `COMPLETED_WITH_CONFLICTS` + neues Model `TimetableConflict` (queryable + resolvable — Foundation für #177-C). Migration `20260604073426_add_timetable_conflict_and_status`.
- `handleCompletion`: deterministische greedy-Partition über teacher-key + room-key. Akzeptierte Lessons → `createMany(skipDuplicates)` (kann beide Unique-Constraints nicht mehr verletzen). Dropped Lessons → `TimetableConflict` mit aufgelösten Labels (Lehrer/Fach/Klasse/Raum). `try/catch → FAILED` bleibt **nur** als Fallback für unerwartete (nicht-slot-clash) DB-Fehler.
- `GET runs/:runId/conflicts` + Conflict-Count auf der Runs-Liste.

**Frontend (`/admin/solver`)**
- Amber Badge `N Konflikte` + Aktivieren-Button auch für `COMPLETED_WITH_CONFLICTS`.
- Read-only `ConflictsCard`: „N Konflikte zu lösen" mit human-lesbarer Liste (welcher Lehrer/Raum in welchem Slot doppelt belegt ist) + Deep-Link zu „Stundenplan bearbeiten".

## Regression-Lock (CLAUDE.md hard rule)

- **API-Unit** (`timetable.service.spec.ts`): der bisherige #175-Test „→ FAILED" ist jetzt „→ COMPLETED_WITH_CONFLICTS" (nicht-konfligierende Lesson persistiert, Konflikt mit Labels erfasst). Neu: unerwarteter DB-Fehler → FAILED-Fallback; `getConflicts` happy/404. **Würde ohne den Fix fehlschlagen** (vor #177 gab es weder den Status noch das Model).
- **E2E** (`admin-solver-conflicts.spec.ts`, throwaway-school, D4-konform, desktop+firefox grün lokal): CONFLICT-01 rendert Konflikt-Card + aktiven Aktivieren-Button; CONFLICT-02 aktiviert den Teilplan → `/timetable` zeigt die persistierte Lesson. Neue Fixture-Option `withConflict`.

## Lokale Verifikation
- `nest build` (api) + `tsc -b && vite build` (web): 0 issues.
- API vitest: 805 passed. (Vorbestehender, unabhängiger `PeriodsEditor.spec.tsx`-Fehler auf `main` — kein Bezug, läuft nicht in CI.)
- E2E: `admin-solver-conflicts` + `timetable-generation-flow` grün auf desktop **und** desktop-firefox.

## Scope / Follow-ups
- **#177-C** (Manual Resolution UX) ist `blocked-by` dieser PR — baut auf `TimetableConflict` auf.
- **#177-D** (Diagnostics) folgt danach.
- Pattern A (Solver-Weight/Time-Tuning) bewusst nicht enthalten — garantiert keine Feasibility; Soft-Persist ist der robuste Floor.

Closes #179
Refs #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)