### PR TITLE
feat(timetable): #180 — Manual Conflict Resolution UX (Pattern C of #177)

### DIFF
--- a/apps/api/src/modules/timetable/dto/resolve-conflict.dto.ts
+++ b/apps/api/src/modules/timetable/dto/resolve-conflict.dto.ts
@@ -1,0 +1,48 @@
+import { IsIn, IsInt, IsOptional, IsString, Min } from 'class-validator';
+
+/**
+ * Issue #177-C — body for
+ * `POST runs/:runId/conflicts/:conflictId/resolve`.
+ *
+ * Three resolution actions for a dropped-lesson conflict:
+ *   - `cancel`            — drop the lesson permanently (no row created).
+ *   - `reassign-resource` — re-place the lesson at its ORIGINAL slot with a
+ *                           different free resource: `newTeacherId` for a
+ *                           TEACHER conflict, `newRoomId` for a ROOM conflict.
+ *   - `move-slot`         — re-place the lesson with its ORIGINAL teacher+room
+ *                           at a different free slot (`dayOfWeek` +
+ *                           `periodNumber`, optional `weekType`).
+ *
+ * class-validator decorators are mandatory: the global ValidationPipe runs
+ * `whitelist + forbidNonWhitelisted`, so undecorated props are rejected.
+ */
+export class ResolveConflictDto {
+  @IsIn(['reassign-resource', 'move-slot', 'cancel'])
+  action!: 'reassign-resource' | 'move-slot' | 'cancel';
+
+  /** reassign-resource on a TEACHER conflict: the replacement teacher id. */
+  @IsOptional()
+  @IsString()
+  newTeacherId?: string;
+
+  /** reassign-resource on a ROOM conflict: the replacement room id. */
+  @IsOptional()
+  @IsString()
+  newRoomId?: string;
+
+  /** move-slot: target day (DayOfWeek enum value, e.g. "TUESDAY"). */
+  @IsOptional()
+  @IsString()
+  dayOfWeek?: string;
+
+  /** move-slot: target period number. */
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  periodNumber?: number;
+
+  /** move-slot: target week type ("BOTH" | "A" | "B"); defaults to the conflict's. */
+  @IsOptional()
+  @IsString()
+  weekType?: string;
+}

--- a/apps/api/src/modules/timetable/timetable-conflict.service.spec.ts
+++ b/apps/api/src/modules/timetable/timetable-conflict.service.spec.ts
@@ -1,0 +1,293 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { TimetableConflictService } from './timetable-conflict.service';
+import { PrismaService } from '../../config/database/prisma.service';
+import { ResolveConflictDto } from './dto/resolve-conflict.dto';
+
+/**
+ * Issue #177-C — unit tests for the manual conflict-resolution service.
+ * Prisma is fully mocked; $transaction runs the callback against the same mock
+ * (tx === prisma) so we can assert the writes inside the transaction.
+ */
+describe('TimetableConflictService', () => {
+  let service: TimetableConflictService;
+  let prisma: any;
+
+  const baseConflict = {
+    id: 'conf-1',
+    runId: 'run-1',
+    conflictType: 'TEACHER',
+    classSubjectId: 'cs-1',
+    teacherId: 'teacher-1',
+    roomId: 'room-1',
+    dayOfWeek: 'MONDAY',
+    periodNumber: 1,
+    weekType: 'BOTH',
+    conflictsWithClassSubjectId: 'cs-2',
+    status: 'OPEN',
+  };
+
+  const mockPrisma = {
+    timetableConflict: {
+      findUnique: vi.fn(),
+      update: vi.fn().mockResolvedValue({}),
+      count: vi.fn().mockResolvedValue(0),
+    },
+    timetableRun: {
+      findUniqueOrThrow: vi.fn().mockResolvedValue({ schoolId: 'school-1' }),
+      update: vi.fn().mockResolvedValue({}),
+    },
+    timetableLesson: {
+      findFirst: vi.fn().mockResolvedValue(null),
+      findMany: vi.fn().mockResolvedValue([]),
+      create: vi.fn().mockResolvedValue({ id: 'lesson-new' }),
+    },
+    classSubject: {
+      findUnique: vi.fn().mockResolvedValue({
+        subjectId: 'subj-1',
+        classId: 'class-1',
+        subject: { requiredRoomType: null },
+      }),
+      findMany: vi.fn().mockResolvedValue([{ id: 'cs-1' }]),
+    },
+    teacherSubject: {
+      findMany: vi.fn().mockResolvedValue([]),
+      findFirst: vi.fn().mockResolvedValue({ id: 'ts-1' }),
+    },
+    room: {
+      findMany: vi.fn().mockResolvedValue([]),
+      findUnique: vi.fn().mockResolvedValue({ roomType: 'KLASSENZIMMER' }),
+    },
+    schoolDay: {
+      findMany: vi.fn().mockResolvedValue([{ dayOfWeek: 'MONDAY' }]),
+    },
+    period: {
+      findMany: vi
+        .fn()
+        .mockResolvedValue([{ periodNumber: 1 }, { periodNumber: 2 }]),
+    },
+    $transaction: vi.fn().mockImplementation(async (cb: any) => cb(mockPrisma)),
+  };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    // Restore stable defaults cleared above.
+    mockPrisma.timetableConflict.findUnique.mockResolvedValue({
+      ...baseConflict,
+    });
+    mockPrisma.timetableConflict.update.mockResolvedValue({});
+    mockPrisma.timetableConflict.count.mockResolvedValue(0);
+    mockPrisma.timetableRun.findUniqueOrThrow.mockResolvedValue({
+      schoolId: 'school-1',
+    });
+    mockPrisma.timetableRun.update.mockResolvedValue({});
+    mockPrisma.timetableLesson.findFirst.mockResolvedValue(null);
+    mockPrisma.timetableLesson.findMany.mockResolvedValue([]);
+    mockPrisma.timetableLesson.create.mockResolvedValue({ id: 'lesson-new' });
+    mockPrisma.classSubject.findUnique.mockResolvedValue({
+      subjectId: 'subj-1',
+      classId: 'class-1',
+      subject: { requiredRoomType: null },
+    });
+    mockPrisma.classSubject.findMany.mockResolvedValue([{ id: 'cs-1' }]);
+    mockPrisma.teacherSubject.findFirst.mockResolvedValue({ id: 'ts-1' });
+    mockPrisma.$transaction.mockImplementation(async (cb: any) =>
+      cb(mockPrisma),
+    );
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TimetableConflictService,
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
+    }).compile();
+    service = module.get(TimetableConflictService);
+  });
+
+  describe('resolveConflict', () => {
+    it('cancel: marks the conflict RESOLVED, creates no lesson, flips run to COMPLETED when last open', async () => {
+      mockPrisma.timetableConflict.count.mockResolvedValue(0);
+
+      const res = await service.resolveConflict(
+        'run-1',
+        'conf-1',
+        { action: 'cancel' } as ResolveConflictDto,
+        'user-1',
+      );
+
+      expect(mockPrisma.timetableLesson.create).not.toHaveBeenCalled();
+      expect(mockPrisma.timetableConflict.update).toHaveBeenCalledWith({
+        where: { id: 'conf-1' },
+        data: expect.objectContaining({
+          status: 'RESOLVED',
+          resolutionAction: 'cancel',
+          resolvedBy: 'user-1',
+        }),
+      });
+      expect(mockPrisma.timetableRun.update).toHaveBeenCalledWith({
+        where: { id: 'run-1' },
+        data: { status: 'COMPLETED' },
+      });
+      expect(res).toMatchObject({ resolved: true, runCompleted: true });
+    });
+
+    it('cancel: keeps run COMPLETED_WITH_CONFLICTS when other open conflicts remain', async () => {
+      mockPrisma.timetableConflict.count.mockResolvedValue(2);
+
+      const res = await service.resolveConflict(
+        'run-1',
+        'conf-1',
+        { action: 'cancel' } as ResolveConflictDto,
+        'user-1',
+      );
+
+      expect(mockPrisma.timetableRun.update).not.toHaveBeenCalled();
+      expect(res.runCompleted).toBe(false);
+    });
+
+    it('move-slot: creates the lesson at the new slot with the original teacher+room', async () => {
+      mockPrisma.timetableConflict.count.mockResolvedValue(0);
+
+      await service.resolveConflict(
+        'run-1',
+        'conf-1',
+        {
+          action: 'move-slot',
+          dayOfWeek: 'TUESDAY',
+          periodNumber: 3,
+        } as ResolveConflictDto,
+        'user-1',
+      );
+
+      expect(mockPrisma.timetableLesson.create).toHaveBeenCalledTimes(1);
+      const data = mockPrisma.timetableLesson.create.mock.calls[0][0].data;
+      expect(data).toMatchObject({
+        runId: 'run-1',
+        classSubjectId: 'cs-1',
+        teacherId: 'teacher-1',
+        roomId: 'room-1',
+        dayOfWeek: 'TUESDAY',
+        periodNumber: 3,
+        isManualEdit: true,
+        editedBy: 'user-1',
+      });
+    });
+
+    it('reassign-resource (TEACHER): validates qualification + creates lesson with the new teacher at the original slot', async () => {
+      mockPrisma.timetableConflict.count.mockResolvedValue(0);
+
+      await service.resolveConflict(
+        'run-1',
+        'conf-1',
+        {
+          action: 'reassign-resource',
+          newTeacherId: 'teacher-2',
+        } as ResolveConflictDto,
+        'user-1',
+      );
+
+      expect(mockPrisma.teacherSubject.findFirst).toHaveBeenCalledWith({
+        where: { teacherId: 'teacher-2', subjectId: 'subj-1' },
+        select: { id: true },
+      });
+      const data = mockPrisma.timetableLesson.create.mock.calls[0][0].data;
+      expect(data).toMatchObject({
+        teacherId: 'teacher-2',
+        roomId: 'room-1',
+        dayOfWeek: 'MONDAY',
+        periodNumber: 1,
+      });
+    });
+
+    it('reassign-resource (TEACHER): rejects an unqualified teacher', async () => {
+      mockPrisma.teacherSubject.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.resolveConflict(
+          'run-1',
+          'conf-1',
+          {
+            action: 'reassign-resource',
+            newTeacherId: 'teacher-x',
+          } as ResolveConflictDto,
+          'user-1',
+        ),
+      ).rejects.toBeInstanceOf(BadRequestException);
+      expect(mockPrisma.timetableLesson.create).not.toHaveBeenCalled();
+    });
+
+    it('throws on an already-resolved conflict', async () => {
+      mockPrisma.timetableConflict.findUnique.mockResolvedValue({
+        ...baseConflict,
+        status: 'RESOLVED',
+      });
+
+      await expect(
+        service.resolveConflict(
+          'run-1',
+          'conf-1',
+          { action: 'cancel' } as ResolveConflictDto,
+          'user-1',
+        ),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('throws NotFound when the conflict does not belong to the run', async () => {
+      mockPrisma.timetableConflict.findUnique.mockResolvedValue({
+        ...baseConflict,
+        runId: 'other-run',
+      });
+
+      await expect(
+        service.resolveConflict(
+          'run-1',
+          'conf-1',
+          { action: 'cancel' } as ResolveConflictDto,
+          'user-1',
+        ),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+
+  describe('getSuggestions', () => {
+    it('TEACHER: returns free qualified teachers + free slots (excluding the original)', async () => {
+      mockPrisma.teacherSubject.findMany.mockResolvedValue([
+        {
+          teacher: {
+            id: 'teacher-2',
+            person: { lastName: 'Huber', firstName: 'Max' },
+          },
+        },
+        {
+          // already-assigned teacher must be excluded
+          teacher: {
+            id: 'teacher-1',
+            person: { lastName: 'Müller', firstName: 'Anna' },
+          },
+        },
+      ]);
+      // teacher-2 is free at the original slot.
+      mockPrisma.timetableLesson.findFirst.mockResolvedValue(null);
+      // For computeFreeSlots: teacher busy MON-1 (original), room busy MON-1.
+      mockPrisma.timetableLesson.findMany.mockResolvedValue([
+        { dayOfWeek: 'MONDAY', periodNumber: 1, weekType: 'BOTH' },
+      ]);
+
+      const result = await service.getSuggestions('run-1', 'conf-1');
+
+      expect(result.conflictType).toBe('TEACHER');
+      expect(result.alternativeResources).toEqual([
+        { id: 'teacher-2', label: 'Huber Max' },
+      ]);
+      // MON-1 is the original (skipped); MON-2 is free.
+      expect(result.freeSlots).toContainEqual(
+        expect.objectContaining({ dayOfWeek: 'MONDAY', periodNumber: 2 }),
+      );
+      expect(
+        result.freeSlots.some(
+          (s) => s.dayOfWeek === 'MONDAY' && s.periodNumber === 1,
+        ),
+      ).toBe(false);
+    });
+  });
+});

--- a/apps/api/src/modules/timetable/timetable-conflict.service.ts
+++ b/apps/api/src/modules/timetable/timetable-conflict.service.ts
@@ -1,0 +1,519 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { PrismaService } from '../../config/database/prisma.service';
+import { Prisma } from '../../config/database/generated/client.js';
+import { ResolveConflictDto } from './dto/resolve-conflict.dto';
+
+/** Cap how many free-slot suggestions we compute/return per conflict. */
+const MAX_FREE_SLOT_SUGGESTIONS = 16;
+
+/** Stable Mon→Sun ordering for free-slot suggestion lists. */
+const DAY_ORDER = [
+  'MONDAY',
+  'TUESDAY',
+  'WEDNESDAY',
+  'THURSDAY',
+  'FRIDAY',
+  'SATURDAY',
+  'SUNDAY',
+];
+
+const DAY_ABBR: Record<string, string> = {
+  MONDAY: 'Mo',
+  TUESDAY: 'Di',
+  WEDNESDAY: 'Mi',
+  THURSDAY: 'Do',
+  FRIDAY: 'Fr',
+  SATURDAY: 'Sa',
+  SUNDAY: 'So',
+};
+
+interface SlotPlacement {
+  teacherId: string;
+  roomId: string;
+  dayOfWeek: string;
+  periodNumber: number;
+  weekType: string;
+}
+
+/**
+ * Issue #177-C — manual resolution of the dropped-lesson conflicts behind a
+ * COMPLETED_WITH_CONFLICTS run (see #177-B for how they are recorded).
+ *
+ * `getSuggestions` surfaces the viable ways out (free qualified teachers /
+ * free compatible rooms at the original slot + free slots elsewhere);
+ * `resolveConflict` applies the admin's choice atomically and flips the run
+ * back to COMPLETED once the last OPEN conflict is gone.
+ */
+@Injectable()
+export class TimetableConflictService {
+  private readonly logger = new Logger(TimetableConflictService.name);
+
+  constructor(private prisma: PrismaService) {}
+
+  /**
+   * Week-type compatibility OR-filter (mirrors timetable-edit.service): a BOTH
+   * lesson clashes with A, B and BOTH; an A lesson clashes with A and BOTH.
+   */
+  private weekTypeFilter(weekType: string): Prisma.TimetableLessonWhereInput['OR'] {
+    return [
+      { weekType },
+      { weekType: 'BOTH' },
+      ...(weekType === 'BOTH' ? [{ weekType: 'A' }, { weekType: 'B' }] : []),
+    ];
+  }
+
+  private weekCompatible(a: string, b: string): boolean {
+    return a === 'BOTH' || b === 'BOTH' || a === b;
+  }
+
+  /** Load a conflict and assert it belongs to the run (404 otherwise). */
+  private async loadConflict(runId: string, conflictId: string) {
+    const conflict = await this.prisma.timetableConflict.findUnique({
+      where: { id: conflictId },
+    });
+    if (!conflict || conflict.runId !== runId) {
+      throw new NotFoundException('Konflikt nicht gefunden.');
+    }
+    return conflict;
+  }
+
+  /**
+   * Suggestions for resolving a single conflict:
+   *  - alternativeResources: for a TEACHER conflict, qualified teachers free at
+   *    the original slot; for a ROOM conflict, type-compatible rooms free at
+   *    the original slot (used by the `reassign-resource` action).
+   *  - freeSlots: slots where BOTH the conflict's teacher and room are free
+   *    (used by the `move-slot` action).
+   */
+  async getSuggestions(runId: string, conflictId: string) {
+    const conflict = await this.loadConflict(runId, conflictId);
+    const run = await this.prisma.timetableRun.findUniqueOrThrow({
+      where: { id: runId },
+      select: { schoolId: true },
+    });
+    const schoolId = run.schoolId;
+
+    const cs = await this.prisma.classSubject.findUnique({
+      where: { id: conflict.classSubjectId },
+      select: {
+        subjectId: true,
+        subject: { select: { requiredRoomType: true } },
+      },
+    });
+
+    const alternativeResources: { id: string; label: string }[] = [];
+
+    if (conflict.conflictType === 'TEACHER' && cs) {
+      // Teachers qualified for the subject (TeacherSubject) in this school,
+      // excluding the already-assigned teacher, that are free at the slot.
+      const qualified = await this.prisma.teacherSubject.findMany({
+        where: { subjectId: cs.subjectId, teacher: { schoolId } },
+        select: {
+          teacher: {
+            select: {
+              id: true,
+              person: { select: { lastName: true, firstName: true } },
+            },
+          },
+        },
+      });
+      for (const q of qualified) {
+        const t = q.teacher;
+        if (t.id === conflict.teacherId) continue;
+        const busy = await this.prisma.timetableLesson.findFirst({
+          where: {
+            runId,
+            teacherId: t.id,
+            dayOfWeek: conflict.dayOfWeek,
+            periodNumber: conflict.periodNumber,
+            OR: this.weekTypeFilter(conflict.weekType),
+          },
+          select: { id: true },
+        });
+        if (!busy) {
+          alternativeResources.push({
+            id: t.id,
+            label: `${t.person?.lastName ?? ''} ${t.person?.firstName ?? ''}`.trim(),
+          });
+        }
+      }
+    } else if (conflict.conflictType === 'ROOM') {
+      const requiredRoomType = cs?.subject?.requiredRoomType ?? null;
+      const rooms = await this.prisma.room.findMany({
+        where: {
+          schoolId,
+          ...(requiredRoomType ? { roomType: requiredRoomType } : {}),
+        },
+        select: { id: true, name: true },
+        orderBy: { name: 'asc' },
+      });
+      for (const r of rooms) {
+        if (r.id === conflict.roomId) continue;
+        const busy = await this.prisma.timetableLesson.findFirst({
+          where: {
+            runId,
+            roomId: r.id,
+            dayOfWeek: conflict.dayOfWeek,
+            periodNumber: conflict.periodNumber,
+            OR: this.weekTypeFilter(conflict.weekType),
+          },
+          select: { id: true },
+        });
+        if (!busy) alternativeResources.push({ id: r.id, label: r.name });
+      }
+    }
+
+    const freeSlots = await this.computeFreeSlots(runId, schoolId, conflict);
+
+    return {
+      conflictId: conflict.id,
+      conflictType: conflict.conflictType,
+      alternativeResources,
+      freeSlots,
+    };
+  }
+
+  /**
+   * Slots (active SchoolDay × non-break Period) where BOTH the conflict's
+   * teacher and room are free (week-type compatible), excluding the original
+   * slot. Capped at MAX_FREE_SLOT_SUGGESTIONS.
+   */
+  private async computeFreeSlots(
+    runId: string,
+    schoolId: string,
+    conflict: { teacherId: string; roomId: string; dayOfWeek: string; periodNumber: number; weekType: string },
+  ) {
+    const [days, periods, teacherLessons, roomLessons] = await Promise.all([
+      this.prisma.schoolDay.findMany({
+        where: { schoolId, isActive: true },
+        select: { dayOfWeek: true },
+      }),
+      this.prisma.period.findMany({
+        where: { timeGrid: { schoolId }, isBreak: false },
+        select: { periodNumber: true },
+        orderBy: { periodNumber: 'asc' },
+      }),
+      this.prisma.timetableLesson.findMany({
+        where: { runId, teacherId: conflict.teacherId },
+        select: { dayOfWeek: true, periodNumber: true, weekType: true },
+      }),
+      this.prisma.timetableLesson.findMany({
+        where: { runId, roomId: conflict.roomId },
+        select: { dayOfWeek: true, periodNumber: true, weekType: true },
+      }),
+    ]);
+
+    const activeDays = DAY_ORDER.filter((d) =>
+      days.some((sd) => sd.dayOfWeek === d),
+    );
+    // De-duplicate period numbers (one TimeGrid per school, but be defensive).
+    const periodNumbers = Array.from(
+      new Set(periods.map((p) => p.periodNumber)),
+    ).sort((a, b) => a - b);
+
+    const busyAt = (
+      lessons: { dayOfWeek: string; periodNumber: number; weekType: string }[],
+      day: string,
+      period: number,
+    ) =>
+      lessons.some(
+        (l) =>
+          l.dayOfWeek === day &&
+          l.periodNumber === period &&
+          this.weekCompatible(l.weekType, conflict.weekType),
+      );
+
+    const slots: {
+      dayOfWeek: string;
+      periodNumber: number;
+      weekType: string;
+      label: string;
+    }[] = [];
+    for (const day of activeDays) {
+      for (const period of periodNumbers) {
+        if (day === conflict.dayOfWeek && period === conflict.periodNumber) {
+          continue;
+        }
+        if (
+          busyAt(teacherLessons, day, period) ||
+          busyAt(roomLessons, day, period)
+        ) {
+          continue;
+        }
+        slots.push({
+          dayOfWeek: day,
+          periodNumber: period,
+          weekType: conflict.weekType,
+          label: `${DAY_ABBR[day] ?? day} ${period}. Stunde`,
+        });
+        if (slots.length >= MAX_FREE_SLOT_SUGGESTIONS) return slots;
+      }
+    }
+    return slots;
+  }
+
+  /**
+   * Apply the admin's chosen resolution atomically:
+   *  - `cancel`            → no lesson; just mark the conflict RESOLVED.
+   *  - `reassign-resource` → create the lesson at its original slot with the
+   *                          replacement teacher (TEACHER) or room (ROOM).
+   *  - `move-slot`         → create the lesson at a new slot with the original
+   *                          teacher + room.
+   *
+   * Any created lesson is validated against teacher/room/student-group clashes
+   * first, then guarded by a P2002 catch inside the transaction. When the last
+   * OPEN conflict for the run is resolved, the run flips back to COMPLETED.
+   */
+  async resolveConflict(
+    runId: string,
+    conflictId: string,
+    dto: ResolveConflictDto,
+    userId: string,
+  ) {
+    const conflict = await this.loadConflict(runId, conflictId);
+    if (conflict.status === 'RESOLVED') {
+      throw new BadRequestException('Konflikt ist bereits gelöst.');
+    }
+
+    let placement: SlotPlacement | null = null;
+
+    if (dto.action === 'cancel') {
+      placement = null;
+    } else if (dto.action === 'reassign-resource') {
+      placement = await this.buildReassignPlacement(conflict, dto);
+    } else {
+      // move-slot
+      if (!dto.dayOfWeek || dto.periodNumber == null) {
+        throw new BadRequestException(
+          'move-slot erfordert dayOfWeek + periodNumber.',
+        );
+      }
+      placement = {
+        teacherId: conflict.teacherId,
+        roomId: conflict.roomId,
+        dayOfWeek: dto.dayOfWeek,
+        periodNumber: dto.periodNumber,
+        weekType: dto.weekType ?? conflict.weekType,
+      };
+    }
+
+    if (placement) {
+      await this.assertSlotFree(runId, conflict.classSubjectId, placement);
+    }
+
+    let runCompleted = false;
+    await this.prisma.$transaction(async (tx) => {
+      if (placement) {
+        try {
+          await tx.timetableLesson.create({
+            data: {
+              runId,
+              classSubjectId: conflict.classSubjectId,
+              teacherId: placement.teacherId,
+              roomId: placement.roomId,
+              dayOfWeek: placement.dayOfWeek as any,
+              periodNumber: placement.periodNumber,
+              weekType: placement.weekType,
+              isManualEdit: true,
+              editedBy: userId,
+              editedAt: new Date(),
+            },
+          });
+        } catch (err) {
+          if (
+            err instanceof Prisma.PrismaClientKnownRequestError &&
+            err.code === 'P2002'
+          ) {
+            // Lost a race — another lesson took the slot between validation and
+            // insert. Surface as 409 so the UI re-fetches suggestions.
+            throw new ConflictException(
+              'Der Slot ist nicht mehr frei. Bitte erneut versuchen.',
+            );
+          }
+          throw err;
+        }
+      }
+
+      await tx.timetableConflict.update({
+        where: { id: conflictId },
+        data: {
+          status: 'RESOLVED',
+          resolutionAction: dto.action,
+          resolvedBy: userId,
+          resolvedAt: new Date(),
+        },
+      });
+
+      const remaining = await tx.timetableConflict.count({
+        where: { runId, status: 'OPEN' },
+      });
+      if (remaining === 0) {
+        await tx.timetableRun.update({
+          where: { id: runId },
+          data: { status: 'COMPLETED' as any },
+        });
+        runCompleted = true;
+      }
+    });
+
+    this.logger.log(
+      `Conflict ${conflictId} resolved via ${dto.action} by ${userId}` +
+        (runCompleted ? ` — run ${runId} now COMPLETED` : ''),
+    );
+
+    return { resolved: true, conflictId, action: dto.action, runCompleted };
+  }
+
+  /**
+   * Validate + build the placement for a reassign-resource action: a free,
+   * qualified replacement teacher (TEACHER conflict) or a free, type-compatible
+   * replacement room (ROOM conflict). Throws on a bad/unsuitable target.
+   */
+  private async buildReassignPlacement(
+    conflict: {
+      conflictType: string;
+      classSubjectId: string;
+      teacherId: string;
+      roomId: string;
+      dayOfWeek: string;
+      periodNumber: number;
+      weekType: string;
+    },
+    dto: ResolveConflictDto,
+  ): Promise<SlotPlacement> {
+    if (conflict.conflictType === 'TEACHER') {
+      if (!dto.newTeacherId) {
+        throw new BadRequestException(
+          'reassign-resource für einen Lehrer-Konflikt erfordert newTeacherId.',
+        );
+      }
+      const cs = await this.prisma.classSubject.findUnique({
+        where: { id: conflict.classSubjectId },
+        select: { subjectId: true },
+      });
+      const qualified = await this.prisma.teacherSubject.findFirst({
+        where: { teacherId: dto.newTeacherId, subjectId: cs?.subjectId },
+        select: { id: true },
+      });
+      if (!qualified) {
+        throw new BadRequestException(
+          'Der gewählte Lehrer ist nicht für dieses Fach qualifiziert.',
+        );
+      }
+      return {
+        teacherId: dto.newTeacherId,
+        roomId: conflict.roomId,
+        dayOfWeek: conflict.dayOfWeek,
+        periodNumber: conflict.periodNumber,
+        weekType: conflict.weekType,
+      };
+    }
+
+    // ROOM conflict
+    if (!dto.newRoomId) {
+      throw new BadRequestException(
+        'reassign-resource für einen Raum-Konflikt erfordert newRoomId.',
+      );
+    }
+    const cs = await this.prisma.classSubject.findUnique({
+      where: { id: conflict.classSubjectId },
+      select: { subject: { select: { requiredRoomType: true } } },
+    });
+    const room = await this.prisma.room.findUnique({
+      where: { id: dto.newRoomId },
+      select: { roomType: true },
+    });
+    if (!room) {
+      throw new BadRequestException('Der gewählte Raum existiert nicht.');
+    }
+    const requiredRoomType = cs?.subject?.requiredRoomType ?? null;
+    if (requiredRoomType && room.roomType !== requiredRoomType) {
+      throw new BadRequestException(
+        'Der gewählte Raum hat nicht den für dieses Fach benötigten Raumtyp.',
+      );
+    }
+    return {
+      teacherId: conflict.teacherId,
+      roomId: dto.newRoomId,
+      dayOfWeek: conflict.dayOfWeek,
+      periodNumber: conflict.periodNumber,
+      weekType: conflict.weekType,
+    };
+  }
+
+  /**
+   * Reject a placement that would clash with an existing lesson in the run:
+   * teacher double-book, room double-book, or the class already busy
+   * (student-group). Week-type aware. Throws ConflictException (409).
+   */
+  private async assertSlotFree(
+    runId: string,
+    classSubjectId: string,
+    placement: SlotPlacement,
+  ): Promise<void> {
+    const weekOr = this.weekTypeFilter(placement.weekType);
+
+    const teacherClash = await this.prisma.timetableLesson.findFirst({
+      where: {
+        runId,
+        teacherId: placement.teacherId,
+        dayOfWeek: placement.dayOfWeek as any,
+        periodNumber: placement.periodNumber,
+        OR: weekOr,
+      },
+      select: { id: true },
+    });
+    if (teacherClash) {
+      throw new ConflictException(
+        'Der Lehrer ist in diesem Slot bereits eingeteilt.',
+      );
+    }
+
+    const roomClash = await this.prisma.timetableLesson.findFirst({
+      where: {
+        runId,
+        roomId: placement.roomId,
+        dayOfWeek: placement.dayOfWeek as any,
+        periodNumber: placement.periodNumber,
+        OR: weekOr,
+      },
+      select: { id: true },
+    });
+    if (roomClash) {
+      throw new ConflictException('Der Raum ist in diesem Slot bereits belegt.');
+    }
+
+    // Student-group clash: the class must not already have a lesson at the slot.
+    const cs = await this.prisma.classSubject.findUnique({
+      where: { id: classSubjectId },
+      select: { classId: true },
+    });
+    if (cs) {
+      const classCsIds = await this.prisma.classSubject.findMany({
+        where: { classId: cs.classId },
+        select: { id: true },
+      });
+      const studentClash = await this.prisma.timetableLesson.findFirst({
+        where: {
+          runId,
+          classSubjectId: { in: classCsIds.map((c) => c.id) },
+          dayOfWeek: placement.dayOfWeek as any,
+          periodNumber: placement.periodNumber,
+          OR: weekOr,
+        },
+        select: { id: true },
+      });
+      if (studentClash) {
+        throw new ConflictException(
+          'Die Klasse hat in diesem Slot bereits Unterricht.',
+        );
+      }
+    }
+  }
+}

--- a/apps/api/src/modules/timetable/timetable.controller.ts
+++ b/apps/api/src/modules/timetable/timetable.controller.ts
@@ -32,6 +32,8 @@ import { TimetableViewQueryDto, TimetableViewResponseDto } from './dto/timetable
 import { ValidateMoveDto, MoveValidationResponseDto } from './dto/validate-move.dto';
 import { MoveLessonDto } from './dto/move-lesson.dto';
 import { TimetableEditService } from './timetable-edit.service';
+import { TimetableConflictService } from './timetable-conflict.service';
+import { ResolveConflictDto } from './dto/resolve-conflict.dto';
 import { CheckPermissions } from '../auth/decorators/check-permissions.decorator';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { AuthenticatedUser } from '../auth/types/authenticated-user';
@@ -50,6 +52,7 @@ export class TimetableController {
     private timetableService: TimetableService,
     private timetableEditService: TimetableEditService,
     private timetableExportService: TimetableExportService,
+    private timetableConflictService: TimetableConflictService,
   ) {}
 
   @Get('constraint-catalog')
@@ -132,6 +135,52 @@ export class TimetableController {
   @ApiResponse({ status: 404, description: 'Run not found' })
   async getConflicts(@Param('runId') runId: string) {
     return this.timetableService.getConflicts(runId);
+  }
+
+  /**
+   * GET /api/v1/schools/:schoolId/timetable/runs/:runId/conflicts/:conflictId/suggestions
+   * Issue #177-C: resolution options for one conflict — free qualified
+   * teachers / free compatible rooms at the original slot, plus free slots
+   * elsewhere. Drives the resolution dialog.
+   */
+  @Get('runs/:runId/conflicts/:conflictId/suggestions')
+  @CheckPermissions({ action: 'read', subject: 'timetable' })
+  @ApiOperation({ summary: 'Get resolution suggestions for a timetable conflict' })
+  @ApiResponse({ status: 200, description: 'Suggestions (resources + free slots)' })
+  @ApiResponse({ status: 404, description: 'Conflict not found' })
+  async getConflictSuggestions(
+    @Param('runId') runId: string,
+    @Param('conflictId') conflictId: string,
+  ) {
+    return this.timetableConflictService.getSuggestions(runId, conflictId);
+  }
+
+  /**
+   * POST /api/v1/schools/:schoolId/timetable/runs/:runId/conflicts/:conflictId/resolve
+   * Issue #177-C: apply a resolution (cancel / reassign-resource / move-slot)
+   * atomically. Flips the run back to COMPLETED once the last OPEN conflict is
+   * resolved.
+   */
+  @Post('runs/:runId/conflicts/:conflictId/resolve')
+  @HttpCode(HttpStatus.OK)
+  @CheckPermissions({ action: 'update', subject: 'timetable' })
+  @ApiOperation({ summary: 'Resolve a timetable conflict' })
+  @ApiResponse({ status: 200, description: 'Conflict resolved' })
+  @ApiResponse({ status: 400, description: 'Invalid resolution payload' })
+  @ApiResponse({ status: 404, description: 'Conflict not found' })
+  @ApiResponse({ status: 409, description: 'Target slot/resource is no longer free' })
+  async resolveConflict(
+    @Param('runId') runId: string,
+    @Param('conflictId') conflictId: string,
+    @Body() dto: ResolveConflictDto,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    return this.timetableConflictService.resolveConflict(
+      runId,
+      conflictId,
+      dto,
+      user.id,
+    );
   }
 
   @Delete('runs/:runId/stop')

--- a/apps/api/src/modules/timetable/timetable.module.ts
+++ b/apps/api/src/modules/timetable/timetable.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { TimetableController, SolverCallbackController } from './timetable.controller';
 import { TimetableService } from './timetable.service';
 import { TimetableEditService } from './timetable-edit.service';
+import { TimetableConflictService } from './timetable-conflict.service';
 import { TimetableExportService } from './timetable-export.service';
 import { TimetableGateway } from './timetable.gateway';
 import { TimetableEventsGateway } from './timetable-events.gateway';
@@ -24,6 +25,7 @@ import { SolveWatchdogService } from './solve-watchdog.service';
   providers: [
     TimetableService,
     TimetableEditService,
+    TimetableConflictService,
     TimetableExportService,
     TimetableGateway,
     TimetableEventsGateway,

--- a/apps/api/src/modules/timetable/timetable.service.spec.ts
+++ b/apps/api/src/modules/timetable/timetable.service.spec.ts
@@ -572,7 +572,9 @@ describe('TimetableService', () => {
         where: { schoolId: 'school-1' },
         orderBy: { createdAt: 'desc' },
         take: 3,
-        include: { _count: { select: { conflicts: true } } },
+        include: {
+          _count: { select: { conflicts: { where: { status: 'OPEN' } } } },
+        },
       });
     });
   });

--- a/apps/api/src/modules/timetable/timetable.service.ts
+++ b/apps/api/src/modules/timetable/timetable.service.ts
@@ -409,9 +409,12 @@ export class TimetableService {
       where: { schoolId },
       orderBy: { createdAt: 'desc' },
       take: MAX_RUNS_PER_SCHOOL,
-      // Issue #177-B: surface the conflict count so /admin/solver can render
-      // the "N Konflikte zu lösen" badge without a per-row follow-up fetch.
-      include: { _count: { select: { conflicts: true } } },
+      // Issue #177-B/C: surface the count of *open* conflicts so /admin/solver
+      // renders an accurate "N Konflikte zu lösen" badge that decreases as the
+      // admin resolves them — without a per-row follow-up fetch.
+      include: {
+        _count: { select: { conflicts: { where: { status: 'OPEN' } } } },
+      },
     });
   }
 

--- a/apps/web/e2e/admin-school-settings.spec.ts
+++ b/apps/web/e2e/admin-school-settings.spec.ts
@@ -8,7 +8,7 @@
  *   - prisma:seed executed so an admin user + sample school exist
  *   - DATABASE_URL exported in the test-runner shell (source apps/api/.env)
  */
-import { expect, test } from '@playwright/test';
+import { expect, test, type Page } from '@playwright/test';
 import {
   cleanupOrphanYear,
   seedOrphanYear,
@@ -16,13 +16,39 @@ import {
 } from './fixtures/orphan-year';
 import { getAdminToken, loginAsAdmin } from './helpers/login';
 
+/**
+ * Firefox aborts `page.goto` with NS_BINDING_ABORTED when the settings SPA does
+ * a client-side redirect (school-context bootstrap) while the document request
+ * is still in flight. This is a navigation-timing flake, not a cross-spec data
+ * race: SCHOOL-05 flaked on desktop-firefox in CI run 27100522605 while passing
+ * on chromium and on the immediately-prior run. Retrying the navigation lands
+ * after the app has settled. FIXME: deterministic-e2e #112
+ */
+async function gotoSettings(page: Page, tab?: string): Promise<void> {
+  const url = tab
+    ? `/admin/school/settings?tab=${tab}`
+    : '/admin/school/settings';
+  let lastErr: unknown;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      await page.goto(url);
+      return;
+    } catch (err) {
+      lastErr = err;
+      if (!String(err).includes('NS_BINDING_ABORTED')) throw err;
+      await page.waitForTimeout(250);
+    }
+  }
+  throw lastErr;
+}
+
 test.describe('Phase 10 — Admin School Settings (desktop)', () => {
   test.beforeEach(async ({ page }) => {
     await loginAsAdmin(page);
     // 10.3-01: loginAsRole no longer navigates to /admin/school/settings;
     // specs own their own post-login routing. This beforeEach restores the
     // pre-10.3 behavior for the admin-school-settings.spec shell.
-    await page.goto('/admin/school/settings');
+    await gotoSettings(page);
   });
 
   // 10.4-02: throwaway cleanup for SCHOOL-03 E2E-SCHOOL03-* rows.
@@ -106,7 +132,7 @@ test.describe('Phase 10 — Admin School Settings (desktop)', () => {
   });
 
   test('SCHOOL-02: time grid tab renders toggles + periods + Save', async ({ page }) => {
-    await page.goto('/admin/school/settings?tab=timegrid');
+    await gotoSettings(page, 'timegrid');
     await expect(page.getByRole('heading', { name: 'Unterrichtstage' })).toBeVisible();
 
     // At least Mo-Fr toggles visible.
@@ -135,7 +161,7 @@ test.describe('Phase 10 — Admin School Settings (desktop)', () => {
     // 10.4-02: parameterize year name to avoid multi-worker collision
     // (seed school is shared across all admin-school-settings workers).
     const yearName = `E2E-SCHOOL03-${Date.now()}`;
-    await page.goto('/admin/school/settings?tab=years');
+    await gotoSettings(page, 'years');
     await page.getByRole('button', { name: /Neues Schuljahr anlegen/ }).click();
     // Dialog open — 5 fields.
     await page.getByLabel('Name').fill(yearName);
@@ -182,7 +208,7 @@ test.describe('Phase 10 — Admin School Settings (desktop)', () => {
   test('SCHOOL-04: A/B toggle persists across reload + toast "Option gespeichert."', async ({
     page,
   }) => {
-    await page.goto('/admin/school/settings?tab=options');
+    await gotoSettings(page, 'options');
     const toggle = page.getByLabel('A/B-Wochen-Modus aktivieren');
     const initiallyChecked = await toggle.isChecked();
     await toggle.click();
@@ -210,7 +236,7 @@ test.describe('Phase 10 — Admin School Settings (desktop)', () => {
 
     const fixture: OrphanFixture = await seedOrphanYear(schoolId);
     try {
-      await page.goto('/admin/school/settings?tab=years');
+      await gotoSettings(page, 'years');
       const yearLabel = page.getByText(/^ORPHAN-TEST-YEAR-/);
       await expect(yearLabel).toBeVisible();
       const card = yearLabel.locator(

--- a/apps/web/e2e/admin-solver-conflicts.spec.ts
+++ b/apps/web/e2e/admin-solver-conflicts.spec.ts
@@ -128,4 +128,48 @@ test.describe('Issue #177-B — COMPLETED_WITH_CONFLICTS workflow (throwaway-sch
       'persisted partial-plan lesson must render after activation',
     ).toBeVisible();
   });
+
+  test('CONFLICT-03: resolving the last conflict (cancel) flips the run to COMPLETED and clears the card', async ({
+    page,
+    context,
+  }) => {
+    // #177-C: the resolution dialog's "cancel" path always works (no dependency
+    // on free teachers/rooms), so it is the deterministic happy-path lock.
+    fixture = await createThrowawaySchool({
+      roles: { admin: true },
+      withTimetableStack: { active: false },
+      withConflict: true,
+      namePrefix: 'E2E-CONFLICT03',
+    });
+    const stack = fixture.timetable!;
+
+    await useThrowawaySchoolHeader(context, fixture.schoolId);
+    await loginAsAdmin(page);
+    await page.goto('/admin/solver');
+
+    // Open the resolution dialog for the seeded conflict.
+    await expect(page.getByTestId('solver-conflicts-card')).toBeVisible();
+    await page.getByTestId(`resolve-conflict-${stack.conflictId}`).click();
+
+    const dialog = page.getByTestId('conflict-resolve-dialog');
+    await expect(dialog).toBeVisible();
+
+    // "Lektion entfernen" (cancel) is the default selection — submit it.
+    await page.getByTestId('conflict-resolve-submit').click();
+
+    // The run had exactly one conflict → resolving it completes the plan.
+    await expect(
+      page.getByText('Stundenplan ist jetzt vollständig'),
+    ).toBeVisible();
+
+    // The conflict card disappears (no OPEN conflicts left) and the run row no
+    // longer advertises conflicts (status flipped COMPLETED_WITH_CONFLICTS →
+    // COMPLETED), so the plain Aktivieren button is now offered.
+    await expect(page.getByTestId('solver-conflicts-card')).toHaveCount(0);
+    const runRow = page.getByTestId(`recent-run-row-${stack.timetableRunId}`);
+    await expect(runRow).not.toContainText('Konflikte');
+    await expect(
+      page.getByTestId(`activate-run-${stack.timetableRunId}`),
+    ).toBeVisible();
+  });
 });

--- a/apps/web/src/components/admin/solver/ConflictResolutionDialog.tsx
+++ b/apps/web/src/components/admin/solver/ConflictResolutionDialog.tsx
@@ -1,0 +1,279 @@
+import { useEffect, useState } from 'react';
+import { toast } from 'sonner';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import type { TimetableConflictDto } from '@/hooks/useTimetableConflicts';
+import {
+  useConflictSuggestions,
+  useResolveConflict,
+  type ResolveConflictPayload,
+} from '@/hooks/useConflictResolution';
+
+/**
+ * Issue #177-C — resolution dialog for a single dropped-lesson conflict.
+ *
+ * Three actions, gated on what the suggestions endpoint returns:
+ *   - reassign-resource: assign a free qualified teacher (TEACHER conflict) or
+ *     a free compatible room (ROOM conflict) at the original slot.
+ *   - move-slot: move the lesson (original teacher + room) to a free slot.
+ *   - cancel: drop the lesson permanently.
+ *
+ * On success the run flips back to COMPLETED once the last conflict is gone.
+ */
+
+type Action = ResolveConflictPayload['action'];
+
+export function ConflictResolutionDialog({
+  open,
+  schoolId,
+  runId,
+  conflict,
+  onClose,
+}: {
+  open: boolean;
+  schoolId: string;
+  runId: string;
+  conflict: TimetableConflictDto | null;
+  onClose: () => void;
+}) {
+  const conflictId = conflict?.id ?? null;
+  const isTeacher = conflict?.conflictType === 'TEACHER';
+
+  const { data: suggestions, isLoading } = useConflictSuggestions(
+    schoolId,
+    runId,
+    conflictId,
+    open,
+  );
+  const resolve = useResolveConflict(schoolId, runId);
+
+  const [action, setAction] = useState<Action>('cancel');
+  const [resourceId, setResourceId] = useState<string>('');
+  const [slotKey, setSlotKey] = useState<string>('');
+
+  // Reset the form each time the dialog opens for a (new) conflict.
+  useEffect(() => {
+    if (open) {
+      setAction('cancel');
+      setResourceId('');
+      setSlotKey('');
+    }
+  }, [open, conflictId]);
+
+  const resources = suggestions?.alternativeResources ?? [];
+  const freeSlots = suggestions?.freeSlots ?? [];
+  const reassignLabel = isTeacher
+    ? 'Anderen Lehrer zuweisen'
+    : 'Anderen Raum zuweisen';
+
+  const handleSubmit = () => {
+    if (!conflict) return;
+    let payload: ResolveConflictPayload;
+    if (action === 'cancel') {
+      payload = { action: 'cancel' };
+    } else if (action === 'reassign-resource') {
+      if (!resourceId) {
+        toast.error(
+          isTeacher ? 'Bitte einen Lehrer wählen.' : 'Bitte einen Raum wählen.',
+        );
+        return;
+      }
+      payload = isTeacher
+        ? { action: 'reassign-resource', newTeacherId: resourceId }
+        : { action: 'reassign-resource', newRoomId: resourceId };
+    } else {
+      const slot = freeSlots.find(
+        (s) => `${s.dayOfWeek}-${s.periodNumber}-${s.weekType}` === slotKey,
+      );
+      if (!slot) {
+        toast.error('Bitte einen freien Slot wählen.');
+        return;
+      }
+      payload = {
+        action: 'move-slot',
+        dayOfWeek: slot.dayOfWeek,
+        periodNumber: slot.periodNumber,
+        weekType: slot.weekType,
+      };
+    }
+
+    resolve.mutate(
+      { conflictId: conflict.id, payload },
+      {
+        onSuccess: (res) => {
+          toast.success(
+            res.runCompleted
+              ? 'Konflikt gelöst — Stundenplan ist jetzt vollständig.'
+              : 'Konflikt gelöst.',
+          );
+          onClose();
+        },
+        onError: (err) => {
+          toast.error('Konflikt konnte nicht gelöst werden', {
+            description:
+              err instanceof Error ? err.message : 'Unbekannter Fehler',
+          });
+        },
+      },
+    );
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="sm:max-w-md" data-testid="conflict-resolve-dialog">
+        <DialogHeader>
+          <DialogTitle>Konflikt lösen</DialogTitle>
+        </DialogHeader>
+
+        {conflict && (
+          <div className="space-y-4">
+            <div className="rounded-md border border-border bg-muted/30 p-3 text-sm">
+              <div className="font-semibold">{conflict.subjectLabel}</div>
+              <div className="text-muted-foreground">
+                {isTeacher ? 'Lehrer-Doppelbelegung' : 'Raum-Doppelbelegung'}
+                {conflict.conflictsWithLabel
+                  ? ` · kollidiert mit ${conflict.conflictsWithLabel}`
+                  : ''}
+              </div>
+            </div>
+
+            <RadioGroup
+              value={action}
+              onValueChange={(v) => setAction(v as Action)}
+              className="space-y-3"
+            >
+              {/* reassign-resource */}
+              <div className="space-y-2">
+                <div className="flex items-center gap-2">
+                  <RadioGroupItem
+                    value="reassign-resource"
+                    id="action-reassign"
+                    disabled={resources.length === 0}
+                    data-testid="action-reassign"
+                  />
+                  <Label
+                    htmlFor="action-reassign"
+                    className={
+                      resources.length === 0 ? 'text-muted-foreground' : ''
+                    }
+                  >
+                    {reassignLabel}
+                    {!isLoading && resources.length === 0 && (
+                      <span className="text-xs"> (keine frei)</span>
+                    )}
+                  </Label>
+                </div>
+                {action === 'reassign-resource' && resources.length > 0 && (
+                  <Select value={resourceId} onValueChange={setResourceId}>
+                    <SelectTrigger
+                      className="min-h-11 sm:min-h-9"
+                      data-testid="reassign-select"
+                    >
+                      <SelectValue
+                        placeholder={isTeacher ? 'Lehrer wählen' : 'Raum wählen'}
+                      />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {resources.map((r) => (
+                        <SelectItem key={r.id} value={r.id}>
+                          {r.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+              </div>
+
+              {/* move-slot */}
+              <div className="space-y-2">
+                <div className="flex items-center gap-2">
+                  <RadioGroupItem
+                    value="move-slot"
+                    id="action-move"
+                    disabled={freeSlots.length === 0}
+                    data-testid="action-move"
+                  />
+                  <Label
+                    htmlFor="action-move"
+                    className={
+                      freeSlots.length === 0 ? 'text-muted-foreground' : ''
+                    }
+                  >
+                    In freien Slot verschieben
+                    {!isLoading && freeSlots.length === 0 && (
+                      <span className="text-xs"> (keiner frei)</span>
+                    )}
+                  </Label>
+                </div>
+                {action === 'move-slot' && freeSlots.length > 0 && (
+                  <Select value={slotKey} onValueChange={setSlotKey}>
+                    <SelectTrigger
+                      className="min-h-11 sm:min-h-9"
+                      data-testid="move-select"
+                    >
+                      <SelectValue placeholder="Slot wählen" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {freeSlots.map((s) => {
+                        const key = `${s.dayOfWeek}-${s.periodNumber}-${s.weekType}`;
+                        return (
+                          <SelectItem key={key} value={key}>
+                            {s.label}
+                          </SelectItem>
+                        );
+                      })}
+                    </SelectContent>
+                  </Select>
+                )}
+              </div>
+
+              {/* cancel */}
+              <div className="flex items-center gap-2">
+                <RadioGroupItem
+                  value="cancel"
+                  id="action-cancel"
+                  data-testid="action-cancel"
+                />
+                <Label htmlFor="action-cancel">Lektion entfernen</Label>
+              </div>
+            </RadioGroup>
+          </div>
+        )}
+
+        <DialogFooter className="flex flex-col-reverse sm:flex-row sm:justify-end gap-2">
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={onClose}
+            disabled={resolve.isPending}
+          >
+            Abbrechen
+          </Button>
+          <Button
+            type="button"
+            onClick={handleSubmit}
+            disabled={resolve.isPending}
+            data-testid="conflict-resolve-submit"
+          >
+            {resolve.isPending ? 'Wird gelöst…' : 'Lösen'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/admin/solver/ConflictsCard.tsx
+++ b/apps/web/src/components/admin/solver/ConflictsCard.tsx
@@ -1,19 +1,19 @@
-import { Link } from '@tanstack/react-router';
+import { useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
 import {
   useTimetableConflicts,
   type TimetableConflictDto,
 } from '@/hooks/useTimetableConflicts';
+import { ConflictResolutionDialog } from './ConflictResolutionDialog';
 
 /**
- * Issue #177-B — read-only surface for the dropped-lesson conflicts behind a
+ * Issue #177-B/C — surface + resolve the dropped-lesson conflicts behind a
  * COMPLETED_WITH_CONFLICTS run. Renders "N Konflikte zu lösen" with a
- * human-readable list (which teacher/room is double-booked in which slot) and
- * a deep-link to the manual editor. Returns null when the run has no conflicts
- * so the page stays clean for healthy runs.
- *
- * The full per-conflict resolution UX (reassign teacher / move slot / cancel)
- * lands in #177-C; this card is the visibility floor that unblocks the admin.
+ * human-readable list (which teacher/room is double-booked in which slot), and
+ * a per-conflict "Lösen" button that opens the resolution dialog (#177-C:
+ * reassign teacher/room, move to a free slot, or cancel the lesson). Returns
+ * null when the run has no open conflicts so the page stays clean.
  */
 
 const DAY_LABELS: Record<string, string> = {
@@ -39,7 +39,11 @@ export function ConflictsCard({
   schoolId: string;
   runId: string;
 }) {
-  const { data: conflicts = [] } = useTimetableConflicts(schoolId, runId);
+  const { data: allConflicts = [] } = useTimetableConflicts(schoolId, runId);
+  const [selected, setSelected] = useState<TimetableConflictDto | null>(null);
+
+  // Only OPEN conflicts are actionable; resolved ones drop off the card.
+  const conflicts = allConflicts.filter((c) => c.status === 'OPEN');
 
   if (conflicts.length === 0) return null;
 
@@ -67,53 +71,67 @@ export function ConflictsCard({
           {conflicts.map((c) => (
             <li
               key={c.id}
-              className="rounded-md border border-amber-200 bg-background/60 p-3"
+              className="flex flex-wrap items-start justify-between gap-3 rounded-md border border-amber-200 bg-background/60 p-3"
               data-testid={`conflict-row-${c.id}`}
             >
-              <div className="flex flex-wrap items-center gap-2">
-                <span className="rounded bg-amber-100 px-2 py-0.5 text-xs font-semibold text-amber-800">
-                  {c.conflictType === 'TEACHER'
-                    ? 'Lehrer-Doppelbelegung'
-                    : 'Raum-Doppelbelegung'}
-                </span>
-                <span className="font-mono text-xs text-muted-foreground">
-                  {slotLabel(c)}
-                </span>
-              </div>
-              <div className="mt-1.5">
-                <span className="font-semibold">
-                  {c.subjectLabel ?? 'Lektion'}
-                </span>
-                {c.conflictsWithLabel && (
-                  <>
-                    {' '}
-                    kollidiert mit{' '}
-                    <span className="font-semibold">{c.conflictsWithLabel}</span>
-                  </>
-                )}
-                {c.conflictType === 'TEACHER' && c.teacherLabel && (
-                  <span className="text-muted-foreground">
-                    {' '}
-                    · Lehrer: {c.teacherLabel}
+              <div className="min-w-0">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="rounded bg-amber-100 px-2 py-0.5 text-xs font-semibold text-amber-800">
+                    {c.conflictType === 'TEACHER'
+                      ? 'Lehrer-Doppelbelegung'
+                      : 'Raum-Doppelbelegung'}
                   </span>
-                )}
-                {c.conflictType === 'ROOM' && c.roomLabel && (
-                  <span className="text-muted-foreground">
-                    {' '}
-                    · Raum: {c.roomLabel}
+                  <span className="font-mono text-xs text-muted-foreground">
+                    {slotLabel(c)}
                   </span>
-                )}
+                </div>
+                <div className="mt-1.5">
+                  <span className="font-semibold">
+                    {c.subjectLabel ?? 'Lektion'}
+                  </span>
+                  {c.conflictsWithLabel && (
+                    <>
+                      {' '}
+                      kollidiert mit{' '}
+                      <span className="font-semibold">
+                        {c.conflictsWithLabel}
+                      </span>
+                    </>
+                  )}
+                  {c.conflictType === 'TEACHER' && c.teacherLabel && (
+                    <span className="text-muted-foreground">
+                      {' '}
+                      · Lehrer: {c.teacherLabel}
+                    </span>
+                  )}
+                  {c.conflictType === 'ROOM' && c.roomLabel && (
+                    <span className="text-muted-foreground">
+                      {' '}
+                      · Raum: {c.roomLabel}
+                    </span>
+                  )}
+                </div>
               </div>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => setSelected(c)}
+                data-testid={`resolve-conflict-${c.id}`}
+              >
+                Lösen
+              </Button>
             </li>
           ))}
         </ul>
-        <Link
-          to="/admin/timetable-edit"
-          className="inline-block text-sm font-medium text-primary underline-offset-4 hover:underline"
-        >
-          Stundenplan bearbeiten →
-        </Link>
       </CardContent>
+
+      <ConflictResolutionDialog
+        open={selected !== null}
+        schoolId={schoolId}
+        runId={runId}
+        conflict={selected}
+        onClose={() => setSelected(null)}
+      />
     </Card>
   );
 }

--- a/apps/web/src/hooks/useConflictResolution.ts
+++ b/apps/web/src/hooks/useConflictResolution.ts
@@ -1,0 +1,105 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { apiFetch } from '@/lib/api';
+
+/**
+ * Issue #177-C — resolution suggestions + the resolve mutation for a single
+ * TimetableConflict. The suggestions back the resolution dialog's dropdowns;
+ * the mutation applies the chosen action and (on the last conflict) flips the
+ * run back to COMPLETED.
+ */
+
+export interface ConflictSuggestionsDto {
+  conflictId: string;
+  conflictType: 'TEACHER' | 'ROOM';
+  /** Free qualified teachers (TEACHER) or free compatible rooms (ROOM). */
+  alternativeResources: { id: string; label: string }[];
+  /** Slots free for both the conflict's teacher and room (for move-slot). */
+  freeSlots: {
+    dayOfWeek: string;
+    periodNumber: number;
+    weekType: string;
+    label: string;
+  }[];
+}
+
+export interface ResolveConflictPayload {
+  action: 'reassign-resource' | 'move-slot' | 'cancel';
+  newTeacherId?: string;
+  newRoomId?: string;
+  dayOfWeek?: string;
+  periodNumber?: number;
+  weekType?: string;
+}
+
+export function useConflictSuggestions(
+  schoolId: string | null | undefined,
+  runId: string | null | undefined,
+  conflictId: string | null | undefined,
+  enabled: boolean,
+) {
+  return useQuery({
+    queryKey: [
+      'timetable-conflict-suggestions',
+      schoolId ?? '',
+      runId ?? '',
+      conflictId ?? '',
+    ],
+    queryFn: async (): Promise<ConflictSuggestionsDto> => {
+      const res = await apiFetch(
+        `/api/v1/schools/${schoolId}/timetable/runs/${runId}/conflicts/${conflictId}/suggestions`,
+      );
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      return (await res.json()) as ConflictSuggestionsDto;
+    },
+    enabled: enabled && !!schoolId && !!runId && !!conflictId,
+  });
+}
+
+export function useResolveConflict(
+  schoolId: string | null | undefined,
+  runId: string | null | undefined,
+) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (vars: {
+      conflictId: string;
+      payload: ResolveConflictPayload;
+    }) => {
+      const res = await apiFetch(
+        `/api/v1/schools/${schoolId}/timetable/runs/${runId}/conflicts/${vars.conflictId}/resolve`,
+        { method: 'POST', body: JSON.stringify(vars.payload) },
+      );
+      if (!res.ok) {
+        let message = `HTTP ${res.status}`;
+        try {
+          const body = (await res.json()) as { message?: string | string[] };
+          if (body?.message) {
+            message = Array.isArray(body.message)
+              ? body.message.join(', ')
+              : body.message;
+          }
+        } catch {
+          /* keep the HTTP fallback */
+        }
+        throw new Error(message);
+      }
+      return (await res.json()) as {
+        resolved: boolean;
+        conflictId: string;
+        action: string;
+        runCompleted: boolean;
+      };
+    },
+    onSuccess: () => {
+      // Refresh the conflict list, the recent-runs list (status may have
+      // flipped to COMPLETED), and the active timetable view.
+      void queryClient.invalidateQueries({
+        queryKey: ['timetable-conflicts', schoolId ?? '', runId ?? ''],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: ['timetable-runs:recent'],
+      });
+      void queryClient.invalidateQueries({ queryKey: ['timetable-view'] });
+    },
+  });
+}


### PR DESCRIPTION
## Was & Warum

Sub-Issue **C** von #177, baut auf **B** (#179, gemerged) auf. Ein `COMPLETED_WITH_CONFLICTS`-Run (residuale Lehrer-/Raum-Doppelbelegung aus dem Solver) ist jetzt **direkt im UI auflösbar** — ohne Datenbestand oder Constraint-Modeling manuell anzufassen.

## Änderungen

**Backend — `TimetableConflictService`**
- `getSuggestions(runId, conflictId)`: Auflösungs-Optionen
  - `alternativeResources`: bei TEACHER-Konflikt qualifizierte (TeacherSubject) + im Slot freie Lehrer; bei ROOM-Konflikt typ-kompatible + freie Räume.
  - `freeSlots`: Slots (aktive SchoolDays × Perioden) in denen Lehrer **und** Raum frei sind (week-type-aware).
- `resolveConflict(runId, conflictId, dto, userId)` in einer Transaktion:
  - `cancel` — Lektion endgültig verwerfen.
  - `reassign-resource` — am Original-Slot mit freiem Lehrer (`newTeacherId`) bzw. Raum (`newRoomId`); validiert Qualifikation / Raumtyp + Slot-Freiheit.
  - `move-slot` — Original-Lehrer+Raum in einen freien Slot.
  - Clash-Validierung (Lehrer/Raum/Student-Group) + P2002→409-Guard.
  - Letzter OPEN-Konflikt gelöst → Run `COMPLETED_WITH_CONFLICTS` → `COMPLETED`.
- Endpoints: `GET runs/:runId/conflicts/:conflictId/suggestions` + `POST .../resolve` (`@CurrentUser` → `resolvedBy`).
- `findRuns` zählt jetzt nur **offene** Konflikte → Badge sinkt beim Auflösen.

**Frontend**
- `ConflictResolutionDialog`: Radio (anderer Lehrer/Raum · freier Slot · entfernen) mit Suggestion-Dropdowns; per-Konflikt „Lösen"-Button auf der `ConflictsCard`. Resolved Konflikte fallen aus der Karte; Run-Status-Flip wird live invalidiert.

## Regression-Lock
- **API-Unit** (`timetable-conflict.service.spec.ts`, 8): cancel→COMPLETED, „andere offen → bleibt", move-slot create, reassign (qualifiziert) create + reject-unqualified, already-resolved/NotFound, getSuggestions (freie Lehrer + freie Slots).
- **E2E** (`admin-solver-conflicts.spec.ts` CONFLICT-03, desktop+firefox grün lokal): Konflikt via Dialog (cancel) lösen → Toast „Stundenplan ist jetzt vollständig" → Karte weg + Run-Row ohne „Konflikte" + Aktivieren sichtbar.

## Lokale Verifikation
- API build 0 issues · web `tsc -b && vite build` grün.
- API vitest: **813 passed** (+8).
- E2E: CONFLICT-01/02/03 grün auf desktop **und** desktop-firefox.

## Scope
- Kein Schema-Change (baut auf B's `TimetableConflict` auf) → keine Migration.
- Out of scope (wie im Issue): „Re-Solve nur für die N konfligierenden Slots".
- **#177-D** (Diagnostics) folgt als Nächstes.

Closes #180
Refs #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)