### PR TITLE
fix(web): #188 — Tailwind-v4 bare-[--var] bricht Select-max-height → Dropdown-Overflow

### DIFF
--- a/apps/web/e2e/timetable-perspective-dropdown.spec.ts
+++ b/apps/web/e2e/timetable-perspective-dropdown.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * Issue #188 — the admin timetable perspective dropdown must stay within the
+ * viewport. With realistic data density (seed: 32 teachers + 12 classes + 25
+ * rooms) the shadcn Select content used Tailwind-v3 `max-h-[--var]` syntax,
+ * which Tailwind v4 compiles to invalid `max-height:--var` (no `var()` wrap) →
+ * the cap was dropped → the 69-row list ran off the bottom of the screen and
+ * was unreachable.
+ *
+ * This spec would FAIL without the fix: the unbounded list renders ~2200px tall
+ * on the 800px desktop viewport.
+ *
+ * Read-only on the SEED school on purpose (D4 exception): the overflow only
+ * reproduces with many entities, and a throwaway school has a single teacher.
+ * No writes here, so there is no cross-spec race.
+ */
+import { expect, test } from '@playwright/test';
+import { loginAsAdmin } from './helpers/login';
+
+test.describe('Issue #188 — Select dropdown stays within the viewport', () => {
+  test.skip(
+    ({ isMobile }) => isMobile,
+    'Viewport-bound assertion is run on the desktop project.',
+  );
+
+  test('PERSP-DROPDOWN-01: the perspective dropdown is height-bounded with the full seed roster', async ({
+    page,
+  }) => {
+    await loginAsAdmin(page);
+    await page.goto('/timetable');
+
+    // The perspective selector trigger (admin/schulleitung only).
+    const trigger = page.getByRole('combobox').first();
+    await expect(trigger).toBeVisible();
+    await trigger.click();
+
+    const listbox = page.getByRole('listbox');
+    await expect(listbox).toBeVisible();
+
+    // The roster is large enough that an unbounded list would overflow — assert
+    // it is, so the height bound below is a meaningful check.
+    expect(
+      await listbox.getByRole('option').count(),
+      'seed roster should yield many options',
+    ).toBeGreaterThan(20);
+
+    const box = await listbox.boundingBox();
+    const vp = page.viewportSize();
+    expect(box, 'dropdown bounding box').toBeTruthy();
+    expect(vp, 'viewport size').toBeTruthy();
+
+    // The max-height cap keeps the content within the viewport (and scrollable).
+    // Pre-#188 this was ~2200px on an 800px viewport.
+    expect(box!.height).toBeLessThanOrEqual(vp!.height);
+    // And it must not run off the bottom edge (small tolerance for borders).
+    expect(box!.y + box!.height).toBeLessThanOrEqual(vp!.height + 2);
+  });
+});

--- a/apps/web/src/components/admin/solver-tuning/ClassAutocomplete.tsx
+++ b/apps/web/src/components/admin/solver-tuning/ClassAutocomplete.tsx
@@ -79,7 +79,7 @@ export function ClassAutocomplete({
           <ChevronDown className="h-4 w-4 ml-2 shrink-0 opacity-50" aria-hidden />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
+      <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0" align="start">
         <Command shouldFilter={false}>
           <CommandInput
             value={query}

--- a/apps/web/src/components/admin/solver-tuning/SubjectAutocomplete.tsx
+++ b/apps/web/src/components/admin/solver-tuning/SubjectAutocomplete.tsx
@@ -90,7 +90,7 @@ export function SubjectAutocomplete({
           <ChevronDown className="h-4 w-4 ml-2 shrink-0 opacity-50" aria-hidden />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
+      <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0" align="start">
         <Command shouldFilter={false}>
           <CommandInput
             value={query}

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -75,7 +75,11 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-select-content-transform-origin]",
+        // #188: Tailwind v4 no longer auto-wraps a bare `[--var]` arbitrary
+        // value in var(); it must be `[var(--var)]`. Without this the
+        // max-height compiled to invalid `max-height:--radix-...` and was
+        // dropped → dropdowns with many items overflowed the viewport.
+        "relative z-50 max-h-[var(--radix-select-content-available-height)] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[var(--radix-select-content-transform-origin)]",
         position === "popper" &&
           "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
         className


### PR DESCRIPTION
## Bug
Als Admin unter **/stundenplan** lief der Perspektiven-Dropdown (Lehrer/Klassen/Räume) mit realer Datendichte (69 Einträge) über den unteren Viewport-Rand hinaus und war nicht erreichbar/scrollbar.

## Ursache
shadcn `Select` nutzte `max-h-[--radix-select-content-available-height]` — **Tailwind-v3-Syntax**. Tailwind **v4** wrappt das nackte `[--var]` nicht mehr automatisch in `var()` → compiliert zu ungültigem `max-height:--radix-…` → verworfen → **kein Höhen-Cap** → Overflow (gemessen: 2620px auf 800px-Viewport).

## Fix (ganze Bug-Klasse)
Alle bare `[--var]` → `[var(--var)]` (gültig in v3 **und** v4):
- `ui/select.tsx` — max-h + transform-origin
- `solver-tuning/ClassAutocomplete.tsx` + `SubjectAutocomplete.tsx` — Popover-Breite

## Verifikation
- Compiliertes CSS jetzt `max-height:var(--radix-select-content-available-height)` ✓
- **E2E** `timetable-perspective-dropdown.spec.ts`: Admin → Dropdown öffnen → Listbox-Höhe ≤ Viewport. **Rot ohne Fix** (2620px > 800px), grün mit Fix. Read-only auf Seed-Schule (D4-Ausnahme dokumentiert — throwaway hat nur 1 Lehrer).
- Kein Schema-Change.

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)