### PR TITLE
fix(timetable): #186 — Feasibility-Check zählt parallele Gruppen nicht mehr doppelt

### DIFF
--- a/apps/api/src/modules/timetable/timetable-diagnostics.service.spec.ts
+++ b/apps/api/src/modules/timetable/timetable-diagnostics.service.spec.ts
@@ -5,6 +5,27 @@ import { PrismaService } from '../../config/database/prisma.service';
 /**
  * Issue #177-D — unit tests for the solver diagnostics service.
  */
+
+/** Build a ClassSubject mock row in the shape getFeasibility selects. */
+function cs(o: {
+  weeklyHours: number;
+  teacherId: string | null;
+  groupId: string | null;
+  classId?: string;
+  className?: string;
+  requiredRoomType?: string | null;
+}) {
+  return {
+    weeklyHours: o.weeklyHours,
+    teacherId: o.teacherId,
+    classId: o.classId ?? 'c1',
+    groupId: o.groupId,
+    schoolClass: { name: o.className ?? '4A' },
+    teacher: o.teacherId ? { person: { lastName: o.teacherId } } : null,
+    subject: { requiredRoomType: o.requiredRoomType ?? null },
+  };
+}
+
 describe('TimetableDiagnosticsService', () => {
   let service: TimetableDiagnosticsService;
   let prisma: any;
@@ -81,6 +102,50 @@ describe('TimetableDiagnosticsService', () => {
       expect(types).toContain('TEACHER_OVERLOADED');
       // 10 lessons vs 1 room × 5 slots = 5 → room capacity error too.
       expect(types).toContain('ROOM_CAPACITY');
+    });
+
+    // #186 regression: the demo's 4th-year classes have 41 summed weekly hours
+    // but only 40 slots — yet 12 of those hours are PARALLEL groups (Englisch
+    // ×2, Religion ×2) that share slots. Real demand = 29 whole-class + 4
+    // (busiest group) = 33 ≤ 40. Pre-fix this raised a false CLASS_OVERLOADED.
+    it('does NOT false-flag a class whose hours fit once parallel groups are de-duplicated', async () => {
+      prisma.schoolDay.count.mockResolvedValue(5);
+      prisma.period.count.mockResolvedValue(8); // gridSlots = 40
+      prisma.classSubject.findMany.mockResolvedValue([
+        // 29h whole-class (groupId null)
+        cs({ weeklyHours: 29, teacherId: 't-whole', groupId: null }),
+        // Englisch: two parallel groups, 4h each
+        cs({ weeklyHours: 4, teacherId: 't-engA', groupId: 'g-eng-A' }),
+        cs({ weeklyHours: 4, teacherId: 't-engB', groupId: 'g-eng-B' }),
+        // Religion: two parallel groups, 2h each
+        cs({ weeklyHours: 2, teacherId: 't-relA', groupId: 'g-rel-A' }),
+        cs({ weeklyHours: 2, teacherId: 't-relB', groupId: 'g-rel-B' }),
+      ]); // Σ weeklyHours = 41, but demand = 29 + max(4,4,2,2) = 33
+      prisma.room.groupBy.mockResolvedValue([
+        { roomType: 'KLASSENZIMMER', _count: { _all: 25 } },
+      ]);
+
+      const res = await service.getFeasibility('school-1');
+
+      expect(res.warnings.map((w) => w.type)).not.toContain('CLASS_OVERLOADED');
+      expect(res.feasible).toBe(true);
+      expect(res.totalLessons).toBe(41); // unchanged: every group lesson is real
+    });
+
+    it('still flags a genuinely over-dimensioned whole-class load', async () => {
+      prisma.schoolDay.count.mockResolvedValue(5);
+      prisma.period.count.mockResolvedValue(8); // gridSlots = 40
+      prisma.classSubject.findMany.mockResolvedValue([
+        cs({ weeklyHours: 42, teacherId: 't1', groupId: null }), // > 40, no groups
+      ]);
+      prisma.room.groupBy.mockResolvedValue([
+        { roomType: 'KLASSENZIMMER', _count: { _all: 25 } },
+      ]);
+
+      const res = await service.getFeasibility('school-1');
+
+      expect(res.feasible).toBe(false);
+      expect(res.warnings.map((w) => w.type)).toContain('CLASS_OVERLOADED');
     });
 
     it('warns (non-fatal) about unassigned-teacher hours', async () => {

--- a/apps/api/src/modules/timetable/timetable-diagnostics.service.ts
+++ b/apps/api/src/modules/timetable/timetable-diagnostics.service.ts
@@ -60,6 +60,9 @@ export class TimetableDiagnosticsService {
           weeklyHours: true,
           teacherId: true,
           classId: true,
+          // #186: groupId distinguishes parallel group lessons (which share a
+          // slot) from whole-class lessons (which do not).
+          groupId: true,
           schoolClass: { select: { name: true } },
           teacher: {
             select: { person: { select: { lastName: true } } },
@@ -102,23 +105,46 @@ export class TimetableDiagnosticsService {
       });
     }
 
-    // Per-class capacity: a class can hold at most one lesson per slot.
-    const hoursByClass = new Map<string, { name: string; hours: number }>();
+    // Per-class capacity: a class can hold at most one lesson per slot, BUT
+    // parallel group lessons (disjoint student sets — e.g. two language groups
+    // or kath./evang. Religion) share a slot. #186: the sound, false-alarm-free
+    // lower bound on the slots a class needs is therefore
+    //   whole-class hours  +  hours of the single busiest group
+    // — the busiest group's lessons run sequentially AND are mutually exclusive
+    // with the whole-class lessons for those students, so this sum is always
+    // ≤ the true minimum; other groups run in parallel and do not raise it.
+    // Summing ALL weeklyHours (the pre-#186 behaviour) double-counts parallel
+    // groups and raised a false CLASS_OVERLOADED on group-split classes.
+    const classNames = new Map<string, string>();
+    const wholeClassHours = new Map<string, number>();
+    const groupHoursByClass = new Map<string, Map<string, number>>();
     for (const cs of classSubjects) {
-      const entry = hoursByClass.get(cs.classId) ?? {
-        name: cs.schoolClass?.name ?? cs.classId,
-        hours: 0,
-      };
-      entry.hours += cs.weeklyHours;
-      hoursByClass.set(cs.classId, entry);
+      classNames.set(cs.classId, cs.schoolClass?.name ?? cs.classId);
+      if (!cs.groupId) {
+        wholeClassHours.set(
+          cs.classId,
+          (wholeClassHours.get(cs.classId) ?? 0) + cs.weeklyHours,
+        );
+      } else {
+        let groups = groupHoursByClass.get(cs.classId);
+        if (!groups) {
+          groups = new Map();
+          groupHoursByClass.set(cs.classId, groups);
+        }
+        groups.set(cs.groupId, (groups.get(cs.groupId) ?? 0) + cs.weeklyHours);
+      }
     }
     if (gridSlots > 0) {
-      for (const { name, hours } of hoursByClass.values()) {
-        if (hours > gridSlots) {
+      for (const [classId, name] of classNames) {
+        const whole = wholeClassHours.get(classId) ?? 0;
+        const groups = groupHoursByClass.get(classId);
+        const busiestGroup = groups ? Math.max(0, ...groups.values()) : 0;
+        const demand = whole + busiestGroup;
+        if (demand > gridSlots) {
           warnings.push({
             type: 'CLASS_OVERLOADED',
             severity: 'error',
-            message: `Klasse ${name}: ${hours} Wochenstunden, aber nur ${gridSlots} Slots verfügbar.`,
+            message: `Klasse ${name}: ${demand} Wochenstunden (parallele Gruppen berücksichtigt), aber nur ${gridSlots} Slots verfügbar.`,
           });
         }
       }
@@ -193,7 +219,7 @@ export class TimetableDiagnosticsService {
       gridSlots,
       totalLessons,
       roomCount,
-      classCount: hoursByClass.size,
+      classCount: classNames.size,
       teacherCount: hoursByTeacher.size,
       warnings,
     };


### PR DESCRIPTION
## Bug

Der Pre-Solve-Feasibility-Check aus #181 (Pattern D) meldete auf dem Demo-Gymnasium fälschlich `CLASS_OVERLOADED` für die 4. Klassen (41 summierte Wochenstunden vs. 40 Slots). `getFeasibility` summierte **alle** `ClassSubject.weeklyHours` pro Klasse und ignorierte **parallele Gruppen** (disjunkte Schülermengen, die sich einen Slot teilen): Englisch ×2 Gruppen + Religion ×2 Gruppen = 12 h, die real nur 6 Slot-Stunden brauchen → echte Nachfrage 33 ≤ 40.

Damit verletzte der Check seine #181-Design-Zusage „keine Fehlalarme".

## Fix

Pro Klasse: `demand = ganze-Klasse-Stunden + Stunden der größten EINZELNEN Gruppe` statt `Σ aller weeklyHours`. Das ist eine **beweisbar fehlalarm-freie** untere Schranke (die busiest Gruppe ist sequenziell zu sich selbst und exklusiv zu den Ganze-Klasse-Lektionen; andere Gruppen laufen parallel). Lehrer-/Raum-Checks bleiben unverändert (parallelisieren nicht über Gruppen).

## Verifikation
- **Live** auf dem Demo-Gymnasium: `feasible: true`, **0 Warnungen** (vorher 3 falsche `CLASS_OVERLOADED`).
- **Regression-Test** (`timetable-diagnostics.service.spec.ts`): 29 h ganze Klasse + parallele Englisch(×2)/Religion(×2)-Gruppen (Σ=41) bei 40 Slots → **kein** `CLASS_OVERLOADED` (schlägt ohne Fix fehl). Echte Über-Dimensionierung (42 > 40 ganze Klasse) → warnt weiterhin.
- API vitest: **819 passed** (+2). DIAG-01/02 E2E grün (DIAG-01 nutzt Ganze-Klasse-Overload → warnt korrekt weiter).
- Kein Schema-Change → keine Migration.

Closes #186
Refs #181 #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)