### PR TITLE
feat(timetable): #181 — Solver Diagnostics (Pre-Solve-Check + Solve-Report) (Pattern D of #177)

### DIFF
--- a/apps/api/src/modules/timetable/timetable-diagnostics.service.spec.ts
+++ b/apps/api/src/modules/timetable/timetable-diagnostics.service.spec.ts
@@ -1,0 +1,172 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TimetableDiagnosticsService } from './timetable-diagnostics.service';
+import { PrismaService } from '../../config/database/prisma.service';
+
+/**
+ * Issue #177-D — unit tests for the solver diagnostics service.
+ */
+describe('TimetableDiagnosticsService', () => {
+  let service: TimetableDiagnosticsService;
+  let prisma: any;
+
+  const mockPrisma = {
+    schoolDay: { count: vi.fn() },
+    period: { count: vi.fn() },
+    classSubject: { findMany: vi.fn() },
+    room: { groupBy: vi.fn(), findMany: vi.fn() },
+    timetableRun: { findUniqueOrThrow: vi.fn() },
+    teacher: { findMany: vi.fn() },
+  };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TimetableDiagnosticsService,
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
+    }).compile();
+    service = module.get(TimetableDiagnosticsService);
+    prisma = mockPrisma;
+  });
+
+  describe('getFeasibility', () => {
+    it('reports feasible when demand fits the grid', async () => {
+      prisma.schoolDay.count.mockResolvedValue(5);
+      prisma.period.count.mockResolvedValue(5); // gridSlots = 25
+      prisma.classSubject.findMany.mockResolvedValue([
+        {
+          weeklyHours: 4,
+          teacherId: 't1',
+          classId: 'c1',
+          schoolClass: { name: '1A' },
+          teacher: { person: { lastName: 'Müller' } },
+          subject: { requiredRoomType: null },
+        },
+      ]);
+      prisma.room.groupBy.mockResolvedValue([
+        { roomType: 'KLASSENZIMMER', _count: { _all: 3 } },
+      ]);
+
+      const res = await service.getFeasibility('school-1');
+
+      expect(res.feasible).toBe(true);
+      expect(res.gridSlots).toBe(25);
+      expect(res.totalLessons).toBe(4);
+      expect(res.warnings).toHaveLength(0);
+    });
+
+    it('flags an over-dimensioned class as a hard error', async () => {
+      prisma.schoolDay.count.mockResolvedValue(5);
+      prisma.period.count.mockResolvedValue(1); // gridSlots = 5
+      prisma.classSubject.findMany.mockResolvedValue([
+        {
+          weeklyHours: 10, // > 5 slots → CLASS + TEACHER overloaded
+          teacherId: 't1',
+          classId: 'c1',
+          schoolClass: { name: '1A' },
+          teacher: { person: { lastName: 'Müller' } },
+          subject: { requiredRoomType: null },
+        },
+      ]);
+      prisma.room.groupBy.mockResolvedValue([
+        { roomType: 'KLASSENZIMMER', _count: { _all: 1 } },
+      ]);
+
+      const res = await service.getFeasibility('school-1');
+
+      expect(res.feasible).toBe(false);
+      const types = res.warnings.map((w) => w.type);
+      expect(types).toContain('CLASS_OVERLOADED');
+      expect(types).toContain('TEACHER_OVERLOADED');
+      // 10 lessons vs 1 room × 5 slots = 5 → room capacity error too.
+      expect(types).toContain('ROOM_CAPACITY');
+    });
+
+    it('warns (non-fatal) about unassigned-teacher hours', async () => {
+      prisma.schoolDay.count.mockResolvedValue(5);
+      prisma.period.count.mockResolvedValue(5);
+      prisma.classSubject.findMany.mockResolvedValue([
+        {
+          weeklyHours: 3,
+          teacherId: null, // unassigned
+          classId: 'c1',
+          schoolClass: { name: '1A' },
+          teacher: null,
+          subject: { requiredRoomType: null },
+        },
+      ]);
+      prisma.room.groupBy.mockResolvedValue([
+        { roomType: 'KLASSENZIMMER', _count: { _all: 2 } },
+      ]);
+
+      const res = await service.getFeasibility('school-1');
+
+      // A warning does not break feasibility.
+      expect(res.feasible).toBe(true);
+      expect(res.warnings.map((w) => w.type)).toEqual(['UNASSIGNED_TEACHER']);
+      expect(res.warnings[0].severity).toBe('warning');
+    });
+  });
+
+  describe('getReport', () => {
+    it('aggregates teacher/room utilization, class distribution, and top constraints', async () => {
+      prisma.timetableRun.findUniqueOrThrow.mockResolvedValue({
+        id: 'run-1',
+        schoolId: 'school-1',
+        status: 'COMPLETED',
+        hardScore: 0,
+        softScore: -5,
+        violations: [{ type: 'Teacher conflict', count: 2, examples: [] }],
+        lessons: [
+          { teacherId: 't1', roomId: 'r1', classSubjectId: 'cs1' },
+          { teacherId: 't1', roomId: 'r2', classSubjectId: 'cs2' },
+          { teacherId: 't2', roomId: 'r1', classSubjectId: 'cs1' },
+        ],
+      });
+      prisma.schoolDay.count.mockResolvedValue(5);
+      prisma.period.count.mockResolvedValue(1); // gridSlots = 5
+      prisma.teacher.findMany.mockResolvedValue([
+        { id: 't1', person: { lastName: 'Müller' } },
+        { id: 't2', person: { lastName: 'Huber' } },
+      ]);
+      prisma.room.findMany.mockResolvedValue([
+        { id: 'r1', name: 'R1' },
+        { id: 'r2', name: 'R2' },
+      ]);
+      prisma.classSubject.findMany.mockResolvedValue([
+        { id: 'cs1', classId: 'c1', schoolClass: { name: '1A' } },
+        { id: 'cs2', classId: 'c2', schoolClass: { name: '2B' } },
+      ]);
+
+      const res = await service.getReport('run-1');
+
+      expect(res.lessonCount).toBe(3);
+      expect(res.gridSlots).toBe(5);
+
+      // t1 has 2 lessons (40%), t2 has 1 (20%); sorted desc.
+      expect(res.teacherUtilization[0]).toMatchObject({
+        teacherId: 't1',
+        label: 'Müller',
+        lessons: 2,
+        pct: 40,
+      });
+      expect(res.teacherUtilization[1]).toMatchObject({
+        teacherId: 't2',
+        lessons: 1,
+      });
+
+      // r1 hosts 2 lessons, r2 hosts 1.
+      const r1 = res.roomUtilization.find((r) => r.roomId === 'r1');
+      expect(r1).toMatchObject({ label: 'R1', lessons: 2 });
+
+      // cs1 maps to class c1 and appears twice → class 1A has 2 lessons.
+      const c1 = res.classDistribution.find((c) => c.classId === 'c1');
+      expect(c1).toMatchObject({ label: '1A', lessons: 2 });
+
+      expect(res.topConstraints).toEqual([
+        { type: 'Teacher conflict', count: 2 },
+      ]);
+    });
+  });
+});

--- a/apps/api/src/modules/timetable/timetable-diagnostics.service.ts
+++ b/apps/api/src/modules/timetable/timetable-diagnostics.service.ts
@@ -1,0 +1,333 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../../config/database/prisma.service';
+import { ViolationGroupDto } from './dto/solve-progress.dto';
+
+export type FeasibilitySeverity = 'error' | 'warning';
+
+export interface FeasibilityWarning {
+  type: string;
+  severity: FeasibilitySeverity;
+  message: string;
+}
+
+export interface FeasibilityReport {
+  feasible: boolean;
+  gridSlots: number;
+  totalLessons: number;
+  roomCount: number;
+  classCount: number;
+  teacherCount: number;
+  warnings: FeasibilityWarning[];
+}
+
+const TOP_CONSTRAINTS = 5;
+
+/**
+ * Issue #177-D — solver diagnostics.
+ *
+ * `getFeasibility` is a pre-solve sanity check: it compares the demanded weekly
+ * lesson hours against the capacity of the time grid / teachers / rooms and
+ * surfaces over-dimensioning BEFORE a (long) solve is started. It never claims
+ * infeasible on a packing technicality — every `error` it raises is a genuine
+ * necessary-condition violation (demand strictly exceeds an upper bound), so
+ * teacher availability rules are deliberately ignored (they can only reduce
+ * capacity further, never create a false alarm).
+ *
+ * `getReport` is a post-run overview: teacher/room utilization, per-class
+ * lesson distribution, and the hardest remaining constraints.
+ */
+@Injectable()
+export class TimetableDiagnosticsService {
+  constructor(private prisma: PrismaService) {}
+
+  /** Number of schedulable slots = active days × non-break periods. */
+  private async gridSlots(schoolId: string): Promise<number> {
+    const [days, periods] = await Promise.all([
+      this.prisma.schoolDay.count({ where: { schoolId, isActive: true } }),
+      this.prisma.period.count({
+        where: { timeGrid: { schoolId }, isBreak: false },
+      }),
+    ]);
+    return days * periods;
+  }
+
+  async getFeasibility(schoolId: string): Promise<FeasibilityReport> {
+    const [gridSlots, classSubjects, roomGroups] = await Promise.all([
+      this.gridSlots(schoolId),
+      this.prisma.classSubject.findMany({
+        where: { schoolClass: { schoolId } },
+        select: {
+          weeklyHours: true,
+          teacherId: true,
+          classId: true,
+          schoolClass: { select: { name: true } },
+          teacher: {
+            select: { person: { select: { lastName: true } } },
+          },
+          subject: { select: { requiredRoomType: true } },
+        },
+      }),
+      this.prisma.room.groupBy({
+        by: ['roomType'],
+        where: { schoolId },
+        _count: { _all: true },
+      }),
+    ]);
+
+    const roomCount = roomGroups.reduce((sum, g) => sum + g._count._all, 0);
+    const roomsByType = new Map(
+      roomGroups.map((g) => [g.roomType as string, g._count._all]),
+    );
+
+    const totalLessons = classSubjects.reduce(
+      (sum, cs) => sum + cs.weeklyHours,
+      0,
+    );
+
+    const warnings: FeasibilityWarning[] = [];
+
+    if (gridSlots === 0) {
+      warnings.push({
+        type: 'NO_GRID',
+        severity: 'error',
+        message:
+          'Kein Zeitraster: Es sind keine Unterrichtstage oder Perioden definiert.',
+      });
+    }
+    if (roomCount === 0) {
+      warnings.push({
+        type: 'NO_ROOMS',
+        severity: 'error',
+        message: 'Keine Räume angelegt — der Solver kann keinen Plan erzeugen.',
+      });
+    }
+
+    // Per-class capacity: a class can hold at most one lesson per slot.
+    const hoursByClass = new Map<string, { name: string; hours: number }>();
+    for (const cs of classSubjects) {
+      const entry = hoursByClass.get(cs.classId) ?? {
+        name: cs.schoolClass?.name ?? cs.classId,
+        hours: 0,
+      };
+      entry.hours += cs.weeklyHours;
+      hoursByClass.set(cs.classId, entry);
+    }
+    if (gridSlots > 0) {
+      for (const { name, hours } of hoursByClass.values()) {
+        if (hours > gridSlots) {
+          warnings.push({
+            type: 'CLASS_OVERLOADED',
+            severity: 'error',
+            message: `Klasse ${name}: ${hours} Wochenstunden, aber nur ${gridSlots} Slots verfügbar.`,
+          });
+        }
+      }
+    }
+
+    // Per-teacher capacity: a teacher can teach at most one lesson per slot.
+    const hoursByTeacher = new Map<string, { label: string; hours: number }>();
+    let unassignedHours = 0;
+    for (const cs of classSubjects) {
+      if (!cs.teacherId) {
+        unassignedHours += cs.weeklyHours;
+        continue;
+      }
+      const entry = hoursByTeacher.get(cs.teacherId) ?? {
+        label: cs.teacher?.person?.lastName ?? cs.teacherId,
+        hours: 0,
+      };
+      entry.hours += cs.weeklyHours;
+      hoursByTeacher.set(cs.teacherId, entry);
+    }
+    if (gridSlots > 0) {
+      for (const { label, hours } of hoursByTeacher.values()) {
+        if (hours > gridSlots) {
+          warnings.push({
+            type: 'TEACHER_OVERLOADED',
+            severity: 'error',
+            message: `Lehrer ${label}: ${hours} Stunden zugewiesen, aber nur ${gridSlots} Slots verfügbar.`,
+          });
+        }
+      }
+    }
+    if (unassignedHours > 0) {
+      warnings.push({
+        type: 'UNASSIGNED_TEACHER',
+        severity: 'warning',
+        message: `${unassignedHours} Wochenstunden ohne zugewiesenen Lehrer — diese Lektionen können nicht zuverlässig geplant werden.`,
+      });
+    }
+
+    // Room capacity: every lesson needs a room-slot.
+    if (gridSlots > 0 && roomCount > 0 && totalLessons > roomCount * gridSlots) {
+      warnings.push({
+        type: 'ROOM_CAPACITY',
+        severity: 'error',
+        message: `Zu wenige Räume: ${totalLessons} Lektionen, aber nur ${roomCount} × ${gridSlots} = ${
+          roomCount * gridSlots
+        } Raum-Slots.`,
+      });
+    }
+
+    // Special-room-type capacity.
+    if (gridSlots > 0) {
+      const demandByType = new Map<string, number>();
+      for (const cs of classSubjects) {
+        const t = cs.subject?.requiredRoomType;
+        if (t) demandByType.set(t, (demandByType.get(t) ?? 0) + cs.weeklyHours);
+      }
+      for (const [type, demand] of demandByType) {
+        const supply = (roomsByType.get(type) ?? 0) * gridSlots;
+        if (demand > supply) {
+          warnings.push({
+            type: 'ROOM_TYPE_CAPACITY',
+            severity: 'error',
+            message: `Zu wenige Räume vom Typ ${type}: ${demand} Lektionen benötigen ihn, aber nur ${supply} passende Raum-Slots.`,
+          });
+        }
+      }
+    }
+
+    return {
+      feasible: warnings.every((w) => w.severity !== 'error'),
+      gridSlots,
+      totalLessons,
+      roomCount,
+      classCount: hoursByClass.size,
+      teacherCount: hoursByTeacher.size,
+      warnings,
+    };
+  }
+
+  /**
+   * Post-run overview for a single run: teacher/room utilization, per-class
+   * lesson distribution, and the hardest remaining constraints.
+   */
+  async getReport(runId: string) {
+    const run = await this.prisma.timetableRun.findUniqueOrThrow({
+      where: { id: runId },
+      select: {
+        id: true,
+        schoolId: true,
+        status: true,
+        hardScore: true,
+        softScore: true,
+        violations: true,
+        lessons: {
+          select: {
+            teacherId: true,
+            roomId: true,
+            classSubjectId: true,
+          },
+        },
+      },
+    });
+
+    const gridSlots = await this.gridSlots(run.schoolId);
+    const lessons = run.lessons;
+
+    // Resolve display labels for the ids referenced by the lessons.
+    const teacherIds = Array.from(
+      new Set(lessons.map((l) => l.teacherId).filter((id) => id)),
+    );
+    const roomIds = Array.from(new Set(lessons.map((l) => l.roomId)));
+    const csIds = Array.from(new Set(lessons.map((l) => l.classSubjectId)));
+
+    const [teachers, rooms, classSubjects] = await Promise.all([
+      this.prisma.teacher.findMany({
+        where: { id: { in: teacherIds } },
+        select: { id: true, person: { select: { lastName: true } } },
+      }),
+      this.prisma.room.findMany({
+        where: { id: { in: roomIds } },
+        select: { id: true, name: true },
+      }),
+      this.prisma.classSubject.findMany({
+        where: { id: { in: csIds } },
+        select: {
+          id: true,
+          classId: true,
+          schoolClass: { select: { name: true } },
+        },
+      }),
+    ]);
+    const teacherLabel = new Map(
+      teachers.map((t) => [t.id, t.person?.lastName ?? t.id]),
+    );
+    const roomLabel = new Map(rooms.map((r) => [r.id, r.name]));
+    const csClass = new Map(
+      classSubjects.map((cs) => [
+        cs.id,
+        { classId: cs.classId, name: cs.schoolClass?.name ?? cs.classId },
+      ]),
+    );
+
+    const countBy = <K>(
+      keyOf: (l: (typeof lessons)[number]) => K | null,
+    ): Map<K, number> => {
+      const m = new Map<K, number>();
+      for (const l of lessons) {
+        const k = keyOf(l);
+        if (k === null) continue;
+        m.set(k, (m.get(k) ?? 0) + 1);
+      }
+      return m;
+    };
+
+    const pct = (n: number) =>
+      gridSlots > 0 ? Math.round((n / gridSlots) * 100) : 0;
+
+    const teacherUtilization = Array.from(
+      countBy((l) => (l.teacherId ? l.teacherId : null)).entries(),
+    )
+      .map(([id, count]) => ({
+        teacherId: id,
+        label: teacherLabel.get(id) ?? id,
+        lessons: count,
+        pct: pct(count),
+      }))
+      .sort((a, b) => b.lessons - a.lessons);
+
+    const roomUtilization = Array.from(countBy((l) => l.roomId).entries())
+      .map(([id, count]) => ({
+        roomId: id,
+        label: roomLabel.get(id) ?? id,
+        lessons: count,
+        pct: pct(count),
+      }))
+      .sort((a, b) => b.lessons - a.lessons);
+
+    const classCounts = new Map<string, { label: string; lessons: number }>();
+    for (const l of lessons) {
+      const c = csClass.get(l.classSubjectId);
+      if (!c) continue;
+      const entry = classCounts.get(c.classId) ?? { label: c.name, lessons: 0 };
+      entry.lessons += 1;
+      classCounts.set(c.classId, entry);
+    }
+    const classDistribution = Array.from(classCounts.entries())
+      .map(([classId, v]) => ({ classId, label: v.label, lessons: v.lessons }))
+      .sort((a, b) => b.lessons - a.lessons);
+
+    const violations = Array.isArray(run.violations)
+      ? (run.violations as unknown as ViolationGroupDto[])
+      : [];
+    const topConstraints = [...violations]
+      .sort((a, b) => (b.count ?? 0) - (a.count ?? 0))
+      .slice(0, TOP_CONSTRAINTS)
+      .map((v) => ({ type: v.type, count: v.count }));
+
+    return {
+      runId: run.id,
+      status: run.status,
+      hardScore: run.hardScore,
+      softScore: run.softScore,
+      gridSlots,
+      lessonCount: lessons.length,
+      teacherUtilization,
+      roomUtilization,
+      classDistribution,
+      topConstraints,
+    };
+  }
+}

--- a/apps/api/src/modules/timetable/timetable.controller.ts
+++ b/apps/api/src/modules/timetable/timetable.controller.ts
@@ -33,6 +33,7 @@ import { ValidateMoveDto, MoveValidationResponseDto } from './dto/validate-move.
 import { MoveLessonDto } from './dto/move-lesson.dto';
 import { TimetableEditService } from './timetable-edit.service';
 import { TimetableConflictService } from './timetable-conflict.service';
+import { TimetableDiagnosticsService } from './timetable-diagnostics.service';
 import { ResolveConflictDto } from './dto/resolve-conflict.dto';
 import { CheckPermissions } from '../auth/decorators/check-permissions.decorator';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
@@ -53,7 +54,36 @@ export class TimetableController {
     private timetableEditService: TimetableEditService,
     private timetableExportService: TimetableExportService,
     private timetableConflictService: TimetableConflictService,
+    private timetableDiagnosticsService: TimetableDiagnosticsService,
   ) {}
+
+  /**
+   * GET /api/v1/schools/:schoolId/timetable/feasibility
+   * Issue #177-D: pre-solve dimensioning check — compares demanded weekly
+   * lesson hours against time-grid / teacher / room capacity and returns
+   * warnings (so the admin sees over-dimensioning before starting the solver).
+   */
+  @Get('feasibility')
+  @CheckPermissions({ action: 'read', subject: 'timetable' })
+  @ApiOperation({ summary: 'Pre-solve feasibility / dimensioning check' })
+  @ApiResponse({ status: 200, description: 'Feasibility report' })
+  async getFeasibility(@Param('schoolId') schoolId: string) {
+    return this.timetableDiagnosticsService.getFeasibility(schoolId);
+  }
+
+  /**
+   * GET /api/v1/schools/:schoolId/timetable/runs/:runId/report
+   * Issue #177-D: post-run overview — teacher/room utilization, per-class
+   * lesson distribution, and the hardest remaining constraints.
+   */
+  @Get('runs/:runId/report')
+  @CheckPermissions({ action: 'read', subject: 'timetable' })
+  @ApiOperation({ summary: 'Post-run solve report (utilization + distribution)' })
+  @ApiResponse({ status: 200, description: 'Solve report' })
+  @ApiResponse({ status: 404, description: 'Run not found' })
+  async getReport(@Param('runId') runId: string) {
+    return this.timetableDiagnosticsService.getReport(runId);
+  }
 
   @Get('constraint-catalog')
   @CheckPermissions({ action: 'read', subject: 'timetable' })

--- a/apps/api/src/modules/timetable/timetable.module.ts
+++ b/apps/api/src/modules/timetable/timetable.module.ts
@@ -3,6 +3,7 @@ import { TimetableController, SolverCallbackController } from './timetable.contr
 import { TimetableService } from './timetable.service';
 import { TimetableEditService } from './timetable-edit.service';
 import { TimetableConflictService } from './timetable-conflict.service';
+import { TimetableDiagnosticsService } from './timetable-diagnostics.service';
 import { TimetableExportService } from './timetable-export.service';
 import { TimetableGateway } from './timetable.gateway';
 import { TimetableEventsGateway } from './timetable-events.gateway';
@@ -26,6 +27,7 @@ import { SolveWatchdogService } from './solve-watchdog.service';
     TimetableService,
     TimetableEditService,
     TimetableConflictService,
+    TimetableDiagnosticsService,
     TimetableExportService,
     TimetableGateway,
     TimetableEventsGateway,

--- a/apps/web/e2e/admin-solver-diagnostics.spec.ts
+++ b/apps/web/e2e/admin-solver-diagnostics.spec.ts
@@ -1,0 +1,83 @@
+/**
+ * Issue #177-D — regression lock for the solver diagnostics surfaces.
+ *
+ *   DIAG-01 — pre-solve feasibility: an over-dimensioned school (a class
+ *             demanding 99 weekly hours into a 5-slot grid) shows the
+ *             feasibility card with a hard-error warning on /admin/solver.
+ *   DIAG-02 — post-run report: a finished run renders the "Auswertung des
+ *             letzten Laufs" card with teacher/room utilization.
+ *
+ * Throwaway-school architecture (D4): each spec provisions its own school so
+ * there is no shared-resource race and no real solver run needed.
+ */
+import { expect, test } from '@playwright/test';
+import { loginAsAdmin } from './helpers/login';
+import {
+  createThrowawaySchool,
+  type ThrowawaySchoolFixture,
+} from './fixtures/throwaway-school';
+import { useThrowawaySchoolHeader } from './helpers/school-context';
+
+test.describe('Issue #177-D — solver diagnostics (throwaway-school)', () => {
+  test.skip(
+    ({ isMobile }) => isMobile,
+    'Diagnostics rendering is identical across viewports — desktop only.',
+  );
+
+  let fixture: ThrowawaySchoolFixture | undefined;
+
+  test.afterEach(async () => {
+    if (fixture) {
+      await fixture.cleanup();
+      fixture = undefined;
+    }
+  });
+
+  test('DIAG-01: an over-dimensioned school surfaces a feasibility hard-error before solving', async ({
+    page,
+    context,
+  }) => {
+    fixture = await createThrowawaySchool({
+      roles: { admin: true },
+      withTimetableStack: { active: false },
+      withOverload: true,
+      namePrefix: 'E2E-DIAG01',
+    });
+
+    await useThrowawaySchoolHeader(context, fixture.schoolId);
+    await loginAsAdmin(page);
+    await page.goto('/admin/solver');
+
+    const card = page.getByTestId('feasibility-card');
+    await expect(card).toBeVisible();
+    await expect(card).toHaveAttribute('data-feasible', 'false');
+    await expect(
+      page.getByTestId('feasibility-warning-error').first(),
+    ).toBeVisible();
+    // The generate button is NOT blocked — the admin can still start the run.
+    await expect(
+      page.getByRole('button', { name: 'Stundenplan generieren' }),
+    ).toBeEnabled();
+  });
+
+  test('DIAG-02: a finished run renders the solve report with utilization', async ({
+    page,
+    context,
+  }) => {
+    fixture = await createThrowawaySchool({
+      roles: { admin: true },
+      withTimetableStack: { active: true },
+      namePrefix: 'E2E-DIAG02',
+    });
+
+    await useThrowawaySchoolHeader(context, fixture.schoolId);
+    await loginAsAdmin(page);
+    await page.goto('/admin/solver');
+
+    const report = page.getByTestId('solve-report-card');
+    await expect(report).toBeVisible();
+    await expect(report).toContainText('Lehrer-Auslastung');
+    await expect(report).toContainText('Raum-Auslastung');
+    await expect(report).toContainText('Wochenstunden pro Klasse');
+  });
+});

--- a/apps/web/e2e/fixtures/throwaway-school.ts
+++ b/apps/web/e2e/fixtures/throwaway-school.ts
@@ -171,6 +171,13 @@ export interface ThrowawaySchoolOptions {
    */
   withTimetableStack?: boolean | { active?: boolean };
   /**
+   * Issue #177-D — over-dimension the timetable stack so the pre-solve
+   * feasibility check reports a hard error: bumps the stack ClassSubject's
+   * `weeklyHours` to 99, far above the throwaway's grid (5 days × 1 period = 5
+   * slots). Requires `withTimetableStack`.
+   */
+  withOverload?: boolean;
+  /**
    * Issue #177-B — turn the timetable run into a COMPLETED_WITH_CONFLICTS run
    * by recording one TimetableConflict (a TEACHER double-book the solver would
    * have dropped) and flipping the run status. Requires `withTimetableStack`.
@@ -650,7 +657,9 @@ export async function createThrowawaySchool(
           classId: classIdForStack,
           subjectId: subject.id,
           teacherId: teacher.id,
-          weeklyHours: 1,
+          // #177-D: withOverload pushes weeklyHours far above the throwaway
+          // grid (5 slots) so the feasibility check reports a hard error.
+          weeklyHours: options.withOverload ? 99 : 1,
         },
       });
 

--- a/apps/web/src/components/admin/solver/FeasibilityCard.tsx
+++ b/apps/web/src/components/admin/solver/FeasibilityCard.tsx
@@ -1,0 +1,88 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { useFeasibility } from '@/hooks/useSolverDiagnostics';
+
+/**
+ * Issue #177-D — pre-solve dimensioning check on /admin/solver.
+ *
+ * Warns the admin BEFORE a (multi-minute) solve when the problem is
+ * over-dimensioned (a class/teacher demands more hours than slots, too few
+ * rooms, …). It never blocks generation — the admin can still start the
+ * solver — but it turns a guaranteed-to-fail run into an informed decision.
+ */
+export function FeasibilityCard({ schoolId }: { schoolId: string }) {
+  const { data, isLoading } = useFeasibility(schoolId);
+
+  if (isLoading || !data) return null;
+
+  const errors = data.warnings.filter((w) => w.severity === 'error');
+  const warns = data.warnings.filter((w) => w.severity === 'warning');
+
+  // Healthy + nothing to flag → a compact reassurance line.
+  if (data.warnings.length === 0) {
+    return (
+      <Card data-testid="feasibility-card" data-feasible="true">
+        <CardContent className="flex items-center gap-2 py-3 text-sm">
+          <span
+            className="inline-block h-2 w-2 rounded-full bg-emerald-500"
+            aria-hidden="true"
+          />
+          <span className="text-muted-foreground">
+            Dimensionierung geprüft: {data.totalLessons} Lektionen passen in{' '}
+            {data.gridSlots} Slots · {data.classCount} Klassen ·{' '}
+            {data.teacherCount} Lehrer · {data.roomCount} Räume.
+          </span>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const hasErrors = errors.length > 0;
+
+  return (
+    <Card
+      className={
+        hasErrors
+          ? 'border-destructive/60 bg-destructive/5'
+          : 'border-amber-400/60 bg-amber-50/40'
+      }
+      data-testid="feasibility-card"
+      data-feasible={String(data.feasible)}
+    >
+      <CardHeader>
+        <CardTitle
+          className={`text-[20px] ${hasErrors ? 'text-destructive' : 'text-amber-700'}`}
+        >
+          {hasErrors
+            ? 'Dimensionierungs-Problem erkannt'
+            : 'Dimensionierungs-Hinweis'}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3 text-sm">
+        {hasErrors && (
+          <p className="text-muted-foreground">
+            Dieses Setup ist sehr wahrscheinlich nicht lösbar. Sie können den
+            Solver trotzdem starten, er wird aber voraussichtlich kein
+            konfliktfreies Ergebnis liefern.
+          </p>
+        )}
+        <ul className="space-y-1.5">
+          {[...errors, ...warns].map((w, i) => (
+            <li
+              key={`${w.type}-${i}`}
+              className="flex items-start gap-2"
+              data-testid={`feasibility-warning-${w.severity}`}
+            >
+              <span
+                className={`mt-0.5 inline-block h-2 w-2 shrink-0 rounded-full ${
+                  w.severity === 'error' ? 'bg-destructive' : 'bg-amber-500'
+                }`}
+                aria-hidden="true"
+              />
+              <span>{w.message}</span>
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/admin/solver/SolveReportCard.tsx
+++ b/apps/web/src/components/admin/solver/SolveReportCard.tsx
@@ -1,0 +1,124 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { useSolveReport } from '@/hooks/useSolverDiagnostics';
+
+/** Show at most this many rows per utilization list. */
+const MAX_ROWS = 8;
+
+function UtilBar({ pct }: { pct: number }) {
+  const clamped = Math.max(0, Math.min(100, pct));
+  return (
+    <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+      <div
+        className={`h-full rounded-full ${clamped >= 90 ? 'bg-amber-500' : 'bg-primary'}`}
+        style={{ width: `${clamped}%` }}
+      />
+    </div>
+  );
+}
+
+/**
+ * Issue #177-D — post-run solve report on /admin/solver.
+ *
+ * For the most recent finished run, shows teacher/room utilization (lessons vs
+ * available slots), the per-class lesson distribution, and the hardest
+ * remaining constraints — independent of whether the run completed cleanly or
+ * with conflicts. Read-only.
+ */
+export function SolveReportCard({
+  schoolId,
+  runId,
+}: {
+  schoolId: string;
+  runId: string;
+}) {
+  const { data } = useSolveReport(schoolId, runId);
+
+  if (!data || data.lessonCount === 0) return null;
+
+  return (
+    <Card data-testid="solve-report-card">
+      <CardHeader>
+        <CardTitle className="text-[20px]">Auswertung des letzten Laufs</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-5 text-sm">
+        <p className="text-xs text-muted-foreground">
+          {data.lessonCount} Lektionen · {data.gridSlots} Slots ·{' '}
+          {data.teacherUtilization.length} Lehrer · {data.roomUtilization.length}{' '}
+          Räume
+        </p>
+
+        <section className="space-y-2">
+          <h3 className="text-xs font-semibold uppercase text-muted-foreground">
+            Lehrer-Auslastung
+          </h3>
+          <ul className="space-y-2">
+            {data.teacherUtilization.slice(0, MAX_ROWS).map((t) => (
+              <li key={t.teacherId} className="space-y-1">
+                <div className="flex justify-between">
+                  <span>{t.label}</span>
+                  <span className="font-mono tabular-nums text-muted-foreground">
+                    {t.lessons}/{data.gridSlots} · {t.pct}%
+                  </span>
+                </div>
+                <UtilBar pct={t.pct} />
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <section className="space-y-2">
+          <h3 className="text-xs font-semibold uppercase text-muted-foreground">
+            Raum-Auslastung
+          </h3>
+          <ul className="space-y-2">
+            {data.roomUtilization.slice(0, MAX_ROWS).map((r) => (
+              <li key={r.roomId} className="space-y-1">
+                <div className="flex justify-between">
+                  <span>{r.label}</span>
+                  <span className="font-mono tabular-nums text-muted-foreground">
+                    {r.lessons}/{data.gridSlots} · {r.pct}%
+                  </span>
+                </div>
+                <UtilBar pct={r.pct} />
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <section className="space-y-2">
+          <h3 className="text-xs font-semibold uppercase text-muted-foreground">
+            Wochenstunden pro Klasse
+          </h3>
+          <ul className="space-y-1">
+            {data.classDistribution.slice(0, MAX_ROWS).map((c) => (
+              <li key={c.classId} className="flex justify-between">
+                <span>{c.label}</span>
+                <span className="font-mono tabular-nums text-muted-foreground">
+                  {c.lessons}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        {data.topConstraints.length > 0 && (
+          <section className="space-y-2">
+            <h3 className="text-xs font-semibold uppercase text-muted-foreground">
+              Härteste Constraints
+            </h3>
+            <ul className="space-y-1">
+              {data.topConstraints.map((v) => (
+                <li key={v.type} className="flex justify-between">
+                  <span>{v.type}</span>
+                  <span className="font-mono tabular-nums text-muted-foreground">
+                    {v.count}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/hooks/useSolverDiagnostics.ts
+++ b/apps/web/src/hooks/useSolverDiagnostics.ts
@@ -1,0 +1,80 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiFetch } from '@/lib/api';
+
+/**
+ * Issue #177-D — solver diagnostics hooks.
+ *
+ * `useFeasibility` powers the pre-solve dimensioning warning; `useSolveReport`
+ * powers the post-run utilization overview. Both are read-only and tolerate a
+ * missing schoolId/runId by staying disabled.
+ */
+
+export interface FeasibilityWarning {
+  type: string;
+  severity: 'error' | 'warning';
+  message: string;
+}
+
+export interface FeasibilityReport {
+  feasible: boolean;
+  gridSlots: number;
+  totalLessons: number;
+  roomCount: number;
+  classCount: number;
+  teacherCount: number;
+  warnings: FeasibilityWarning[];
+}
+
+export interface SolveReport {
+  runId: string;
+  status: string;
+  hardScore: number | null;
+  softScore: number | null;
+  gridSlots: number;
+  lessonCount: number;
+  teacherUtilization: {
+    teacherId: string;
+    label: string;
+    lessons: number;
+    pct: number;
+  }[];
+  roomUtilization: {
+    roomId: string;
+    label: string;
+    lessons: number;
+    pct: number;
+  }[];
+  classDistribution: { classId: string; label: string; lessons: number }[];
+  topConstraints: { type: string; count: number }[];
+}
+
+export function useFeasibility(schoolId: string | null | undefined) {
+  return useQuery({
+    queryKey: ['timetable-feasibility', schoolId ?? ''],
+    queryFn: async (): Promise<FeasibilityReport | null> => {
+      const res = await apiFetch(
+        `/api/v1/schools/${schoolId}/timetable/feasibility`,
+      );
+      if (!res.ok) return null;
+      return (await res.json()) as FeasibilityReport;
+    },
+    enabled: !!schoolId,
+  });
+}
+
+export function useSolveReport(
+  schoolId: string | null | undefined,
+  runId: string | null | undefined,
+) {
+  return useQuery({
+    queryKey: ['timetable-report', schoolId ?? '', runId ?? ''],
+    queryFn: async (): Promise<SolveReport | null> => {
+      const res = await apiFetch(
+        `/api/v1/schools/${schoolId}/timetable/runs/${runId}/report`,
+      );
+      if (!res.ok) return null;
+      return (await res.json()) as SolveReport;
+    },
+    enabled: !!schoolId && !!runId,
+  });
+}

--- a/apps/web/src/routes/_authenticated/admin/solver.tsx
+++ b/apps/web/src/routes/_authenticated/admin/solver.tsx
@@ -10,6 +10,8 @@ import { useRecentTimetableRuns } from '@/hooks/useRecentTimetableRuns';
 import { apiFetch } from '@/lib/api';
 import { GeneratorPageWeightsCard } from '@/components/admin/solver/GeneratorPageWeightsCard';
 import { ConflictsCard } from '@/components/admin/solver/ConflictsCard';
+import { FeasibilityCard } from '@/components/admin/solver/FeasibilityCard';
+import { SolveReportCard } from '@/components/admin/solver/SolveReportCard';
 
 export const Route = createFileRoute('/_authenticated/admin/solver')({
   component: AdminSolverPage,
@@ -152,6 +154,14 @@ function AdminSolverPage() {
     (r) => r.status === 'COMPLETED_WITH_CONFLICTS' || r.conflictCount > 0,
   );
 
+  // #177-D: the most recent finished run drives the post-run report card.
+  const reportRun = recentRuns.find(
+    (r) =>
+      r.status === 'COMPLETED' ||
+      r.status === 'COMPLETED_WITH_CONFLICTS' ||
+      r.status === 'STOPPED',
+  );
+
   return (
     <div className="max-w-[800px] mx-auto space-y-6">
       {/* Page header */}
@@ -168,6 +178,9 @@ function AdminSolverPage() {
       {/* Phase 14-02 D-06: read-only Schul-Gewichtungen card with deep-link
           to /admin/solver-tuning?tab=weights. */}
       {schoolId && <GeneratorPageWeightsCard schoolId={schoolId} />}
+
+      {/* #177-D: pre-solve dimensioning check — warns before a doomed run. */}
+      {schoolId && <FeasibilityCard schoolId={schoolId} />}
 
       {/* Status + trigger card */}
       <Card>
@@ -370,6 +383,12 @@ function AdminSolverPage() {
           is double-booked in which slot) so the admin can resolve them. */}
       {schoolId && conflictRun && (
         <ConflictsCard schoolId={schoolId} runId={conflictRun.id} />
+      )}
+
+      {/* #177-D: post-run overview (utilization, distribution, top constraints)
+          for the most recent finished run. */}
+      {schoolId && reportRun && (
+        <SolveReportCard schoolId={schoolId} runId={reportRun.id} />
       )}
 
       {/* #53 Schicht 1: failure card — surfaces the watchdog-detected


### PR DESCRIPTION
## Was & Warum

Sub-Issue **D** von #177 (letzter Baustein, baut auf B+C auf, beide gemerged). Gibt dem Admin eine **Dimensionierungs-Lupe vor** dem Solven und eine **Auswertung danach**.

## Änderungen

**Backend — `TimetableDiagnosticsService`**
- `getFeasibility(schoolId)`: vergleicht die benötigten Wochenstunden mit der Kapazität von Zeitraster / Klassen / Lehrern / Räumen → `warnings[]` + `feasible`. Warnungs-Typen: `CLASS_OVERLOADED`, `TEACHER_OVERLOADED`, `ROOM_CAPACITY`, `ROOM_TYPE_CAPACITY`, `UNASSIGNED_TEACHER`, `NO_GRID`, `NO_ROOMS`. **Jeder `error` ist eine echte notwendige-Bedingung-Verletzung** (Nachfrage übersteigt eine obere Schranke) — keine falschen „infeasible"-Behauptungen (Lehrer-Availability bewusst ignoriert, kann Kapazität nur weiter senken).
- `getReport(runId)`: Lehrer-/Raum-Auslastung, Wochenstunden-Verteilung pro Klasse, härteste Constraints (aus `violations` JSON).
- Endpoints: `GET timetable/feasibility` + `GET runs/:runId/report`.

**Frontend (`/admin/solver`)**
- `FeasibilityCard`: Pre-Solve-Warnung (rot bei error, amber bei warning, grüne Bestätigung wenn machbar). **Blockiert die Generierung nicht** — der Admin kann „trotzdem starten" (wie im Issue gefordert).
- `SolveReportCard`: Post-Run-Übersicht mit Auslastungs-Balken + Klassen-Verteilung + Top-Constraints für den letzten fertigen Lauf.

## Regression-Lock
- **API-Unit** (`timetable-diagnostics.service.spec.ts`, 4): feasible-Pfad, over-dimensioned (CLASS/TEACHER/ROOM-error), unassigned-teacher-warning (non-fatal), report-Aggregation.
- **E2E** (`admin-solver-diagnostics.spec.ts`, desktop+firefox grün lokal): DIAG-01 über-dimensionierte Schule → Feasibility-Hard-Error + Generieren-Button bleibt aktiv; DIAG-02 fertiger Lauf → Report-Card mit Auslastung. Neue Fixture-Option `withOverload`.

## Lokale Verifikation
- API build 0 issues · web `tsc -b && vite build` grün.
- API vitest: **817 passed** (+4).
- E2E: DIAG-01/02 + CONFLICT-01/02/03 grün auf desktop **und** desktop-firefox (10/10 — Diagnostics-Karten brechen die Konflikt-Karte aus C nicht).

## Scope
- Kein Schema-Change → keine Migration. Report inline auf `/admin/solver` (keine neue Route → kein routeTree-Regen-Risiko).
- Damit ist **#177 komplett**: B (Soft-Persist) + C (Resolution UX) + D (Diagnostics).

Closes #181
Refs #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)